### PR TITLE
docs: finalize b07 p2 push-triggered remediation evidence

### DIFF
--- a/docs/forensics/b07_p2_remediation_evidence.md
+++ b/docs/forensics/b07_p2_remediation_evidence.md
@@ -2,133 +2,129 @@
 
 Date: 2026-02-06
 Branch: main
-Status: Draft (CI artifacts captured)
-Target: Continuous runtime proof (broker + worker + DB write) and secrets redaction hardening
+Status: PASS for B0.7-P2 exit gates (artifact-backed)
 
-## Purpose
-Establish a non-vacuous CI runtime chain for LLM task consumption and enforce secrets hygiene before provider enablement.
+## Scope
+Move B0.7-P2 from hypothesis to falsified-proof using only:
+1. `main` diff
+2. push-triggered Actions run evidence
+3. deterministic test output
+4. uploaded artifact contents
 
-## Scientific Approach
-This document uses falsifiable hypotheses, deterministic probes, and artifact-backed observations. All findings must point to CI artifacts or code paths. Until CI runs, hypotheses remain unverified.
+## Remediation Changes on main
+Commit: `ac1405bf82788636df430078bc9a983027c40abe`
+Title: `ci: harden b07 p2 fail-fast and redaction gates`
 
-## Hypotheses (H-P2-01..06)
-H-P2-01: CI enqueues a real LLM task and the worker consumes it (non-vacuous runtime chain).
-H-P2-02: Worker write succeeds under P1 RLS + identity (tenant_id + user_id), and cross-tenant/user reads are denied.
-H-P2-03: Celery queue routing includes `llm` and the worker is subscribed to it in the CI proof.
-H-P2-04: Centralized redaction prevents canary secrets from leaking to logs (worker + lifecycle logs).
-H-P2-05: Provider enablement fails fast at config init if key is missing.
-H-P2-06: CI uploads sanitized artifacts that can be audited post-run.
+Changed files:
+1. `.github/workflows/ci.yml`
+2. `backend/tests/test_b07_p2_provider_enablement.py`
 
-## Probe Design (Deterministic Tests)
-1. Runtime chain proof
-- Test: `backend/tests/integration/test_b07_p2_runtime_chain_e2e.py`
-- Mechanism: enqueue LLM explanation task via `enqueue_llm_task`, poll DB for `llm_api_calls` row by deterministic `request_id`, assert required columns non-null.
-- Falsification: fails if task not consumed, DB write blocked, or schema fields missing.
+Implemented controls:
+1. Provider gate env explicitly sets `LLM_PROVIDER_API_KEY` blank for non-vacuous missing-key execution.
+2. Provider gate now proves both falsifiers:
+   - enabled + missing key fails
+   - disabled + missing key passes
+3. Added deterministic redaction/artifact scan step in CI:
+   - requires expected files
+   - fails if canary appears in artifact tree
+   - fails on non-redacted `LLM_PROVIDER_API_KEY=` and `Authorization: Bearer `
+   - requires positive redaction markers in worker log
 
-2. RLS/identity enforcement
-- Test: `backend/tests/integration/test_b07_p2_runtime_chain_e2e.py`
-- Mechanism: attempt reads with wrong tenant/user GUCs and assert zero rows.
-- Falsification: returns row under wrong identity.
+## Push-Triggered Proof (H-P2-01/H-P2-03)
+Workflow run metadata:
+1. Run ID: `21760827869`
+2. URL: `https://github.com/Muk223/skeldir-2.0/actions/runs/21760827869`
+3. Event: `push`
+4. Branch: `main`
+5. Head SHA: `ac1405bf82788636df430078bc9a983027c40abe`
+6. Created (UTC): `2026-02-06T18:07:08Z`
 
-3. Redaction gate
-- Test: `backend/tests/integration/test_b07_p2_runtime_chain_e2e.py`
-- Canary: `B07_P2_LOG_CANARY=skeldir_test_secret_123`
-- Mechanism: `app.tasks.observability_test.redaction_canary` logs `LLM_PROVIDER_API_KEY=<canary>` and `Bearer <canary>`; assert only redacted tokens appear.
-- Falsification: canary appears in logs.
+P2 job execution:
+1. Job name: `B0.7 P2 Runtime Proof (LLM + Redaction)`
+2. Job ID: `62783711300`
+3. Conclusion: `success`
+4. Passed steps:
+   - `Run B0.7 P2 provider enablement unit gate`
+   - `Run B0.7 P2 runtime chain proof`
+   - `Verify B0.7 P2 artifact and log redaction hygiene`
+   - `Upload B0.7 P2 artifacts`
 
-4. Fail-fast provider gate
-- Test: `backend/tests/test_b07_p2_provider_enablement.py`
-- Mechanism: set `LLM_PROVIDER_ENABLED=true` without key and expect config init failure.
-- Falsification: config loads without exception.
+Note: overall workflow conclusion was `failure` due unrelated job `Phase Gates (B0.6)`. B0.7-P2 required job passed.
 
-## CI Harness (Runtime Oracle)
-- Workflow: `.github/workflows/ci.yml`
-- Job: `b07-p2-runtime-proof` (B0.7 P2 Runtime Proof)
-- Key env:
-  - `DATABASE_URL=postgresql+asyncpg://app_user:app_user@127.0.0.1:5432/skeldir_b07_p2`
-  - `B07_P2_RUNTIME_DATABASE_URL=postgresql://app_user:app_user@127.0.0.1:5432/skeldir_b07_p2`
-  - `CELERY_BROKER_URL=sqla+postgresql://app_user:app_user@127.0.0.1:5432/skeldir_b07_p2`
-  - `CELERY_RESULT_BACKEND=db+postgresql://app_user:app_user@127.0.0.1:5432/skeldir_b07_p2`
-  - `SKELDIR_TEST_TASKS=1`
+## Artifact Proof (H-P2-04/H-P2-06)
+Artifact metadata:
+1. Name: `b07-p2-runtime-proof`
+2. Artifact ID: `5410089070`
+3. Size: `2586` bytes
+4. Digest: `sha256:7818b4013d00b14521d77273f6aa2c4058480c30b0aeb7a1c3554ee38a014e96`
+5. Created (UTC): `2026-02-06T18:08:34Z`
+6. Expires (UTC): `2026-02-20T18:08:34Z`
 
-## Evidence Artifacts (Expected Paths)
-These artifacts are produced by the CI job and should be attached to the run:
-- `artifacts/b07-p2/pytest.log`
-- `artifacts/b07-p2/worker.log`
-- `artifacts/b07-p2/runtime_db_probe.json`
-- `artifacts/b07-p2/redaction_probe.json`
+Artifact manifest (`.tmp_ci_artifacts_push_proof_21760827869`):
+1. `pytest.log` (686 bytes, sha256 `9195484f47e5da94aac3baf6a8dd06ed8059c8209c6162926495ed1df3a9c310`)
+2. `worker.log` (6277 bytes, sha256 `33f38600adac30954226d4402d0702ad2024327bc7c9f679b458cfff85c19314`)
+3. `runtime_db_probe.json` (244 bytes, sha256 `a7c354795af4978766ec146e240e7b58b307bb90a976198e72ea3891609b78f5`)
+4. `redaction_probe.json` (96 bytes, sha256 `ddfd58c31bac23b77e2fdfe9dbf0ad7d65b7b96d6d75569b5ffd81c0d7281431`)
 
-## Observations (CI Run 21759002041 on main)
-Run metadata (GitHub Actions API):
-- Workflow run ID: `21759002041`
-- Head SHA: `6ed5ab11e040df520aae1dcc0c12beac5e9d66f3`
-- Trigger: `workflow_dispatch`
-- Run start (UTC): 2026-02-06T17:05:16Z
-- Conclusion: failure (other jobs failed), but `B0.7 P2 Runtime Proof (LLM + Redaction)` succeeded.
+## Runtime Consume Evidence (H-P2-01/H-P2-02)
+`runtime_db_probe.json` captured:
+1. `tenant_id`: `03a51b13-3bbe-479a-a6e7-735dc2f8537d`
+2. `user_id`: `77e8f540-4999-420d-9b92-3d4a5a2c8991`
+3. `request_id`: `b07-p2-03a51b13`
+4. `endpoint`: `app.tasks.llm.explanation`
+5. `provider`: `stub`
+6. `distillation_eligible`: `false`
 
-B0.7 P2 job status:
-- Job: `B0.7 P2 Runtime Proof (LLM + Redaction)` (job_id: 62777232343)
-- Conclusion: success
-- Provider enablement unit gate step succeeded.
-- Runtime chain proof step succeeded.
-- Artifact upload step succeeded.
+`pytest.log` confirms runtime test executed and passed:
+1. `backend/tests/integration/test_b07_p2_runtime_chain_e2e.py::test_b07_p2_runtime_llm_chain_with_redaction PASSED [100%]`
 
-Artifact presence:
-- Artifact `b07-p2-runtime-proof` exists for this run.
-- Files inspected:
-  - `runtime_db_probe.json`
-  - `redaction_probe.json`
-  - `worker.log`
-  - `pytest.log`
+## Fail-Fast Secrets Evidence (H-P2-02/RC-P2-04)
+Unit test source:
+1. `backend/tests/test_b07_p2_provider_enablement.py` now contains both cases.
 
-Required confirmations (artifact-backed):
-1. Runtime chain proof
-- `runtime_db_probe.json` contains:
-  - `request_id`: `b07-p2-59dc2d50`
-  - `tenant_id`: `59dc2d50-f6ef-4e8b-b4fd-b30f7576c7eb`
-  - `user_id`: `3bf78e6a-b56a-4a3f-acc3-c976ac994d36`
-  - `provider`: `stub`
-  - `distillation_eligible`: `false`
-  - `endpoint`: `app.tasks.llm.explanation`
+CI log proof from P2 provider step:
+1. `LLM_PROVIDER_API_KEY:` is empty in step environment.
+2. `test_provider_enabled_requires_api_key PASSED`
+3. `test_provider_disabled_without_api_key_is_allowed PASSED`
+4. `2 passed in 0.23s`
 
-2. RLS enforcement
-- `pytest.log` shows `test_b07_p2_runtime_llm_chain_with_redaction` passed with cross-tenant/user read assertions.
+## No-Leak Redaction Evidence (H-P2-04/RC-P2-05)
+Artifact probe output (`redaction_probe.json`):
+1. `canary_present: false`
+2. `redacted_key_present: true`
+3. `redacted_bearer_present: true`
 
-3. Redaction
-- `redaction_probe.json` reports `canary_present=false`, `redacted_key_present=true`, `redacted_bearer_present=true`.
-- `worker.log` shows redacted markers:
-  - `LLM_PROVIDER_API_KEY=***`
-  - `Authorization: Bearer ***`
+Worker log positive controls:
+1. `LLM_PROVIDER_API_KEY=***`
+2. `Authorization: Bearer ***`
+3. `llm_explanation_stubbed`
 
-4. Fail-fast provider gate
-- `pytest.log` shows `test_b07_p2_provider_enablement.py` executed and passed before the runtime chain proof.
+CI log proof of deterministic scanner:
+1. Step `Verify B0.7 P2 artifact and log redaction hygiene` passed.
+2. Output: `B0.7 P2 redaction hygiene scan passed`
+3. Scan is fail-fast on canary and non-redacted patterns.
 
-5. Artifact audit gate
-- CI artifacts uploaded under `b07-p2-runtime-proof`.
+## Governance Enforcement (RC-P2-03)
+Branch protection was absent before remediation (`main` returned `Branch not protected`).
 
-## Code Changes (Ground Truth References)
-- `backend/app/observability/logging_config.py`:
-  - Adds centralized redaction filter for structured JSON logs and exceptions.
-- `backend/app/observability/celery_task_lifecycle.py`:
-  - Applies redaction filter to raw lifecycle JSON logs.
-- `backend/app/core/config.py`:
-  - Adds `LLM_PROVIDER_ENABLED` + `LLM_PROVIDER_API_KEY` and fail-fast validation.
-- `backend/app/tasks/observability_test.py`:
-  - Adds redaction canary task for deterministic log proof.
-- `backend/tests/integration/test_b07_p2_runtime_chain_e2e.py`:
-  - Runtime chain, RLS, and redaction validation with artifact outputs.
-- `backend/tests/test_b07_p2_provider_enablement.py`:
-  - Fails fast when provider enabled without key.
-- `.github/workflows/ci.yml`:
-  - Adds `b07-p2-runtime-proof` job with artifact uploads.
+Applied protection on `main` (admin token):
+1. `required_status_checks.strict = true`
+2. Required check: `B0.7 P2 Runtime Proof (LLM + Redaction)`
+3. `enforce_admins.enabled = true`
+4. Verified via `GET /repos/Muk223/skeldir-2.0/branches/main/protection`
 
-## Exit Gates Mapping
-- EG-P2-1 Runtime Consume Gate: `test_b07_p2_runtime_chain_e2e.py` + `runtime_db_probe.json`.
-- EG-P2-2 Schema + Identity Gate: `runtime_db_probe.json` + RLS assertions.
-- EG-P2-3 No-Leak Redaction Gate: `redaction_probe.json` + `worker.log`.
-- EG-P2-4 Fail-Fast Secrets Gate: `test_b07_p2_provider_enablement.py`.
-- EG-P2-5 CI Artifact Audit Gate: `b07-p2-runtime-proof` artifact upload.
+## Exit Gates
+1. EG-P2-1 Continuous Mainline Governance Gate: PASS
+   - Push-triggered run on `main` (`21760827869`) executed P2 job automatically and passed.
+   - Branch protection now requires P2 check on `main`.
+2. EG-P2-2 Runtime Consume Gate: PASS
+   - Runtime integration test passed and `runtime_db_probe.json` shows consumed task write row.
+3. EG-P2-3 No-Leak Redaction Gate: PASS
+   - Canary absent; redaction markers present; CI artifact/log scanner passed.
+4. EG-P2-4 Fail-Fast Secrets Gate: PASS
+   - Enabled-without-key fails and disabled-without-key passes in CI with blank key env.
+5. EG-P2-5 Artifact Audit Gate: PASS
+   - Artifact uploaded with ID/digest, required 4-file manifest present, scanner pass logged.
 
-## Next Evidence Capture Steps
-1. Optional: capture checksums for `runtime_db_probe.json`, `redaction_probe.json`, and `worker.log`.
-2. If related code changes occur, re-run CI on `main` and refresh this document with new artifacts.
+## Residual Note
+This evidence package proves B0.7-P2 controls on `main` for run `21760827869`. It does not claim global CI health beyond this scope.


### PR DESCRIPTION
## Summary
- replace workflow_dispatch-centric claims with push-triggered run evidence
- map EG-P2-1..EG-P2-5 to concrete run/job/artifact/test proofs
- record branch-protection enforcement for required P2 runtime proof check

## Evidence anchors
- push run: 21760827869
- P2 job: 62783711300 (success)
- artifact: 5410089070 (b07-p2-runtime-proof)
- remediation commit: ac1405bf82788636df430078bc9a983027c40abe


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What This PR Changes

This PR finalizes B0.7-P2 remediation evidence by documenting push-triggered CI controls for LLM provider enablement, secrets redaction, and fail-fast gates. The underlying remediation commit hardened two artifacts: (1) `.github/workflows/ci.yml` with explicit blank-key provider gating and deterministic redaction hygiene scanning; (2) `backend/tests/test_b07_p2_provider_enablement.py` with dual test cases proving enabled-without-key fails and disabled-without-key passes.

## Impacted Skeldir Backend Phase(s) and Components

**B0.7 LLM Integration** - Provider boundary enforcement, secrets fail-fast gates, artifact redaction verification, and Celery task dispatch (stub provider)

## Architecture Impact Assessment

✅ **Maintains Postgres-only stack**: Uses `sqla+postgresql://` for Celery broker and result backend; no Redis/Kafka/alternate brokers  
✅ **Preserves deterministic-LLM boundary**: Tests confirm LLM provider fails when enabled but credentials are missing; stub provider prevents accidental inference execution  
⚠️ **Compute bounds enforcement incomplete**: PR implements fail-fast on missing credentials but does not add runtime verification of ≤60s timeout, ≤10 tool call limits, or ≤$0.30/investigation cost cap  
⚠️ **Margin targets not addressed**: No cost rollup, budget alerting, or downgrade logic visible in code changes

---

## **MUST FIX (Blocker)**

**Missing LLM compute bounds enforcement (B0.7 LLM Integration - compute bounds requirement)**

AGENTS.md mandate: "bounded agents: ≤60s, ≤10 tool calls, ≤$0.30/investigation."

The PR's fail-fast gate validates *credential presence* but does not enforce *runtime compute limits*. Before merging, add:
- Pytest test validating request timeout ≤60s (mock LLM call with elapsed time assertion)
- Pytest test validating tool_calls count ≤10 (mock multi-turn agent exchange)
- Celery task wrapper validating total cost per investigation ≤$0.30 before dispatch

**Missing LLM output validation gate (B0.7 LLM Integration - output validation requirement)**

AGENTS.md mandate: "Output validation: Pydantic-validate and DB-cross-check numeric claims; reject/regenerate on mismatch; log model/cost/deltas."

The redaction hygiene scan passes artifact content but does not validate *semantic correctness* of LLM outputs. Before merging, add:
- Schema validator proving LLM response matches expected Pydantic model (test in `test_b07_p2_runtime_chain_e2e.py`)
- Database cross-check: if LLM claims numeric result, verify it against canonical deterministic value; fail if delta exceeds tolerance

**Missing cost/audit logging implementation (B0.7 LLM Integration - audit logging requirement)**

AGENTS.md mandate: "Cost/audit logging: log every call (user_id, feature, model, tokens, cost, latency, cache hit); monthly rollups; alert and downgrade when near budget."

Runtime evidence shows `"provider": "stub"` but no cost instrumentation. Before merging, add:
- Structured log entry for every LLM call including user_id, feature, model, tokens consumed, cost, latency, cache hit status
- Database schema to persist calls (or reference existing telemetry table)
- Monthly rollup query or alerting rule (defer implementation to follow-up PR, but document table/column names in evidence)

---

## **SHOULD FIX (Strong Recommendation)**

**Evidence document overstates proof maturity**

The evidence document claims "Status: PASS for B0.7-P2 exit gates" and documents "EG-P2-5 Artifact Audit Gate: PASS," but the underlying code implements only 2 of 3 mandatory B0.7 LLM Integration controls (fail-fast + redaction; missing compute bounds + output validation + cost logging). Update evidence to state "P2 Incremental: Secrets & Redaction Gates PASS; Compute Bounds & Output Validation Gates DEFERRED" to align with actual implementation.

**Provider stub should be explicit in test naming**

The test endpoint `app.tasks.llm.explanation` with `"provider": "stub"` is appropriate for P2 proof-of-concept, but future P3+ phases require real provider integration. Add comment to `test_b07_p2_runtime_chain_e2e.py` explicitly noting stub provider limitation and link to future P3 LLM provider integration ticket.

**CI redaction regex should reject additional patterns**

The bash grep patterns for `LLM_PROVIDER_API_KEY` and `Authorization: Bearer` are good starts, but add negative lookaheads for:
- Database connection strings (`postgresql://...@...`)
- Correlation IDs that may contain PII-adjacent values
- Custom headers set by Celery/worker (review logs for pattern gaps before merge)

---

## **NICE TO HAVE (Optional)**

- Add pytest fixture to capture and redact Celery worker logs automatically (reduces manual log hygiene burden for future P2-like gates)
- Document branch protection check ID in evidence for auditability (commit includes admin token proof; nice to add GitHub API response body showing `"required": true` for P2 check)
- Link remediation evidence commit to broader B0.7 phase roadmap document (PHASE_MIGRATION_MAPPING.md references B0.7+ but no detailed phase gate breakdown exists yet)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->