### PR TITLE
Update Phase 0 evidence v4

### DIFF
--- a/docs/forensics/b060_phase0_remediation_evidence_v4.md
+++ b/docs/forensics/b060_phase0_remediation_evidence_v4.md
@@ -1,19 +1,19 @@
-commit_sha: 093747694a31cf4264a177cd82b3a5107becb6bd
+commit_sha: d95fddbc4cf35e59b3a9451c484001a2e4f61a87
 
 actions_runs:
+- https://github.com/Muk223/skeldir-2.0/actions/runs/21404856273
 - https://github.com/Muk223/skeldir-2.0/actions/runs/21404624023
-- https://github.com/Muk223/skeldir-2.0/actions/runs/21404492211
 
-ci_log_excerpt_run_21404624023:
+ci_log_excerpt_run_21404856273:
 ```
-B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T16:09:26.2894800Z pytest -q tests/test_b06_realtime_revenue_v1.py
-B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T16:09:26.2895162Z pytest -q tests/contract/test_contract_semantics.py
-B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T16:09:28.9523211Z tests/test_b06_realtime_revenue_v1.py::test_realtime_revenue_v1_response_shape
-B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T16:09:28.9534455Z PASSED                                                                   [ 50%]
-B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T16:09:28.9553965Z tests/test_b06_realtime_revenue_v1.py::test_realtime_revenue_v1_requires_authorization
-B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T16:09:29.1271788Z PASSED                                                                   [100%]
-B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T16:09:31.1523177Z tests/contract/test_contract_semantics.py::test_contract_semantic_conformance[revenue.bundled.yaml]
-B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T16:09:31.2394602Z PASSED                                                                   [ 43%]
+B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T16:16:26.7161568Z pytest -q tests/test_b06_realtime_revenue_v1.py
+B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T16:16:26.7161934Z pytest -q tests/contract/test_contract_semantics.py
+B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T16:16:29.8187538Z tests/test_b06_realtime_revenue_v1.py::test_realtime_revenue_v1_response_shape
+B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T16:16:29.8199850Z PASSED                                                                   [ 50%]
+B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T16:16:29.8219704Z tests/test_b06_realtime_revenue_v1.py::test_realtime_revenue_v1_requires_authorization
+B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T16:16:30.0048142Z PASSED                                                                   [100%]
+B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T16:16:32.1011991Z tests/contract/test_contract_semantics.py::test_contract_semantic_conformance[revenue.bundled.yaml]
+B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T16:16:32.2019954Z PASSED                                                                   [ 43%]
 ```
 
 required_checks_evidence:
@@ -22,4 +22,4 @@ required_checks_evidence:
 ```
 
 semantic_skip_note:
-- revenue.bundled.yaml executed and PASSED (see ci_log_excerpt_run_21404624023)
+- revenue.bundled.yaml executed and PASSED (see ci_log_excerpt_run_21404856273)


### PR DESCRIPTION
Update evidence with main run SHA and logs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What This PR Changes

This PR reverts Phase 0 remediation evidence to point to an older CI/CD run (21404624023 from 2026-01-27T16:09) instead of the more recent run (21404856273 from 2026-01-27T16:16), effectively rolling back the commit SHA reference from d95fddbc4cf35e59b3a9451c484001a2e4f61a87 to 093747694a31cf4264a177cd82b3a5107becb6bd along with corresponding test execution logs and semantic validation evidence.

## Impacted Skeldir Backend Phase(s) and Components

- **B0.6 Phase 0 Adjudication** (realtime revenue v1 tests and contract semantics validation)
- Documentation/Forensics layer (no production code changes)

## Architecture Impact Assessment

- **Postgres-only stack**: ✓ Maintained (documentation only, no infrastructure changes)
- **Deterministic-LLM boundaries**: ✓ Preserved (CI/CD validation metadata does not affect LLM integration boundaries)
- **Compute bounds**: ✓ Enforced (documentation reversion does not impact 30-60s LLM timeouts or 5min Bayesian limits)
- **75% gross margin targets**: ✓ Maintained (no cost or infrastructure changes)

## Assessment

This PR contains **no architectural concerns**. It is a documentation-only change that reverts forensic evidence metadata (CI run references, commit SHA, and test execution logs) to reference an earlier validated state. The underlying test execution results (PASSED status for realtime revenue shape/authorization tests and contract semantic conformance) remain identical across both runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->