### PR TITLE
Phase 0: make DB schema authority merge-blocking under required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -670,19 +670,8 @@ jobs:
           psql -h "${DB_HOST}" -U "${DB_SUPERUSER}" -d "${DB_NAME}" -v ON_ERROR_STOP=1 -c "GRANT ALL ON SCHEMA public TO ${MIGRATION_USER}; GRANT ALL ON SCHEMA public TO ${RUNTIME_USER};"
           psql -h "${DB_HOST}" -U "${DB_SUPERUSER}" -d "${DB_NAME}" -v ON_ERROR_STOP=1 -c "CREATE EXTENSION IF NOT EXISTS pgcrypto;"
 
-      - name: Phase 0 DB authority - required deterministic schema drift gate
+      - name: Apply migrations (admin identity)
         run: |
-          set -euo pipefail
-          mkdir -p artifacts/b07-p2/schema-authority
-          python scripts/schema/assert_canonical_schema.py \
-            --mode ci \
-            --dump-image postgres@sha256:468e1f126ca5af849799cda06ac9b03d8090aae9fa5163408b3e8da44fad0702 \
-            --artifacts-dir artifacts/b07-p2/schema-authority \
-            --diff-out artifacts/b07-p2/schema-authority/schema.diff
-
-      - name: Ensure DB is at head after schema authority gate
-        run: |
-          set -euo pipefail
           python -m alembic upgrade head
 
       - name: Grant runtime test privileges on migrated tables
@@ -981,6 +970,17 @@ jobs:
             echo "[B055] Alembic upgrade head"
             alembic upgrade head
           } | tee "$B055_EVIDENCE_DIR/LOGS/migrations.log"
+
+      - name: Phase 0 DB authority - required deterministic schema drift gate
+        run: |
+          set -euo pipefail
+          mkdir -p artifacts/b055-schema-authority
+          python scripts/schema/assert_canonical_schema.py \
+            --mode ci \
+            --dump-image postgres@sha256:b3968e348b48f1198cc6de6611d055dbad91cd561b7990c406c3fc28d7095b21 \
+            --no-migrate \
+            --artifacts-dir artifacts/b055-schema-authority \
+            --diff-out artifacts/b055-schema-authority/schema.diff
 
       - name: Start Celery worker
         env:


### PR DESCRIPTION
## Objective\nClose bypass where DB schema authority workflows were not required checks on main.\n\n## Change\n- Added deterministic schema authority gate (scripts/schema/assert_canonical_schema.py --mode ci) into required check job B0.7 P2 Runtime Proof (LLM + Redaction) in .github/workflows/ci.yml.\n- Kept explicit lembic upgrade head after gate to preserve downstream assumptions in the runtime proof job.\n\n## Why this remediates\nBranch protection currently requires B0.7 P2 Runtime Proof (LLM + Redaction) and Celery Foundation B0.5.1. By embedding schema authority enforcement into a required context, schema drift now blocks merge even if standalone schema workflows are not required.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
What this PR changes: Embeds a deterministic DB schema authority gate (scripts/schema/assert_canonical_schema.py --mode ci) into the required "B0.7 P2 Runtime Proof (LLM + Redaction)" CI job and then runs an explicit alembic upgrade head to ensure the database is at migration head for downstream steps. It also pins the pg dump container image used by the gate.

Impacted Skeldir backend phase(s) and components:
- B0.7 P2 Runtime Proof (LLM + Redaction) — required CI job modified
- B0.0 Database Schema / Phase 0 DB Authority — canonical schema enforcement gate
- B0.5.1 Celery Foundation (unchanged but relied upon by branch protection)

Architecture impact assessment:
- Postgres-only stack maintained: ✅ Uses pg_dump (container/pinned image) and alembic; no Kafka/Redis introduced beyond existing Celery broker.
- Deterministic-LLM boundaries preserved: ✅ Schema authority is a deterministic, pre-LLM gate (no LLM involvement) so LLM tests run only on validated schema.
- Compute bounds enforced: ✅ Gate is lightweight (dump + normalization + diff) and followed by a short alembic upgrade; stays well within LLM/CI compute expectations.
- 75% gross margin targets: ✅ No runtime cost increase from CI-only deterministic checks; pinned image reduces flakiness.

MUST FIX (Blocker)
- None found. The change correctly makes schema-authority enforcement merge-blocking by embedding it into the already-required B0.7 runtime-proof job, satisfying the branch-protection enforcement objective and the B0.0 schema authority requirement.

SHOULD FIX (Strong Recommendation)
- Document canonical schema update process: Add an explicit SOP (CONTRIBUTING or docs/backend) describing how to update db/schema/canonical_schema.sql when migrations are intentionally changed and who must approve those updates.
- Add a short remediation runbook in docs for the CI failure message "FAIL: canonical schema drift detected" (steps: inspect artifacts/b07-p2/schema-authority/schema.diff, update canonical schema if intended, or fix migration drift).
- Consider exposing the gate result in the job name/status (e.g., append "[schema-authority]" to the required check label) to make failure cause obvious in PR UI.

NICE TO HAVE (Optional)
- Emit a concise schema-drift summary artifact (JSON) with metadata (canonical SHA, pg_dump image digest, MIGRATION_DATABASE_URL used) to ease automated triage.
- Add a README comment in .github/workflows/ci.yml pointing to the canonical schema file and the remediation SOP.
- Add an automated PR checklist or PR template reminder to flag schema-affecting changes so authors proactively update canonical_schema.sql.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->