### PR TITLE
Fix R3/R7 app_user DB auth regression

### DIFF
--- a/.github/workflows/r3-ingestion-under-fire.yml
+++ b/.github/workflows/r3-ingestion-under-fire.yml
@@ -113,7 +113,9 @@ jobs:
           DO $$
           BEGIN
             IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user') THEN
-              CREATE ROLE app_user LOGIN PASSWORD 'app_user';
+              CREATE ROLE app_user LOGIN PASSWORD 'app_user' NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT;
+            ELSE
+              ALTER ROLE app_user LOGIN PASSWORD 'app_user' NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT;
             END IF;
           END$$;
           GRANT CONNECT ON DATABASE r3 TO app_user;

--- a/.github/workflows/r7-final-winning-state.yml
+++ b/.github/workflows/r7-final-winning-state.yml
@@ -185,6 +185,8 @@ jobs:
           BEGIN
             IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user') THEN
               CREATE ROLE app_user LOGIN PASSWORD 'app_user' NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT;
+            ELSE
+              ALTER ROLE app_user LOGIN PASSWORD 'app_user' NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT;
             END IF;
           END
           $$;


### PR DESCRIPTION
## Summary
- fix R3 workflow role provisioning so existing app_user roles are repaired to LOGIN+PASSWORD
- apply same idempotent role repair in R7 bootstrap for consistency

## Root cause
- migration 202511131121_add_grants can pre-create app_user without LOGIN/password
- R3 previously only created app_user when missing, so existing no-password role caused readiness 503 and harness failure

## Validation
- CI workflows on this PR

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## What This PR Changes
This PR fixes a database authentication regression in the R3 (Ingestion Under Fire) and R7 (Final Winning State) CI workflows by adding idempotent repair logic for the `app_user` PostgreSQL role. Previously, if the `app_user` role existed without LOGIN/password capabilities (as can occur from the migration `202511131121_add_grants.py`), workflow readiness checks would fail with 503 errors. The fix adds an ELSE branch to ALTER existing roles with proper credentials and privilege flags.

## Impacted Skeldir Backend Phase(s) and Components
**B0.x Foundation / Database Bootstrap** — CI/CD workflow provisioning for R3 and R7 readiness validation phases. No changes to production application code, schemas, or runtime behavior.

## Architecture Impact Assessment

**Does this maintain Postgres-only stack?**
✓ **Yes.** Changes only modify PostgreSQL role provisioning within CI workflows using standard SQL. No external dependencies (Kafka, Redis, etc.) are introduced.

**Does this preserve deterministic-LLM boundaries?**
✓ **Yes.** This is CI infrastructure with no LLM involvement. Deterministic-LLM boundaries are unaffected.

**Does this enforce compute bounds?**
✓ **Yes.** This is a provisioning fix with negligible compute impact. No new timeouts or resource consumption introduced.

**Does this maintain 75% gross margin targets?**
✓ **Yes.** CI infrastructure optimizations have no direct margin impact.

## Technical Summary

**R3 Workflow (`r3-ingestion-under-fire.yml`)**
- Adds conditional logic in PostgreSQL provisioning step: if `app_user` role does not exist, CREATE it with LOGIN, PASSWORD, NOSUPERUSER, NOCREATEDB, NOCREATEROLE, and INHERIT flags; if it already exists, ALTER it to apply the same privilege set idempotently.
- Lines changed: +3/-1

**R7 Workflow (`r7-final-winning-state.yml`)**
- Adds ELSE branch in bootstrap provisioning to ALTER existing `app_user` role instead of failing on CREATE. Applies identical credential repair (LOGIN, PASSWORD, and privilege flags).
- Lines changed: +2/-0

**Root Cause & Regression Context**
- Migration `202511131121_add_grants.py` pre-creates `app_user` role without LOGIN/password in clean-room setups.
- Prior R3 logic only executed CREATE path, skipping configuration if role already existed.
- Result: readiness probes fail (503), workflow harness cannot authenticate via `app_user`, test execution blocked.
- Fix: Idempotent ALTER ensures credentials and capabilities are always set regardless of role pre-existence.

## Risks and Findings
- **No blockers identified.** Changes are purely idempotent provisioning repairs in CI workflows.
- No application code modifications.
- No migration or schema changes.
- No changes to role permissions beyond ensuring LOGIN and PASSWORD are set.
- Fix applies consistently across R3 and R7 for testing validation coherence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->