### PR TITLE
ci: dedicated Phase 1 runtime conformance gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -277,6 +277,33 @@ jobs:
         run: |
           chmod +x scripts/contracts/run_negative_controls.sh
           bash scripts/contracts/run_negative_controls.sh
+
+  phase1-runtime-conformance:
+    name: Phase 1 Runtime Conformance
+    runs-on: ubuntu-latest
+    needs: [checkout, validate-contracts]
+    env:
+      DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+      PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/backend
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.ADJUDICATED_SHA }}
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install backend test dependencies
+        run: |
+          pip install -r backend/requirements.txt
+          pip install -r backend/requirements-dev.txt
+
+      - name: Execute runtime OpenAPI conformance tests
+        run: |
+          pytest tests/contract/test_contract_semantics.py -q
   validate-phase-manifest:
     name: Validate Phase Manifest
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds a dedicated CI job Phase 1 Runtime Conformance that executes 	ests/contract/test_contract_semantics.py independently of B0.5.3.3 job, enabling EG1.2 to be asserted as a standalone merge-blocking context.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Phase 1 Runtime Conformance Gate Addition

This PR adds a dedicated CI job named `phase1-runtime-conformance` to `.github/workflows/ci.yml` that runs `tests/contract/test_contract_semantics.py` independently of the B0.5.3.3 job. The change makes EG1.2 (Exit Gate 1.2 - Runtime Contract Conformance) assertable as a standalone, merge-blocking CI context using Schemathesis to validate that the FastAPI runtime conforms to bundled OpenAPI contracts.

**Impacted Skeldir Components:**
- B0.1 / B0.2 Phase 1 API Contract Closure
- EG1.2 Runtime Contract Conformance Gate (dynamic contract validation)
- Test infrastructure: `tests/contract/test_contract_semantics.py` (318 lines, Schemathesis-based ASGI testing)

**Architecture Impact Assessment:**
- ✓ Postgres-only stack: Job uses only PostgreSQL DSN, no Kafka/Redis
- ✓ Deterministic-LLM boundaries: Test uses ASGI TestClient (no network/LLM calls), validates deterministic contract conformance only
- ✓ Compute bounds: Pytest-based conformance checking, no LLM invocations, completes in seconds
- ✓ 75% gross margin targets: No cost-bearing infrastructure introduced

---

## MUST FIX (Blocker)

**Missing Postgres Service Definition for DATABASE_URL Validation**
The job defines `DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres` without a corresponding `services:` section containing a postgres:15-alpine container. At test execution, the step `Install backend test dependencies` will succeed, but when pytest imports `backend/app/main.py`, the app initialization code imports `backend/app/db/session.py` (via `from app.core.db import engine`) which attempts to instantiate SQLAlchemy's async engine with the provided DATABASE_URL. Without a running PostgreSQL service on localhost:5432, this connection attempt will fail before any tests execute.

The test file itself uses FastAPI's TestClient (pure ASGI in-memory testing) and does not require a real database for the conformance tests themselves; however, the app import phase is blocking. Contrast with `b0533-revenue-contract` job (lines 1408-1420) which correctly defines `services: postgres: ...` with postgres:15-alpine.

**Remediation:** Add a `services:` section with postgres:15-alpine identical to B0.5.3.3, OR modify the job to set `CONTRACT_TESTING: "1"` and ensure the config loader completely bypasses engine initialization when this flag is set (requires code change to `backend/app/db/session.py` to conditionally skip engine creation during app import).

---

## SHOULD FIX (Strong Recommendation)

**Inconsistent Database Credential Pattern vs. B0.5.3.3**
The new job uses hardcoded `DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres`, while the existing `b0533-revenue-contract` job uses environment-driven credentials constructed from CI variables (`DATABASE_URL_ASYNC: postgresql+asyncpg://app_user:app_user_ci_ephemeral_2025@127.0.0.1:5432/skeldir_validation`). Additionally, the B0.5.3.3 job explicitly validates credentials using password masking (R5-1 through R5-5 gates) and role creation (R5-2), whereas this new job skips all authentication setup. If the postgres service were added using the current hardcoded approach, it would bypass the credential sourcing pattern and make the CI configuration fragile to future auth changes.

**Remediation:** Adopt the B0.5.3.3 credential sourcing pattern: define `DB_HOST`, `DB_PORT`, `DB_NAME`, `APP_USER`, `APP_USER_PASSWORD` environment variables, construct `DATABASE_URL_ASYNC` from these, and add the R5 validation gates (at minimum: role creation and password masking). This maintains auditability and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->