### PR TITLE
Update Phase 1 evidence v2 with merge + CI

### DIFF
--- a/docs/forensics/INDEX.md
+++ b/docs/forensics/INDEX.md
@@ -38,8 +38,8 @@ This index enumerates evidence packs stored under `docs/forensics/`.
 | B0.5.7 Phase 6 | docs/forensics/b057_phase6_ci_enforcement_governance_cleanup_evidence.md | CI enforcement + governance cleanup (least-privilege E2E, Postgres-only guardrails, INDEX enforcement) | 0a470df0f7b7d480ded10060cd4457955284e8ad | https://github.com/Muk223/skeldir-2.0/actions/runs/21340267507 |
 | B0.5.7 Phase 7 | docs/forensics/b057_phase7_operational_readiness_closure_pack_evidence.md | Operational readiness closure pack + governance durability proof | ca485f1db918a5d8764c927189626d17e3093bf2 | https://github.com/Muk223/skeldir-2.0/actions/runs/21363064948 |
 | B0.6 Phase 1 context delta | docs/forensics/phase1_context_delta_notes.md | Phase 1 re-validation context delta notes (pre-remediation) | PR #29 / pending | pending |
-| B0.6 Phase 1 remediation | docs/forensics/b060_phase1_remediation_evidence_v2.md | Phase 1 remediation evidence pack (auth + tenant boundary) | PR #29 / 29174fa | https://github.com/Muk223/skeldir-2.0/actions/runs/21409231639 |
-| B0.6 Phase 1 remediation (superseded) | docs/forensics/b060_phase1_remediation_evidence.md | Superseded by v2 evidence pack. | PR #29 / 29174fa | https://github.com/Muk223/skeldir-2.0/actions/runs/21409231639 |
+| B0.6 Phase 1 remediation | docs/forensics/b060_phase1_remediation_evidence_v2.md | Phase 1 remediation evidence pack (auth + tenant boundary) | PR #29 / d95d0fb | https://github.com/Muk223/skeldir-2.0/actions/runs/21411787347 |
+| B0.6 Phase 1 remediation (superseded) | docs/forensics/b060_phase1_remediation_evidence.md | Superseded by v2 evidence pack. | PR #29 / d95d0fb | https://github.com/Muk223/skeldir-2.0/actions/runs/21411787347 |
 
 ## Root evidence packs
 | Phase/Topic | Evidence pack | Purpose | PR/Commit | CI Run |

--- a/docs/forensics/b060_phase1_remediation_evidence_v2.md
+++ b/docs/forensics/b060_phase1_remediation_evidence_v2.md
@@ -5,7 +5,7 @@ Date: 2026-01-27
 ## SHAs
 
 - Before: `2fc0a5365ebaeffd5f04c38233f7648624099501`
-- After: `29174fad227c89563a42cbb5692830b1d5eabcbe`
+- After: `d95d0fbdb4fb8131869bc735adf243b99df73ec1`
 
 ## Context Delta Re-validation
 
@@ -45,36 +45,35 @@ See `docs/forensics/phase1_context_delta_notes.md`.
 - `Get-Content .github/workflows/ci.yml | Select-String -Pattern "test_b06_realtime_revenue_v1" -Context 3,3`
 - `Get-Content tests/test_b06_realtime_revenue_v1.py`
 - `gh run list --branch b060-phase1-auth-tenant --limit 20`
-- `gh run view 21409231639 --log --job 61641506822`
-- `gh run view 21409231673`
-- `gh run rerun 21409231673 --failed`
+- `gh run view 21411787347 --log --job 61650332306`
+- `gh pr view 29 --json state,mergedAt,mergeCommit`
 
 ## CI Run Link
 
-- https://github.com/Muk223/skeldir-2.0/actions/runs/21409231639 (B0.6 Phase 0 Adjudication)
-- https://github.com/Muk223/skeldir-2.0/actions/runs/21409231639/job/61641506822 (job)
+- https://github.com/Muk223/skeldir-2.0/actions/runs/21411787347 (B0.6 Phase 0 Adjudication)
+- https://github.com/Muk223/skeldir-2.0/actions/runs/21411787347/job/61650332306 (job)
 
 ## CI Log Excerpt (Gate P1-F)
 
 ```
-> B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T18:29:56.2536930Z 
+> B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T19:50:30.0516999Z 
  tests/test_b060_phase1_auth_tenant.py::test_missing_token_returns_401 
-  B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T18:29:56.2550456Z PASSED                        
+  B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T19:50:30.0532139Z PASSED                        
                                            [ 20%]
-> B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T18:29:56.2578920Z 
+> B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T19:50:30.0560936Z 
  tests/test_b060_phase1_auth_tenant.py::test_invalid_token_returns_401 
-  B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T18:29:56.2589731Z PASSED                        
+  B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T19:50:30.0572129Z PASSED                        
                                            [ 40%]
-> B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T18:29:56.2619901Z 
+> B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T19:50:30.0601540Z 
  tests/test_b060_phase1_auth_tenant.py::test_missing_tenant_claim_returns_401 
-  B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T18:29:56.2630747Z PASSED                        
+  B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T19:50:30.0612406Z PASSED                        
                                            [ 60%]
-> B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T18:29:56.2662268Z 
+> B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T19:50:30.0645048Z 
  tests/test_b060_phase1_auth_tenant.py::test_valid_token_sets_tenant_and_calls_session 
-  B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T18:29:56.2673920Z PASSED                        
+  B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T19:50:30.0657745Z PASSED                        
                                            [ 80%]
-> B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T18:29:56.2702672Z 
+> B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T19:50:30.0690896Z 
  tests/test_b060_phase1_auth_tenant.py::test_two_tokens_yield_distinct_tenants 
-  B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T18:29:56.6365232Z PASSED                        
+  B0.6 Phase 0 Adjudication	B0.6 Phase 0 adjudication tests	2026-01-27T19:50:30.4109015Z PASSED                        
                                            [100%]
 ```


### PR DESCRIPTION
Update Phase 1 evidence v2 with merge SHA and main CI run/logs. Restore INDEX refs to main CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR updates B0.6 Phase 1 remediation forensic evidence documentation to reflect the actual merge commit and CI run from PR #29 (JWT auth + tenant boundary implementation). The changes are documentation-only, updating merge SHA references from an interim commit to the final merge commit (`d95d0fb`) and pointing to the correct CI run (`21411787347`).

## Impacted Skeldir Backend Phase

- **B0.6 Phase 1** (JWT auth + tenant boundary remediation) - Documentation evidence pointers only

## Architecture Impact Assessment

✅ **Maintains Postgres-only stack:** JWT authentication and tenant boundary enforcement remain deterministic database operations; no new external services introduced.

✅ **Preserves deterministic-LLM boundaries:** Authentication and tenant context validation are purely deterministic operations; no LLM involvement.

✅ **Enforces compute bounds:** JWT validation is lightweight and deterministic; no impact on 30-60s LLM timeouts or 5min Bayesian bounds.

✅ **Maintains 75% gross margin targets:** Documentation-only update; no operational cost changes.

## Assessment

**MUST FIX (Blocker):** None

**SHOULD FIX (Strong Recommendation):** None

**NICE TO HAVE (Optional):** None

---

This is a non-blocking documentation housekeeping PR that corrects forensic evidence pointers after the merge of the actual B0.6 Phase 1 remediation work (PR #29). The underlying remediation (JWT auth + tenant boundary) has already been validated and merged; this PR simply documents the proof of execution with correct references.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->