### PR TITLE
fix(marketing): add robots and sitemap for favicon crawl reliability

### DIFF
--- a/marketing/src/app/robots.ts
+++ b/marketing/src/app/robots.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+
+export const dynamic = "force-static";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: "https://skeldir.com/sitemap.xml",
+  };
+}

--- a/marketing/src/app/sitemap.ts
+++ b/marketing/src/app/sitemap.ts
@@ -1,0 +1,24 @@
+import type { MetadataRoute } from "next";
+
+const BASE_URL = "https://skeldir.com";
+export const dynamic = "force-static";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const routes = [
+    "",
+    "/product",
+    "/pricing",
+    "/agencies",
+    "/resources",
+    "/book-demo",
+    "/signup",
+    "/Login",
+  ];
+
+  return routes.map((route) => ({
+    url: `${BASE_URL}${route}`,
+    lastModified: new Date(),
+    changeFrequency: route === "" ? "weekly" : "monthly",
+    priority: route === "" ? 1.0 : 0.7,
+  }));
+}


### PR DESCRIPTION
## Summary
- add static `robots.txt` route in Next app metadata routes
- add static `sitemap.xml` route covering primary marketing pages
- improve crawler discoverability for favicon/search appearance signals

## Validation
- `npm run build` (marketing) succeeds
- routes generated: `/robots.txt` and `/sitemap.xml`
