### PR TITLE
Phase 0: remove schema drift governance ambiguity

### DIFF
--- a/.github/workflows/schema-drift-check.yml
+++ b/.github/workflows/schema-drift-check.yml
@@ -1,23 +1,11 @@
-name: Schema Drift Check
+name: Schema Drift Diagnostics (Manual)
 
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - 'alembic/versions/**'
-      - 'db/schema/**'
-      - 'scripts/schema/**'
-      - '.github/workflows/schema-drift-check.yml'
-  push:
-    branches:
-      - main
-    paths:
-      - 'alembic/versions/**'
-      - 'db/schema/**'
-      - 'scripts/schema/**'
 
 jobs:
   drift-check:
+    name: Drift diagnostics (non-merge authority)
     runs-on: ubuntu-latest
     services:
       postgres:


### PR DESCRIPTION
## Objective\nEliminate Phase 0 governance ambiguity from dual DB schema authority workflows.\n\n## Change\n- Converted .github/workflows/schema-drift-check.yml to manual diagnostics only (workflow_dispatch).\n- Removed pull_request/push triggers from standalone schema drift workflow.\n- Explicitly named job as non-merge authority.\n\n## Governance outcome\n- Merge-blocking DB schema authority remains singular in required check context: Celery Foundation B0.5.1 (which runs scripts/schema/assert_canonical_schema.py).\n- Standalone drift workflow remains available for ad hoc diagnostics without conflicting merge policy signals.\n

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What This PR Changes

This PR eliminates Phase 0 governance ambiguity by converting the standalone schema drift workflow from automatic triggers (pull_request, push) to manual-only execution (workflow_dispatch), ensuring the merge-blocking schema validation authority remains singular in the required CI check context.

## Impacted Skeldir Backend Phase(s) and Components

- **B0.5.1 Database Schema (Governance)**: Singular schema authority consolidation
- **CI/CD Workflow Governance**: Eliminates dual-signal risk from conflicting automated schema checks

## Architecture Impact Assessment

| Criterion | Status | Notes |
|-----------|--------|-------|
| Postgres-only stack | ✓ Maintained | PostgreSQL 15 service, Alembic, SQLAlchemy—no external message brokers introduced |
| Deterministic-LLM boundaries | ✓ N/A | Schema validation is deterministic infrastructure; no LLM involvement |
| Compute bounds enforcement | ✓ Maintained | Schema drift check completes in seconds; well within 30-60s operational window |
| 75% gross margin targets | ✓ N/A | Infrastructure governance change; no cost impact |

## Review Feedback

**MUST FIX (Blocker)**
- None identified. The governance change correctly implements the singular schema authority principle.

**SHOULD FIX (Strong Recommendation)**
- **Document the authoritative merge-blocking workflow location**: Add a comment in `.github/workflows/schema-drift-check.yml` pointing to the authoritative schema check (B0.5.1) to prevent future confusion. Current state risks developers re-automating this workflow without understanding the governance model.
- **Verify Celery Foundation B0.5.1 enforcement**: Confirm that the required check context in branch protection rules explicitly specifies only the B0.5.1 schema assertion workflow, not this manual diagnostic. Audit `.github` or repository settings documentation to confirm this coupling is documented.

**NICE TO HAVE (Optional)**
- Consider adding a `README` section documenting the Phase 0 schema governance model: which workflows are authoritative (B0.5.1), which are diagnostic (this one), and why automatic triggers were removed. This prevents future confusion during maintenance.
- Add a step that logs a clear message indicating this is a **non-merge-blocking diagnostic tool** before running the schema assertion, reducing risk of misinterpretation in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->