### PR TITLE
Close remaining main CI failures after B2.1-P1 landing

### DIFF
--- a/backend/tests/integration/test_b057_p5_full_chain_e2e.py
+++ b/backend/tests/integration/test_b057_p5_full_chain_e2e.py
@@ -723,7 +723,7 @@ def test_b057_p5_full_chain_webhook_to_matview():
         (artifact_dir / "metrics_api_before.txt").write_text(metrics_api_before, encoding="utf-8")
         (artifact_dir / "metrics_worker_before.txt").write_text(metrics_worker_before, encoding="utf-8")
 
-        event_ts = datetime(2026, 1, 25, 12, 34, 56, tzinfo=timezone.utc)
+        event_ts = datetime.now(timezone.utc).replace(microsecond=0)
         window_start, window_end = _compute_window(event_ts)
         payload = {
             "id": 424242,

--- a/backend/tests/integration/test_b21_p1_semantic_replay_runtime.py
+++ b/backend/tests/integration/test_b21_p1_semantic_replay_runtime.py
@@ -164,6 +164,7 @@ async def _seed_event(
 ) -> None:
     async with engine.begin() as conn:
         await set_tenant_guc(conn, tenant_id, local=True)
+        # RAW_SQL_ALLOWLIST: deterministic runtime seed for B2.1-P1 semantic replay proofs.
         await conn.execute(
             text(
                 """


### PR DESCRIPTION
﻿## Summary
- fix SCHEMA_GUARD failure by adding `RAW_SQL_ALLOWLIST` marker to the B2.1-P1 runtime seed `INSERT INTO attribution_events`
- fix B0.5.7/phase-chain failure mode by using runtime-aligned webhook event timestamp in B057 full-chain E2E, preventing stale scoped-session replay failures

## Failure evidence addressed
- `Phase Gates (SCHEMA_GUARD)` failed on `test_no_raw_inserts_core_tables` for missing marker in `backend/tests/integration/test_b21_p1_semantic_replay_runtime.py`
- `B0.5.7 P6 E2E` failed with `ValueError: session locality violation: requested session scope is stale or invalidated` in recompute worker
- `Phase Chain (B0.4 target)` failed transitively because `SCHEMA_GUARD` failed

## Validation
- `PYTHONPATH=.;backend pytest backend/tests/test_no_raw_inserts_core_tables.py -q -rs`
- `pytest backend/tests/integration/test_b21_p1_semantic_replay_runtime.py -q -rs`
- `python -m py_compile backend/tests/integration/test_b057_p5_full_chain_e2e.py`
