### PR TITLE
fix: unblock R2/R3 by provisioning app_user and applying metadata channel hints

### DIFF
--- a/.github/workflows/r2-data-truth-hardening.yml
+++ b/.github/workflows/r2-data-truth-hardening.yml
@@ -159,6 +159,21 @@ jobs:
           echo "R2_PG_PORT=$R2_PG_PORT" >> "$GITHUB_ENV"
           echo "Postgres host port: $R2_PG_PORT" | tee -a "$GITHUB_STEP_SUMMARY"
 
+      - name: "Provision canonical runtime role prerequisites"
+        run: |
+          set -euo pipefail
+          podman exec skeldir-r2-postgres psql -U $POSTGRES_USER -d $POSTGRES_DB -v ON_ERROR_STOP=1 -c "
+            DO \$\$
+            BEGIN
+              IF NOT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'app_user') THEN
+                CREATE ROLE app_user LOGIN PASSWORD 'app_user' NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT;
+              ELSE
+                ALTER ROLE app_user LOGIN PASSWORD 'app_user' NOSUPERUSER NOCREATEDB NOCREATEROLE INHERIT;
+              END IF;
+            END
+            \$\$;
+          "
+
       - name: "Apply canonical schema"
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- `R2`: create-or-repair `app_user` before applying canonical schema so policy DDL targeting `TO app_user` succeeds
- `R3`: in stripe webhook v2, derive `vendor`, `utm_source`, `utm_medium` from Stripe object metadata when present (fallbacks remain `stripe`)

## Why
- `R2` was failing during schema apply with `ERROR: role app_user does not exist`
- `R3` S9 normalization gate stayed red because event ingestion ignored metadata hints and always normalized from fixed `vendor=stripe, utm_source=stripe`

## Validation
- compiled updated Python modules
- reviewed diffs against failing CI logs for exact failure points