### PR TITLE
B2.1-P1 follow-up: fix replay-compat CI regressions

### DIFF
--- a/backend/tests/integration/test_b057_p5_full_chain_e2e.py
+++ b/backend/tests/integration/test_b057_p5_full_chain_e2e.py
@@ -335,7 +335,10 @@ def _fetch_recompute_job(
                 WHERE tenant_id = :tenant_id
                   AND window_start = :window_start
                   AND window_end = :window_end
-                  AND model_version = '1.0.0'
+                  AND (
+                    model_version = '1.0.0'
+                    OR model_version LIKE '1.0.0::%'
+                  )
                 ORDER BY updated_at DESC
                 LIMIT 1
                 """

--- a/backend/tests/test_b0533_revenue_input_contract.py
+++ b/backend/tests/test_b0533_revenue_input_contract.py
@@ -31,7 +31,7 @@ Contract B Guarantees:
 """
 
 import pytest
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from uuid import uuid4
 from sqlalchemy import text
 
@@ -50,6 +50,59 @@ def _parse_timestamp(iso_string: str) -> datetime:
     else:
         dt = dt.astimezone(timezone.utc)
     return dt
+
+
+async def _upsert_session_authority(
+    conn,
+    *,
+    tenant_id,
+    session_id,
+    issued_at: datetime,
+    expires_at: datetime,
+) -> None:
+    await conn.execute(
+        text(
+            """
+            INSERT INTO session_authority (
+                id,
+                tenant_id,
+                session_id,
+                issued_at,
+                expires_at,
+                last_seen_at,
+                invalidated_at,
+                invalidation_reason,
+                issued_by
+            ) VALUES (
+                :id,
+                :tenant_id,
+                :session_id,
+                :issued_at,
+                :expires_at,
+                :last_seen_at,
+                NULL,
+                NULL,
+                'b0533_contract_test'
+            )
+            ON CONFLICT (tenant_id, session_id)
+            DO UPDATE SET
+                issued_at = EXCLUDED.issued_at,
+                expires_at = EXCLUDED.expires_at,
+                last_seen_at = EXCLUDED.last_seen_at,
+                invalidated_at = NULL,
+                invalidation_reason = NULL,
+                issued_by = EXCLUDED.issued_by
+            """
+        ),
+        {
+            "id": str(uuid4()),
+            "tenant_id": str(tenant_id),
+            "session_id": str(session_id),
+            "issued_at": issued_at,
+            "expires_at": expires_at,
+            "last_seen_at": min(expires_at, issued_at + timedelta(hours=1)),
+        },
+    )
 
 
 @pytest.mark.asyncio
@@ -170,6 +223,21 @@ class TestRevenueInputContract:
                     "channel": channel,
                     "tenant_id": test_tenant_id,
                 }
+            )
+
+            await _upsert_session_authority(
+                conn,
+                tenant_id=test_tenant_id,
+                session_id=session_id_1,
+                issued_at=datetime(2025, 5, 1, 9, 0, tzinfo=timezone.utc),
+                expires_at=datetime(2025, 5, 1, 11, 0, tzinfo=timezone.utc),
+            )
+            await _upsert_session_authority(
+                conn,
+                tenant_id=test_tenant_id,
+                session_id=session_id_2,
+                issued_at=datetime(2025, 5, 1, 14, 0, tzinfo=timezone.utc),
+                expires_at=datetime(2025, 5, 1, 16, 0, tzinfo=timezone.utc),
             )
 
         # Run recompute_window (Contract B: reads events, writes allocations, ignores ledger)
@@ -336,6 +404,21 @@ class TestRevenueInputContract:
                     "channel": channel,
                     "tenant_id": test_tenant_id,
                 }
+            )
+
+            await _upsert_session_authority(
+                conn,
+                tenant_id=test_tenant_id,
+                session_id=session_id_1,
+                issued_at=datetime(2025, 6, 1, 9, 0, tzinfo=timezone.utc),
+                expires_at=datetime(2025, 6, 1, 11, 0, tzinfo=timezone.utc),
+            )
+            await _upsert_session_authority(
+                conn,
+                tenant_id=test_tenant_id,
+                session_id=session_id_2,
+                issued_at=datetime(2025, 6, 1, 14, 0, tzinfo=timezone.utc),
+                expires_at=datetime(2025, 6, 1, 16, 0, tzinfo=timezone.utc),
             )
 
         # BASELINE: Run recompute_window with empty ledger

--- a/docs/forensics/B2.1-P1 Remediation Evidence Pack .md
+++ b/docs/forensics/B2.1-P1 Remediation Evidence Pack .md
@@ -140,6 +140,23 @@ Changes:
 Result:
 - P1 closure is merge-blocking and non-vacuous under semantic weakening.
 
+### R05 - Post-merge compatibility remediation for legacy proof planes
+
+Files:
+- `backend/tests/test_b0533_revenue_input_contract.py`
+- `backend/tests/integration/test_b057_p5_full_chain_e2e.py`
+
+Changes:
+- Updated B0.5.3.3 contract fixtures to seed `session_authority` rows for synthetic
+  sessions used by deterministic recompute assertions.
+- Updated B0.5.7 E2E recompute job probe to accept replay-identity encoded
+  `model_version` rows (`1.0.0::...`) in `attribution_recompute_jobs`, while
+  preserving compatibility with plain `1.0.0`.
+
+Result:
+- Prevents false-negative CI failures introduced by the B2.1-P1 replay identity
+  encoding and session-authority eligibility lock.
+
 ## 4. Local Validation Evidence (Falsifiable)
 
 All commands executed from repository root `c:\Users\ayewhy\II SKELDIR II`.
@@ -162,6 +179,14 @@ Result: `3 passed`
 4. `PYTHONPATH=.;backend DATABASE_URL=postgresql+asyncpg://app_user:app_user@127.0.0.1:5432/skeldir_validation MIGRATION_DATABASE_URL=postgresql://app_user:app_user@127.0.0.1:5432/skeldir_validation pytest backend/tests/test_b0532_window_idempotency.py -q`  
 Result: `4 passed`
 
+### Post-merge compatibility proofs for legacy CI surfaces
+
+5. `pytest backend/tests/test_b0533_revenue_input_contract.py -q -rs`  
+Result: `2 passed`
+
+6. `python -m py_compile backend/tests/integration/test_b057_p5_full_chain_e2e.py backend/tests/test_b0533_revenue_input_contract.py`  
+Result: `pass`
+
 ## 5. Exit Gate Adjudication
 
 1. Canonical Input Taxonomy Lock: **PASS**  
@@ -180,6 +205,8 @@ Result: `4 passed`
 - `backend/app/services/attribution.py`
 - `backend/app/tasks/attribution.py`
 - `backend/tests/integration/test_b21_p1_semantic_replay_runtime.py`
+- `backend/tests/integration/test_b057_p5_full_chain_e2e.py`
+- `backend/tests/test_b0533_revenue_input_contract.py`
 - `backend/tests/test_b0532_window_idempotency.py`
 - `backend/tests/test_b21_p1_attribution_semantics.py`
 - `backend/tests/test_b21_p1_semantic_replay_lock_enforcer.py`
@@ -190,7 +217,7 @@ Result: `4 passed`
 
 ## 7. Protected-Branch Closeout Record
 
-- PR: `pending`
-- Merge commit on `main`: `pending`
-- Authoritative post-merge `main` CI run URL: `pending`
-- Mainline CI result: `pending`
+- PR: `#323` - `https://github.com/Synergyscape-V1/skeldir-2.0/pull/323`
+- Merge commit on `main`: `0e9ac64abfbee9db1db46c7bd5acee83bd2a52af`
+- Authoritative post-merge `main` CI run URL: `https://github.com/Synergyscape-V1/skeldir-2.0/actions/runs/24318734176`
+- Mainline CI result: `failure` (post-merge regressions addressed in R05 follow-up)


### PR DESCRIPTION
﻿## Summary
- seed `session_authority` fixtures in B0.5.3.3 revenue contract tests so deterministic recompute eligibility matches B2.1-P1 replay semantics
- update B0.5.7 full-chain E2E recompute-job probe to match replay-encoded `model_version` (`1.0.0::...`) as well as legacy `1.0.0`
- update B2.1-P1 remediation evidence pack with post-merge compatibility findings and validations

## Root cause
- B2.1-P1 encoded replay identity into `attribution_recompute_jobs.model_version`, but legacy probes still filtered only `model_version='1.0.0'`
- legacy revenue contract tests seeded events without corresponding `session_authority`, producing zero eligible sessions after replay-lock semantics

## Validation
- `pytest backend/tests/test_b0533_revenue_input_contract.py -q -rs`
- `pytest backend/tests/test_b0532_window_idempotency.py -q -rs`
- `pytest backend/tests/integration/test_b21_p1_semantic_replay_runtime.py -q -rs`
- `python scripts/ci/enforce_b21_p1_semantic_replay_lock.py`
- `python -m py_compile backend/tests/integration/test_b057_p5_full_chain_e2e.py backend/tests/test_b0533_revenue_input_contract.py`
