### PR TITLE
Post-merge CI fix: allowlist markers for B2.1-P3 runtime seed inserts

### DIFF
--- a/backend/tests/integration/test_b21_p3_persistence_read_surface_runtime.py
+++ b/backend/tests/integration/test_b21_p3_persistence_read_surface_runtime.py
@@ -206,6 +206,7 @@ async def _seed_projection_fixture(
         for index, (channel_code, revenue_cents, allocation_ratio, confidence_score) in enumerate(rows):
             event_id = uuid4()
             idempotency_key = f"b21-p3-{tenant_id.hex[:8]}-{index}-{event_id.hex[:12]}"
+            # RAW_SQL_ALLOWLIST: deterministic integration fixture seed for P3 runtime path validation.
             await conn.execute(
                 text(
                     """
@@ -277,6 +278,7 @@ async def _seed_projection_fixture(
                     "updated_at": occurred_at,
                 },
             )
+            # RAW_SQL_ALLOWLIST: deterministic integration fixture seed for persisted allocation projection checks.
             await conn.execute(
                 text(
                     """


### PR DESCRIPTION
﻿## Summary
- add `RAW_SQL_ALLOWLIST` markers to the two deterministic seed inserts in `backend/tests/integration/test_b21_p3_persistence_read_surface_runtime.py`
- resolves main CI failures in `Phase Gates (SCHEMA_GUARD)` and `Phase Chain (B0.4 target)` introduced by raw-insert guard enforcement

## Validation
- `PYTHONPATH=. pytest backend/tests/test_no_raw_inserts_core_tables.py -q`
- `pytest backend/tests/integration/test_b21_p3_persistence_read_surface_runtime.py -q`
