### PR TITLE
B2.1-P3 corrective: projection ownership immutability + channels 422 parity

### DIFF
--- a/alembic/versions/007_skeldir_foundation/202604171200_b21_p3_projection_uniqueness_alignment.py
+++ b/alembic/versions/007_skeldir_foundation/202604171200_b21_p3_projection_uniqueness_alignment.py
@@ -1,0 +1,57 @@
+"""B2.1-P3 align allocation uniqueness with projection identity.
+
+Revision ID: 202604171200
+Revises: 202604160930
+Create Date: 2026-04-17 12:00:00
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "202604171200"
+down_revision: Union[str, None] = "202604160930"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Legacy uniqueness only for rows without projection identity.
+    op.execute(
+        "DROP INDEX IF EXISTS idx_attribution_allocations_tenant_event_model_channel"
+    )
+    op.execute(
+        """
+        CREATE UNIQUE INDEX idx_attribution_allocations_tenant_event_model_channel
+        ON attribution_allocations (tenant_id, event_id, model_version, channel_code)
+        WHERE model_version IS NOT NULL AND recompute_job_id IS NULL
+        """
+    )
+
+    # Projection-aware uniqueness for persisted deterministic projections.
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_attribution_allocations_tenant_event_projection_channel
+        ON attribution_allocations (tenant_id, event_id, recompute_job_id, channel_code)
+        WHERE recompute_job_id IS NOT NULL
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP INDEX IF EXISTS idx_attribution_allocations_tenant_event_projection_channel"
+    )
+    op.execute(
+        "DROP INDEX IF EXISTS idx_attribution_allocations_tenant_event_model_channel"
+    )
+    op.execute(
+        """
+        CREATE UNIQUE INDEX idx_attribution_allocations_tenant_event_model_channel
+        ON attribution_allocations (tenant_id, event_id, model_version, channel_code)
+        WHERE model_version IS NOT NULL
+        """
+    )

--- a/alembic/versions/007_skeldir_foundation/202604171330_b21_p3_projection_sum_validation_alignment.py
+++ b/alembic/versions/007_skeldir_foundation/202604171330_b21_p3_projection_sum_validation_alignment.py
@@ -1,0 +1,360 @@
+"""B2.1-P3 align allocation sum validation with projection identity.
+
+Revision ID: 202604171330
+Revises: 202604171200
+Create Date: 2026-04-17 13:30:00
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "202604171330"
+down_revision: Union[str, None] = "202604171200"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_attribution_allocations_tenant_event_projection
+        ON attribution_allocations (tenant_id, event_id, recompute_job_id)
+        WHERE recompute_job_id IS NOT NULL
+        """
+    )
+    op.execute(
+        """
+        COMMENT ON INDEX idx_attribution_allocations_tenant_event_projection IS
+        'Projection-scoped sum-validation index for deterministic allocations.'
+        """
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION check_allocation_sum_stmt_insert()
+        RETURNS TRIGGER AS $$
+        DECLARE
+            tolerance_cents INTEGER := 1;
+            mismatch RECORD;
+        BEGIN
+            WITH affected AS (
+                SELECT DISTINCT tenant_id, event_id, model_version, recompute_job_id
+                FROM newrows
+                WHERE event_id IS NOT NULL
+            )
+            SELECT
+                a.tenant_id,
+                a.event_id,
+                a.model_version,
+                a.recompute_job_id,
+                s.allocated_sum AS allocated_sum,
+                e.revenue_cents AS event_revenue_cents,
+                ABS(s.allocated_sum - e.revenue_cents) AS drift_cents
+            INTO mismatch
+            FROM affected a
+            JOIN attribution_events e
+              ON e.tenant_id = a.tenant_id
+             AND e.id = a.event_id
+            CROSS JOIN LATERAL (
+                SELECT COALESCE(SUM(aa.allocated_revenue_cents), 0) AS allocated_sum
+                FROM attribution_allocations aa
+                WHERE aa.tenant_id = a.tenant_id
+                  AND aa.event_id = a.event_id
+                  AND (
+                    (a.recompute_job_id IS NOT NULL AND aa.recompute_job_id = a.recompute_job_id)
+                    OR (
+                        a.recompute_job_id IS NULL
+                        AND aa.recompute_job_id IS NULL
+                        AND aa.model_version = a.model_version
+                    )
+                  )
+            ) s
+            WHERE ABS(s.allocated_sum - e.revenue_cents) > tolerance_cents
+            LIMIT 1;
+
+            IF FOUND THEN
+                RAISE EXCEPTION
+                    'Allocation sum mismatch: tenant_id=% event_id=% model_version=% allocated=% expected=% drift=%',
+                    mismatch.tenant_id, mismatch.event_id, mismatch.model_version,
+                    mismatch.allocated_sum, mismatch.event_revenue_cents, mismatch.drift_cents;
+            END IF;
+
+            RETURN NULL;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION check_allocation_sum_stmt_update()
+        RETURNS TRIGGER AS $$
+        DECLARE
+            tolerance_cents INTEGER := 1;
+            mismatch RECORD;
+        BEGIN
+            WITH affected AS (
+                SELECT DISTINCT tenant_id, event_id, model_version, recompute_job_id
+                FROM newrows
+                WHERE event_id IS NOT NULL
+                UNION
+                SELECT DISTINCT tenant_id, event_id, model_version, recompute_job_id
+                FROM oldrows
+                WHERE event_id IS NOT NULL
+            )
+            SELECT
+                a.tenant_id,
+                a.event_id,
+                a.model_version,
+                a.recompute_job_id,
+                s.allocated_sum AS allocated_sum,
+                e.revenue_cents AS event_revenue_cents,
+                ABS(s.allocated_sum - e.revenue_cents) AS drift_cents
+            INTO mismatch
+            FROM affected a
+            JOIN attribution_events e
+              ON e.tenant_id = a.tenant_id
+             AND e.id = a.event_id
+            CROSS JOIN LATERAL (
+                SELECT COALESCE(SUM(aa.allocated_revenue_cents), 0) AS allocated_sum
+                FROM attribution_allocations aa
+                WHERE aa.tenant_id = a.tenant_id
+                  AND aa.event_id = a.event_id
+                  AND (
+                    (a.recompute_job_id IS NOT NULL AND aa.recompute_job_id = a.recompute_job_id)
+                    OR (
+                        a.recompute_job_id IS NULL
+                        AND aa.recompute_job_id IS NULL
+                        AND aa.model_version = a.model_version
+                    )
+                  )
+            ) s
+            WHERE ABS(s.allocated_sum - e.revenue_cents) > tolerance_cents
+            LIMIT 1;
+
+            IF FOUND THEN
+                RAISE EXCEPTION
+                    'Allocation sum mismatch: tenant_id=% event_id=% model_version=% allocated=% expected=% drift=%',
+                    mismatch.tenant_id, mismatch.event_id, mismatch.model_version,
+                    mismatch.allocated_sum, mismatch.event_revenue_cents, mismatch.drift_cents;
+            END IF;
+
+            RETURN NULL;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION check_allocation_sum_stmt_delete()
+        RETURNS TRIGGER AS $$
+        DECLARE
+            tolerance_cents INTEGER := 1;
+            mismatch RECORD;
+        BEGIN
+            WITH affected AS (
+                SELECT DISTINCT tenant_id, event_id, model_version, recompute_job_id
+                FROM oldrows
+                WHERE event_id IS NOT NULL
+            )
+            SELECT
+                a.tenant_id,
+                a.event_id,
+                a.model_version,
+                a.recompute_job_id,
+                s.allocated_sum AS allocated_sum,
+                e.revenue_cents AS event_revenue_cents,
+                ABS(s.allocated_sum - e.revenue_cents) AS drift_cents
+            INTO mismatch
+            FROM affected a
+            JOIN attribution_events e
+              ON e.tenant_id = a.tenant_id
+             AND e.id = a.event_id
+            CROSS JOIN LATERAL (
+                SELECT COALESCE(SUM(aa.allocated_revenue_cents), 0) AS allocated_sum
+                FROM attribution_allocations aa
+                WHERE aa.tenant_id = a.tenant_id
+                  AND aa.event_id = a.event_id
+                  AND (
+                    (a.recompute_job_id IS NOT NULL AND aa.recompute_job_id = a.recompute_job_id)
+                    OR (
+                        a.recompute_job_id IS NULL
+                        AND aa.recompute_job_id IS NULL
+                        AND aa.model_version = a.model_version
+                    )
+                  )
+            ) s
+            WHERE ABS(s.allocated_sum - e.revenue_cents) > tolerance_cents
+            LIMIT 1;
+
+            IF FOUND THEN
+                RAISE EXCEPTION
+                    'Allocation sum mismatch: tenant_id=% event_id=% model_version=% allocated=% expected=% drift=%',
+                    mismatch.tenant_id, mismatch.event_id, mismatch.model_version,
+                    mismatch.allocated_sum, mismatch.event_revenue_cents, mismatch.drift_cents;
+            END IF;
+
+            RETURN NULL;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+
+
+def downgrade() -> None:
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION check_allocation_sum_stmt_insert()
+        RETURNS TRIGGER AS $$
+        DECLARE
+            tolerance_cents INTEGER := 1;
+            mismatch RECORD;
+        BEGIN
+            WITH affected AS (
+                SELECT DISTINCT tenant_id, event_id, model_version
+                FROM newrows
+                WHERE event_id IS NOT NULL
+            )
+            SELECT
+                a.tenant_id,
+                a.event_id,
+                a.model_version,
+                s.allocated_sum AS allocated_sum,
+                e.revenue_cents AS event_revenue_cents,
+                ABS(s.allocated_sum - e.revenue_cents) AS drift_cents
+            INTO mismatch
+            FROM affected a
+            JOIN attribution_events e
+              ON e.tenant_id = a.tenant_id
+             AND e.id = a.event_id
+            CROSS JOIN LATERAL (
+                SELECT COALESCE(SUM(aa.allocated_revenue_cents), 0) AS allocated_sum
+                FROM attribution_allocations aa
+                WHERE aa.tenant_id = a.tenant_id
+                  AND aa.event_id = a.event_id
+                  AND aa.model_version = a.model_version
+            ) s
+            WHERE ABS(s.allocated_sum - e.revenue_cents) > tolerance_cents
+            LIMIT 1;
+
+            IF FOUND THEN
+                RAISE EXCEPTION
+                    'Allocation sum mismatch: tenant_id=% event_id=% model_version=% allocated=% expected=% drift=%',
+                    mismatch.tenant_id, mismatch.event_id, mismatch.model_version,
+                    mismatch.allocated_sum, mismatch.event_revenue_cents, mismatch.drift_cents;
+            END IF;
+
+            RETURN NULL;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION check_allocation_sum_stmt_update()
+        RETURNS TRIGGER AS $$
+        DECLARE
+            tolerance_cents INTEGER := 1;
+            mismatch RECORD;
+        BEGIN
+            WITH affected AS (
+                SELECT DISTINCT tenant_id, event_id, model_version
+                FROM newrows
+                WHERE event_id IS NOT NULL
+                UNION
+                SELECT DISTINCT tenant_id, event_id, model_version
+                FROM oldrows
+                WHERE event_id IS NOT NULL
+            )
+            SELECT
+                a.tenant_id,
+                a.event_id,
+                a.model_version,
+                s.allocated_sum AS allocated_sum,
+                e.revenue_cents AS event_revenue_cents,
+                ABS(s.allocated_sum - e.revenue_cents) AS drift_cents
+            INTO mismatch
+            FROM affected a
+            JOIN attribution_events e
+              ON e.tenant_id = a.tenant_id
+             AND e.id = a.event_id
+            CROSS JOIN LATERAL (
+                SELECT COALESCE(SUM(aa.allocated_revenue_cents), 0) AS allocated_sum
+                FROM attribution_allocations aa
+                WHERE aa.tenant_id = a.tenant_id
+                  AND aa.event_id = a.event_id
+                  AND aa.model_version = a.model_version
+            ) s
+            WHERE ABS(s.allocated_sum - e.revenue_cents) > tolerance_cents
+            LIMIT 1;
+
+            IF FOUND THEN
+                RAISE EXCEPTION
+                    'Allocation sum mismatch: tenant_id=% event_id=% model_version=% allocated=% expected=% drift=%',
+                    mismatch.tenant_id, mismatch.event_id, mismatch.model_version,
+                    mismatch.allocated_sum, mismatch.event_revenue_cents, mismatch.drift_cents;
+            END IF;
+
+            RETURN NULL;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION check_allocation_sum_stmt_delete()
+        RETURNS TRIGGER AS $$
+        DECLARE
+            tolerance_cents INTEGER := 1;
+            mismatch RECORD;
+        BEGIN
+            WITH affected AS (
+                SELECT DISTINCT tenant_id, event_id, model_version
+                FROM oldrows
+                WHERE event_id IS NOT NULL
+            )
+            SELECT
+                a.tenant_id,
+                a.event_id,
+                a.model_version,
+                s.allocated_sum AS allocated_sum,
+                e.revenue_cents AS event_revenue_cents,
+                ABS(s.allocated_sum - e.revenue_cents) AS drift_cents
+            INTO mismatch
+            FROM affected a
+            JOIN attribution_events e
+              ON e.tenant_id = a.tenant_id
+             AND e.id = a.event_id
+            CROSS JOIN LATERAL (
+                SELECT COALESCE(SUM(aa.allocated_revenue_cents), 0) AS allocated_sum
+                FROM attribution_allocations aa
+                WHERE aa.tenant_id = a.tenant_id
+                  AND aa.event_id = a.event_id
+                  AND aa.model_version = a.model_version
+            ) s
+            WHERE ABS(s.allocated_sum - e.revenue_cents) > tolerance_cents
+            LIMIT 1;
+
+            IF FOUND THEN
+                RAISE EXCEPTION
+                    'Allocation sum mismatch: tenant_id=% event_id=% model_version=% allocated=% expected=% drift=%',
+                    mismatch.tenant_id, mismatch.event_id, mismatch.model_version,
+                    mismatch.allocated_sum, mismatch.event_revenue_cents, mismatch.drift_cents;
+            END IF;
+
+            RETURN NULL;
+        END;
+        $$ LANGUAGE plpgsql;
+        """
+    )
+
+    op.execute(
+        "DROP INDEX IF EXISTS idx_attribution_allocations_tenant_event_projection"
+    )  # CI:DESTRUCTIVE_OK - rollback path for projection-aware sum-validation index.

--- a/api-contracts/dist/openapi/v1/attribution.bundled.yaml
+++ b/api-contracts/dist/openapi/v1/attribution.bundled.yaml
@@ -527,6 +527,28 @@ paths:
                 description: RFC7807 Problem Details for HTTP APIs with Skeldir extensions
                 required: *ref_0
                 properties: *ref_1
+        '422':
+          description: Projection window exceeds maximum supported range
+          headers:
+            X-Correlation-ID:
+              schema:
+                type: string
+                format: uuid
+          content:
+            application/problem+json:
+              schema:
+                type: object
+                description: RFC7807 Problem Details for HTTP APIs with Skeldir extensions
+                required: *ref_0
+                properties: *ref_1
+              example:
+                type: https://api.skeldir.com/problems/attribution-window-out-of-range
+                title: Projection Window Too Large
+                status: 422
+                detail: Requested projection window exceeds 31 days; read is fail-closed.
+                correlation_id: 11111111-1111-1111-1111-111111111111
+                timestamp: '2026-04-17T12:00:00Z'
+                code: ATTRIBUTION_WINDOW_OUT_OF_RANGE
       x-skeldir-b21-p0:
         implementation_status: mounted_deterministic_channels_surface
         authority_requirements:

--- a/api-contracts/openapi/v1/attribution.yaml
+++ b/api-contracts/openapi/v1/attribution.yaml
@@ -196,6 +196,25 @@ paths:
           $ref: './_common/base.yaml#/components/responses/NotFoundError'
         '409':
           $ref: './_common/base.yaml#/components/responses/ValidationError'
+        '422':
+          description: Projection window exceeds maximum supported range
+          headers:
+            X-Correlation-ID:
+              schema:
+                type: string
+                format: uuid
+          content:
+            application/problem+json:
+              schema:
+                $ref: './_common/base.yaml#/components/schemas/ProblemDetails'
+              example:
+                type: https://api.skeldir.com/problems/attribution-window-out-of-range
+                title: Projection Window Too Large
+                status: 422
+                detail: Requested projection window exceeds 31 days; read is fail-closed.
+                correlation_id: 11111111-1111-1111-1111-111111111111
+                timestamp: '2026-04-17T12:00:00Z'
+                code: ATTRIBUTION_WINDOW_OUT_OF_RANGE
       x-skeldir-b21-p0:
         implementation_status: mounted_deterministic_channels_surface
         authority_requirements:

--- a/backend/app/attribution/semantics.py
+++ b/backend/app/attribution/semantics.py
@@ -200,6 +200,8 @@ class DeterministicReplayIdentity:
             f"taxonomy={self.taxonomy_version};"
             f"lookback_days={self.lookback_days};"
             f"session_scope={self.session_scope_identity};"
+            f"window_start={self.window_start.astimezone(timezone.utc).isoformat()};"
+            f"window_end={self.window_end.astimezone(timezone.utc).isoformat()};"
             f"replay_anchor_at={self.replay_anchor_at.astimezone(timezone.utc).isoformat()}"
         )
         return f"{self.model_version}::{replay_suffix}"

--- a/backend/app/tasks/attribution.py
+++ b/backend/app/tasks/attribution.py
@@ -160,12 +160,13 @@ def _deterministic_allocation_id(
     *,
     tenant_id: UUID,
     event_id: UUID,
+    recompute_job_id: UUID,
     model_version: str,
     channel_code: str,
 ) -> UUID:
     return uuid5(
         _ALLOCATION_ID_NAMESPACE,
-        f"{tenant_id}:{event_id}:{model_version}:{channel_code}",
+        f"{tenant_id}:{event_id}:{recompute_job_id}:{model_version}:{channel_code}",
     )
 
 
@@ -738,7 +739,6 @@ async def _compute_allocations_deterministic_baseline(
                     ORDER BY id ASC
                     ON CONFLICT (id)
                     DO UPDATE SET
-                        recompute_job_id = EXCLUDED.recompute_job_id,
                         allocation_ratio = EXCLUDED.allocation_ratio,
                         model_type = EXCLUDED.model_type,
                         confidence_score = EXCLUDED.confidence_score,
@@ -746,12 +746,14 @@ async def _compute_allocations_deterministic_baseline(
                         allocated_revenue_cents = EXCLUDED.allocated_revenue_cents,
                         updated_at = EXCLUDED.updated_at
                     WHERE
-                        attribution_allocations.recompute_job_id IS DISTINCT FROM EXCLUDED.recompute_job_id
-                        OR attribution_allocations.allocation_ratio IS DISTINCT FROM EXCLUDED.allocation_ratio
-                        OR attribution_allocations.model_type IS DISTINCT FROM EXCLUDED.model_type
-                        OR attribution_allocations.confidence_score IS DISTINCT FROM EXCLUDED.confidence_score
-                        OR attribution_allocations.verified IS DISTINCT FROM EXCLUDED.verified
-                        OR attribution_allocations.allocated_revenue_cents IS DISTINCT FROM EXCLUDED.allocated_revenue_cents;
+                        attribution_allocations.recompute_job_id = EXCLUDED.recompute_job_id
+                        AND (
+                            attribution_allocations.allocation_ratio IS DISTINCT FROM EXCLUDED.allocation_ratio
+                            OR attribution_allocations.model_type IS DISTINCT FROM EXCLUDED.model_type
+                            OR attribution_allocations.confidence_score IS DISTINCT FROM EXCLUDED.confidence_score
+                            OR attribution_allocations.verified IS DISTINCT FROM EXCLUDED.verified
+                            OR attribution_allocations.allocated_revenue_cents IS DISTINCT FROM EXCLUDED.allocated_revenue_cents
+                        );
                     """
                 ),
                 rows,
@@ -946,6 +948,7 @@ async def _compute_allocations_deterministic_baseline(
                     allocation_id = _deterministic_allocation_id(
                         tenant_id=tenant_id,
                         event_id=event_id,
+                        recompute_job_id=recompute_job_id,
                         model_version=model_version,
                         channel_code=channel_code,
                     )
@@ -1207,7 +1210,6 @@ async def _compute_allocations_strategy_kernel(
                     ORDER BY id ASC
                     ON CONFLICT (id)
                     DO UPDATE SET
-                        recompute_job_id = EXCLUDED.recompute_job_id,
                         allocation_ratio = EXCLUDED.allocation_ratio,
                         model_type = EXCLUDED.model_type,
                         confidence_score = EXCLUDED.confidence_score,
@@ -1215,12 +1217,14 @@ async def _compute_allocations_strategy_kernel(
                         allocated_revenue_cents = EXCLUDED.allocated_revenue_cents,
                         updated_at = EXCLUDED.updated_at
                     WHERE
-                        attribution_allocations.recompute_job_id IS DISTINCT FROM EXCLUDED.recompute_job_id
-                        OR attribution_allocations.allocation_ratio IS DISTINCT FROM EXCLUDED.allocation_ratio
-                        OR attribution_allocations.model_type IS DISTINCT FROM EXCLUDED.model_type
-                        OR attribution_allocations.confidence_score IS DISTINCT FROM EXCLUDED.confidence_score
-                        OR attribution_allocations.verified IS DISTINCT FROM EXCLUDED.verified
-                        OR attribution_allocations.allocated_revenue_cents IS DISTINCT FROM EXCLUDED.allocated_revenue_cents;
+                        attribution_allocations.recompute_job_id = EXCLUDED.recompute_job_id
+                        AND (
+                            attribution_allocations.allocation_ratio IS DISTINCT FROM EXCLUDED.allocation_ratio
+                            OR attribution_allocations.model_type IS DISTINCT FROM EXCLUDED.model_type
+                            OR attribution_allocations.confidence_score IS DISTINCT FROM EXCLUDED.confidence_score
+                            OR attribution_allocations.verified IS DISTINCT FROM EXCLUDED.verified
+                            OR attribution_allocations.allocated_revenue_cents IS DISTINCT FROM EXCLUDED.allocated_revenue_cents
+                        );
                     """
                 ),
                 rows,
@@ -1271,6 +1275,7 @@ async def _compute_allocations_strategy_kernel(
                     allocation_id = _deterministic_allocation_id(
                         tenant_id=tenant_id,
                         event_id=conversion.conversion_event.event_id,
+                        recompute_job_id=recompute_job_id,
                         model_version=model_version,
                         channel_code=channel_allocation.channel_code,
                     )
@@ -1544,7 +1549,7 @@ def recompute_window(
                 window_start=window_start_dt,
                 window_end=window_end_dt,
                 recompute_job_id=job_id,
-                model_version=model_version,
+                model_version=job_model_version,
                 replay_identity=replay_identity,
                 session_id=str(session_scope) if session_scope else None,
             )
@@ -1555,7 +1560,7 @@ def recompute_window(
                 window_start=window_start_dt,
                 window_end=window_end_dt,
                 recompute_job_id=job_id,
-                model_version=model_version,
+                model_version=job_model_version,
                 model_type=canonical_model_type,
                 replay_identity=replay_identity,
                 session_id=str(session_scope) if session_scope else None,

--- a/backend/app/tasks/attribution.py
+++ b/backend/app/tasks/attribution.py
@@ -1549,7 +1549,7 @@ def recompute_window(
                 window_start=window_start_dt,
                 window_end=window_end_dt,
                 recompute_job_id=job_id,
-                model_version=job_model_version,
+                model_version=model_version,
                 replay_identity=replay_identity,
                 session_id=str(session_scope) if session_scope else None,
             )
@@ -1560,7 +1560,7 @@ def recompute_window(
                 window_start=window_start_dt,
                 window_end=window_end_dt,
                 recompute_job_id=job_id,
-                model_version=job_model_version,
+                model_version=model_version,
                 model_type=canonical_model_type,
                 replay_identity=replay_identity,
                 session_id=str(session_scope) if session_scope else None,

--- a/backend/tests/integration/test_b21_p3_persistence_read_surface_runtime.py
+++ b/backend/tests/integration/test_b21_p3_persistence_read_surface_runtime.py
@@ -14,6 +14,9 @@ from app.core.db import engine
 from app.db.session import set_tenant_guc
 from app.main import app
 from app.security.auth import AuthContext, get_auth_context
+from app.tasks.attribution import recompute_window
+from app.tasks.authority import SystemAuthorityEnvelope
+from app.tasks.enqueue import enqueue_tenant_task
 from tests.conftest import _insert_tenant
 
 
@@ -348,6 +351,110 @@ async def _job_run_count(*, tenant_id: UUID, recompute_job_id: UUID) -> int:
         return int(value or 0)
 
 
+def _enqueue_recompute_window(
+    *,
+    tenant_id: UUID,
+    window_start: datetime,
+    window_end: datetime,
+    model_version: str,
+) -> dict:
+    return enqueue_tenant_task(
+        recompute_window,
+        envelope=SystemAuthorityEnvelope(tenant_id=tenant_id),
+        kwargs={
+            "window_start": window_start.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "window_end": window_end.astimezone(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "model_version": model_version,
+            "model_type": "deterministic_baseline",
+        },
+    ).get()
+
+
+async def _seed_conversion_event(
+    *,
+    tenant_id: UUID,
+    session_id: UUID,
+    occurred_at: datetime,
+    revenue_cents: int,
+) -> UUID:
+    event_id = uuid4()
+    idempotency_key = f"b21-p3-own-{tenant_id.hex[:8]}-{event_id.hex[:12]}"
+    async with engine.begin() as conn:
+        await set_tenant_guc(conn, tenant_id, local=True)
+        # RAW_SQL_ALLOWLIST: deterministic integration fixture seed for projection ownership stability proof.
+        await conn.execute(
+            text(
+                """
+                INSERT INTO attribution_events (
+                    id,
+                    tenant_id,
+                    occurred_at,
+                    external_event_id,
+                    correlation_id,
+                    session_id,
+                    revenue_cents,
+                    raw_payload,
+                    idempotency_key,
+                    event_type,
+                    channel,
+                    campaign_id,
+                    conversion_value_cents,
+                    currency,
+                    event_timestamp,
+                    processed_at,
+                    processing_status,
+                    retry_count,
+                    created_at,
+                    updated_at
+                ) VALUES (
+                    :id,
+                    :tenant_id,
+                    :occurred_at,
+                    :external_event_id,
+                    :correlation_id,
+                    :session_id,
+                    :revenue_cents,
+                    CAST(:raw_payload AS jsonb),
+                    :idempotency_key,
+                    'purchase',
+                    'direct',
+                    'cmp-b21-p3-ownership',
+                    :conversion_value_cents,
+                    'USD',
+                    :event_timestamp,
+                    :processed_at,
+                    'processed',
+                    0,
+                    :created_at,
+                    :updated_at
+                )
+                ON CONFLICT (tenant_id, idempotency_key) DO NOTHING
+                """
+            ),
+            {
+                "id": str(event_id),
+                "tenant_id": str(tenant_id),
+                "occurred_at": occurred_at,
+                "external_event_id": f"evt-{event_id.hex[:12]}",
+                "correlation_id": str(uuid4()),
+                "session_id": str(session_id),
+                "revenue_cents": int(revenue_cents),
+                "raw_payload": (
+                    '{"global_idempotency_hash":"'
+                    + f"{event_id.hex:0<64}"[:64]
+                    + '"}'
+                ),
+                "idempotency_key": idempotency_key,
+                "conversion_value_cents": int(revenue_cents),
+                "event_timestamp": occurred_at,
+                "processed_at": occurred_at + timedelta(minutes=1),
+                "created_at": occurred_at,
+                "updated_at": occurred_at,
+            },
+        )
+    return event_id
+
+
 @pytest.mark.asyncio
 async def test_b21_p3_channels_endpoint_reads_projection_without_recompute_and_preserves_decimal_strings() -> None:
     await _ensure_runtime_tables()
@@ -577,3 +684,119 @@ async def test_b21_p3_projection_window_bound_exceeds_limit_fails_closed() -> No
     assert response.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY
     body = response.json()
     assert body["code"] == "ATTRIBUTION_WINDOW_OUT_OF_RANGE"
+
+
+@pytest.mark.asyncio
+async def test_b21_p3_sequential_recompute_preserves_projection_row_ownership() -> None:
+    await _ensure_runtime_tables()
+    await _ensure_channel_codes(["direct", "email", "google_search_paid"])
+
+    from app.celery_app import celery_app
+
+    original_eager = celery_app.conf.task_always_eager
+    celery_app.conf.task_always_eager = True
+
+    tenant_id = uuid4()
+    user_id = uuid4()
+    session_id = uuid4()
+    model_version = "1.0.0"
+    authority_now = datetime.now(timezone.utc).replace(microsecond=0)
+    window_end = authority_now
+    window_start_a = window_end - timedelta(hours=2)
+    window_start_b = window_end - timedelta(hours=1)
+    occurred_at = window_end - timedelta(minutes=40)
+
+    try:
+        async with engine.begin() as conn:
+            await _insert_tenant(conn, tenant_id, api_key_hash=f"test_hash_{tenant_id}")
+
+        await _seed_session_authority(
+            tenant_id=tenant_id,
+            session_id=session_id,
+            issued_at=authority_now - timedelta(minutes=5),
+            expires_at=authority_now + timedelta(hours=1),
+        )
+        event_id = await _seed_conversion_event(
+            tenant_id=tenant_id,
+            session_id=session_id,
+            occurred_at=occurred_at,
+            revenue_cents=300,
+        )
+
+        result_a = _enqueue_recompute_window(
+            tenant_id=tenant_id,
+            window_start=window_start_a,
+            window_end=window_end,
+            model_version=model_version,
+        )
+        result_b = _enqueue_recompute_window(
+            tenant_id=tenant_id,
+            window_start=window_start_b,
+            window_end=window_end,
+            model_version=model_version,
+        )
+
+        job_a = UUID(str(result_a["job_id"]))
+        job_b = UUID(str(result_b["job_id"]))
+        assert job_a != job_b
+
+        async with engine.begin() as conn:
+            await set_tenant_guc(conn, tenant_id, local=True)
+            rows = (
+                await conn.execute(
+                    text(
+                        """
+                        SELECT
+                            recompute_job_id::text AS recompute_job_id,
+                            COUNT(*)::bigint AS row_count,
+                            COALESCE(SUM(allocated_revenue_cents), 0)::bigint AS total_cents
+                        FROM attribution_allocations
+                        WHERE tenant_id = :tenant_id
+                          AND event_id = :event_id
+                          AND recompute_job_id IN (:job_a, :job_b)
+                        GROUP BY recompute_job_id
+                        ORDER BY recompute_job_id
+                        """
+                    ),
+                    {
+                        "tenant_id": str(tenant_id),
+                        "event_id": str(event_id),
+                        "job_a": str(job_a),
+                        "job_b": str(job_b),
+                    },
+                )
+            ).mappings().all()
+
+        by_job = {row["recompute_job_id"]: row for row in rows}
+        assert str(job_a) in by_job, "projection A rows were stolen or lost after projection B write"
+        assert str(job_b) in by_job
+        assert int(by_job[str(job_a)]["row_count"]) == 3
+        assert int(by_job[str(job_b)]["row_count"]) == 3
+        assert int(by_job[str(job_a)]["total_cents"]) == 300
+        assert int(by_job[str(job_b)]["total_cents"]) == 300
+
+        async def _auth_override() -> AuthContext:
+            return _auth_context(tenant_id=tenant_id, user_id=user_id)
+
+        app.dependency_overrides[get_auth_context] = _auth_override
+        try:
+            transport = ASGITransport(app=app)
+            async with AsyncClient(transport=transport, base_url="http://test") as client:
+                for job_id in (job_a, job_b):
+                    response = await client.get(
+                        "/api/attribution/channels",
+                        params={
+                            "model_type": "deterministic_baseline",
+                            "recompute_job_id": str(job_id),
+                        },
+                        headers={"X-Correlation-ID": str(uuid4())},
+                    )
+                    assert response.status_code == status.HTTP_200_OK, response.text
+                    payload = response.json()
+                    assert payload["projection"]["recompute_job_id"] == str(job_id)
+                    assert payload["total_revenue_cents"] == 300
+                    assert len(payload["channels"]) == 3
+        finally:
+            app.dependency_overrides.pop(get_auth_context, None)
+    finally:
+        celery_app.conf.task_always_eager = original_eager

--- a/backend/tests/test_b21_p1_attribution_semantics.py
+++ b/backend/tests/test_b21_p1_attribution_semantics.py
@@ -62,3 +62,5 @@ def test_b21_p1_job_model_version_encodes_replay_identity_dimensions() -> None:
     assert "taxonomy=b2.1-p1-v1" in token
     assert "lookback_days=30" in token
     assert "session_scope=__all__" in token
+    assert "window_start=2025-01-01T00:00:00+00:00" in token
+    assert "window_end=2025-01-02T00:00:00+00:00" in token

--- a/backend/tests/test_b21_p3_persistence_read_surface_lock_enforcer.py
+++ b/backend/tests/test_b21_p3_persistence_read_surface_lock_enforcer.py
@@ -13,6 +13,7 @@ TASK_FILE = REPO_ROOT / "backend" / "app" / "tasks" / "attribution.py"
 API_FILE = REPO_ROOT / "backend" / "app" / "api" / "attribution.py"
 SCHEMA_FILE = REPO_ROOT / "backend" / "app" / "schemas" / "attribution.py"
 CONTRACT_FILE = REPO_ROOT / "api-contracts" / "openapi" / "v1" / "attribution.yaml"
+FRONTEND_TYPES_FILE = REPO_ROOT / "frontend" / "src" / "types" / "api" / "attribution.ts"
 RUNTIME_FILE = REPO_ROOT / "backend" / "tests" / "integration" / "test_b21_p3_persistence_read_surface_runtime.py"
 WORKFLOW_FILE = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 REQUIRED_CHECKS_FILE = REPO_ROOT / "contracts-internal" / "governance" / "b03_phase2_required_status_checks.main.json"
@@ -25,6 +26,7 @@ def test_b21_p3_persistence_read_surface_lock_enforcer_passes_repo_state() -> No
         api_file=API_FILE,
         schema_file=SCHEMA_FILE,
         contract_file=CONTRACT_FILE,
+        frontend_types_file=FRONTEND_TYPES_FILE,
         runtime_proof_file=RUNTIME_FILE,
         workflow_file=WORKFLOW_FILE,
         required_checks_file=REQUIRED_CHECKS_FILE,
@@ -100,6 +102,63 @@ def test_b21_p3_persistence_read_surface_lock_enforcer_negative_control_missing_
     assert proc.returncode != 0
     combined = f"{proc.stdout}\n{proc.stderr}"
     assert "contract_missing_required_query_param:model_type" in combined
+
+
+def test_b21_p3_persistence_read_surface_lock_enforcer_negative_control_missing_contract_422_response(
+    tmp_path: Path,
+) -> None:
+    contract_regression = tmp_path / "attribution_contract_422.regression.yaml"
+    contract_regression.write_text(
+        CONTRACT_FILE.read_text(encoding="utf-8").replace(
+            "'422':",
+            "'422_removed':",
+            1,
+        ),
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(ENFORCER),
+            "--contract-file",
+            str(contract_regression),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode != 0
+    combined = f"{proc.stdout}\n{proc.stderr}"
+    assert "contract_missing_channels_422_response" in combined
+
+
+def test_b21_p3_persistence_read_surface_lock_enforcer_negative_control_projection_reassignment_on_conflict(
+    tmp_path: Path,
+) -> None:
+    task_regression = tmp_path / "attribution_task.regression.py"
+    task_regression.write_text(
+        TASK_FILE.read_text(encoding="utf-8").replace(
+            "attribution_allocations.recompute_job_id = EXCLUDED.recompute_job_id",
+            "TRUE",
+        ),
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(ENFORCER),
+            "--task-file",
+            str(task_regression),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode != 0
+    combined = f"{proc.stdout}\n{proc.stderr}"
+    assert "task_missing_token:attribution_allocations.recompute_job_id = EXCLUDED.recompute_job_id" in combined
 
 
 def test_b21_p3_persistence_read_surface_lock_enforcer_negative_control_missing_workflow_hook(

--- a/backend/tests/test_b21_p3_persistence_read_surface_lock_enforcer.py
+++ b/backend/tests/test_b21_p3_persistence_read_surface_lock_enforcer.py
@@ -15,6 +15,14 @@ SCHEMA_FILE = REPO_ROOT / "backend" / "app" / "schemas" / "attribution.py"
 CONTRACT_FILE = REPO_ROOT / "api-contracts" / "openapi" / "v1" / "attribution.yaml"
 FRONTEND_TYPES_FILE = REPO_ROOT / "frontend" / "src" / "types" / "api" / "attribution.ts"
 RUNTIME_FILE = REPO_ROOT / "backend" / "tests" / "integration" / "test_b21_p3_persistence_read_surface_runtime.py"
+CANONICAL_SCHEMA_FILE = REPO_ROOT / "db" / "schema" / "canonical_schema.sql"
+TRIGGER_ALIGNMENT_MIGRATION_FILE = (
+    REPO_ROOT
+    / "alembic"
+    / "versions"
+    / "007_skeldir_foundation"
+    / "202604171330_b21_p3_projection_sum_validation_alignment.py"
+)
 WORKFLOW_FILE = REPO_ROOT / ".github" / "workflows" / "ci.yml"
 REQUIRED_CHECKS_FILE = REPO_ROOT / "contracts-internal" / "governance" / "b03_phase2_required_status_checks.main.json"
 
@@ -28,6 +36,8 @@ def test_b21_p3_persistence_read_surface_lock_enforcer_passes_repo_state() -> No
         contract_file=CONTRACT_FILE,
         frontend_types_file=FRONTEND_TYPES_FILE,
         runtime_proof_file=RUNTIME_FILE,
+        canonical_schema_file=CANONICAL_SCHEMA_FILE,
+        trigger_alignment_migration_file=TRIGGER_ALIGNMENT_MIGRATION_FILE,
         workflow_file=WORKFLOW_FILE,
         required_checks_file=REQUIRED_CHECKS_FILE,
     )
@@ -187,3 +197,32 @@ def test_b21_p3_persistence_read_surface_lock_enforcer_negative_control_missing_
     assert proc.returncode != 0
     combined = f"{proc.stdout}\n{proc.stderr}"
     assert "workflow_missing_token:Enforce B2.1-P3 persistence read-surface lock" in combined
+
+
+def test_b21_p3_persistence_read_surface_lock_enforcer_negative_control_missing_projection_sum_scope(
+    tmp_path: Path,
+) -> None:
+    schema_regression = tmp_path / "canonical_schema.regression.sql"
+    schema_regression.write_text(
+        CANONICAL_SCHEMA_FILE.read_text(encoding="utf-8").replace(
+            "a.recompute_job_id IS NOT NULL AND aa.recompute_job_id = a.recompute_job_id",
+            "a.recompute_job_id IS NOT NULL",
+            1,
+        ),
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(ENFORCER),
+            "--canonical-schema-file",
+            str(schema_regression),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode != 0
+    combined = f"{proc.stdout}\n{proc.stderr}"
+    assert "canonical_schema_projection_scope_count_lt_3:2" in combined

--- a/db/schema/canonical_schema.sql
+++ b/db/schema/canonical_schema.sql
@@ -3043,7 +3043,14 @@ CREATE INDEX idx_attribution_allocations_tenant_event_model ON public.attributio
 -- Name: idx_attribution_allocations_tenant_event_model_channel; Type: INDEX; Schema: public; Owner: -
 --
 
-CREATE UNIQUE INDEX idx_attribution_allocations_tenant_event_model_channel ON public.attribution_allocations USING btree (tenant_id, event_id, model_version, channel_code) WHERE (model_version IS NOT NULL);
+CREATE UNIQUE INDEX idx_attribution_allocations_tenant_event_model_channel ON public.attribution_allocations USING btree (tenant_id, event_id, model_version, channel_code) WHERE ((model_version IS NOT NULL) AND (recompute_job_id IS NULL));
+
+
+--
+-- Name: idx_attribution_allocations_tenant_event_projection_channel; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX idx_attribution_allocations_tenant_event_projection_channel ON public.attribution_allocations USING btree (tenant_id, event_id, recompute_job_id, channel_code) WHERE (recompute_job_id IS NOT NULL);
 
 
 --

--- a/db/schema/canonical_schema.sql
+++ b/db/schema/canonical_schema.sql
@@ -3069,19 +3069,18 @@ CREATE INDEX idx_attribution_allocations_tenant_event_model ON public.attributio
 
 CREATE UNIQUE INDEX idx_attribution_allocations_tenant_event_model_channel ON public.attribution_allocations USING btree (tenant_id, event_id, model_version, channel_code) WHERE ((model_version IS NOT NULL) AND (recompute_job_id IS NULL));
 
+--
+-- Name: idx_attribution_allocations_tenant_event_projection; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_attribution_allocations_tenant_event_projection ON public.attribution_allocations USING btree (tenant_id, event_id, recompute_job_id) WHERE (recompute_job_id IS NOT NULL);
+
 
 --
 -- Name: idx_attribution_allocations_tenant_event_projection_channel; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE UNIQUE INDEX idx_attribution_allocations_tenant_event_projection_channel ON public.attribution_allocations USING btree (tenant_id, event_id, recompute_job_id, channel_code) WHERE (recompute_job_id IS NOT NULL);
-
-
---
--- Name: idx_attribution_allocations_tenant_event_projection; Type: INDEX; Schema: public; Owner: -
---
-
-CREATE INDEX idx_attribution_allocations_tenant_event_projection ON public.attribution_allocations USING btree (tenant_id, event_id, recompute_job_id) WHERE (recompute_job_id IS NOT NULL);
 
 
 --

--- a/db/schema/canonical_schema.sql
+++ b/db/schema/canonical_schema.sql
@@ -119,7 +119,7 @@ CREATE FUNCTION public.check_allocation_sum_stmt_delete() RETURNS trigger
             mismatch RECORD;
         BEGIN
             WITH affected AS (
-                SELECT DISTINCT tenant_id, event_id, model_version
+                SELECT DISTINCT tenant_id, event_id, model_version, recompute_job_id
                 FROM oldrows
                 WHERE event_id IS NOT NULL
             )
@@ -127,6 +127,7 @@ CREATE FUNCTION public.check_allocation_sum_stmt_delete() RETURNS trigger
                 a.tenant_id,
                 a.event_id,
                 a.model_version,
+                a.recompute_job_id,
                 s.allocated_sum AS allocated_sum,
                 e.revenue_cents AS event_revenue_cents,
                 ABS(s.allocated_sum - e.revenue_cents) AS drift_cents
@@ -140,7 +141,14 @@ CREATE FUNCTION public.check_allocation_sum_stmt_delete() RETURNS trigger
                 FROM attribution_allocations aa
                 WHERE aa.tenant_id = a.tenant_id
                   AND aa.event_id = a.event_id
-                  AND aa.model_version = a.model_version
+                  AND (
+                    (a.recompute_job_id IS NOT NULL AND aa.recompute_job_id = a.recompute_job_id)
+                    OR (
+                        a.recompute_job_id IS NULL
+                        AND aa.recompute_job_id IS NULL
+                        AND aa.model_version = a.model_version
+                    )
+                  )
             ) s
             WHERE ABS(s.allocated_sum - e.revenue_cents) > tolerance_cents
             LIMIT 1;
@@ -169,7 +177,7 @@ CREATE FUNCTION public.check_allocation_sum_stmt_insert() RETURNS trigger
             mismatch RECORD;
         BEGIN
             WITH affected AS (
-                SELECT DISTINCT tenant_id, event_id, model_version
+                SELECT DISTINCT tenant_id, event_id, model_version, recompute_job_id
                 FROM newrows
                 WHERE event_id IS NOT NULL
             )
@@ -177,6 +185,7 @@ CREATE FUNCTION public.check_allocation_sum_stmt_insert() RETURNS trigger
                 a.tenant_id,
                 a.event_id,
                 a.model_version,
+                a.recompute_job_id,
                 s.allocated_sum AS allocated_sum,
                 e.revenue_cents AS event_revenue_cents,
                 ABS(s.allocated_sum - e.revenue_cents) AS drift_cents
@@ -190,7 +199,14 @@ CREATE FUNCTION public.check_allocation_sum_stmt_insert() RETURNS trigger
                 FROM attribution_allocations aa
                 WHERE aa.tenant_id = a.tenant_id
                   AND aa.event_id = a.event_id
-                  AND aa.model_version = a.model_version
+                  AND (
+                    (a.recompute_job_id IS NOT NULL AND aa.recompute_job_id = a.recompute_job_id)
+                    OR (
+                        a.recompute_job_id IS NULL
+                        AND aa.recompute_job_id IS NULL
+                        AND aa.model_version = a.model_version
+                    )
+                  )
             ) s
             WHERE ABS(s.allocated_sum - e.revenue_cents) > tolerance_cents
             LIMIT 1;
@@ -219,11 +235,11 @@ CREATE FUNCTION public.check_allocation_sum_stmt_update() RETURNS trigger
             mismatch RECORD;
         BEGIN
             WITH affected AS (
-                SELECT DISTINCT tenant_id, event_id, model_version
+                SELECT DISTINCT tenant_id, event_id, model_version, recompute_job_id
                 FROM newrows
                 WHERE event_id IS NOT NULL
                 UNION
-                SELECT DISTINCT tenant_id, event_id, model_version
+                SELECT DISTINCT tenant_id, event_id, model_version, recompute_job_id
                 FROM oldrows
                 WHERE event_id IS NOT NULL
             )
@@ -231,6 +247,7 @@ CREATE FUNCTION public.check_allocation_sum_stmt_update() RETURNS trigger
                 a.tenant_id,
                 a.event_id,
                 a.model_version,
+                a.recompute_job_id,
                 s.allocated_sum AS allocated_sum,
                 e.revenue_cents AS event_revenue_cents,
                 ABS(s.allocated_sum - e.revenue_cents) AS drift_cents
@@ -244,7 +261,14 @@ CREATE FUNCTION public.check_allocation_sum_stmt_update() RETURNS trigger
                 FROM attribution_allocations aa
                 WHERE aa.tenant_id = a.tenant_id
                   AND aa.event_id = a.event_id
-                  AND aa.model_version = a.model_version
+                  AND (
+                    (a.recompute_job_id IS NOT NULL AND aa.recompute_job_id = a.recompute_job_id)
+                    OR (
+                        a.recompute_job_id IS NULL
+                        AND aa.recompute_job_id IS NULL
+                        AND aa.model_version = a.model_version
+                    )
+                  )
             ) s
             WHERE ABS(s.allocated_sum - e.revenue_cents) > tolerance_cents
             LIMIT 1;
@@ -3051,6 +3075,13 @@ CREATE UNIQUE INDEX idx_attribution_allocations_tenant_event_model_channel ON pu
 --
 
 CREATE UNIQUE INDEX idx_attribution_allocations_tenant_event_projection_channel ON public.attribution_allocations USING btree (tenant_id, event_id, recompute_job_id, channel_code) WHERE (recompute_job_id IS NOT NULL);
+
+
+--
+-- Name: idx_attribution_allocations_tenant_event_projection; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_attribution_allocations_tenant_event_projection ON public.attribution_allocations USING btree (tenant_id, event_id, recompute_job_id) WHERE (recompute_job_id IS NOT NULL);
 
 
 --

--- a/db/schema/canonical_schema.yaml
+++ b/db/schema/canonical_schema.yaml
@@ -387,6 +387,10 @@ tables:
       - name: idx_attribution_allocations_tenant_event_model_channel
         columns: [tenant_id, event_id, model_version, channel_code]
         unique: true
+
+      - name: idx_attribution_allocations_tenant_event_projection_channel
+        columns: [tenant_id, event_id, recompute_job_id, channel_code]
+        unique: true
         
       - name: idx_attribution_allocations_tenant_model_version
         columns: [tenant_id, model_version]

--- a/db/schema/canonical_schema.yaml
+++ b/db/schema/canonical_schema.yaml
@@ -258,6 +258,12 @@ tables:
         nullable: true
         foreign_key: "attribution_events(id) ON DELETE SET NULL"
         invariant: null
+
+      recompute_job_id:
+        type: UUID
+        nullable: true
+        foreign_key: "attribution_recompute_jobs(id) ON DELETE CASCADE"
+        invariant: analytics_important
         
       created_at:
         type: TIMESTAMPTZ
@@ -387,10 +393,17 @@ tables:
       - name: idx_attribution_allocations_tenant_event_model_channel
         columns: [tenant_id, event_id, model_version, channel_code]
         unique: true
+        where: "model_version IS NOT NULL AND recompute_job_id IS NULL"
 
       - name: idx_attribution_allocations_tenant_event_projection_channel
         columns: [tenant_id, event_id, recompute_job_id, channel_code]
         unique: true
+        where: "recompute_job_id IS NOT NULL"
+
+      - name: idx_attribution_allocations_tenant_event_projection
+        columns: [tenant_id, event_id, recompute_job_id]
+        unique: false
+        where: "recompute_job_id IS NOT NULL"
         
       - name: idx_attribution_allocations_tenant_model_version
         columns: [tenant_id, model_version]

--- a/docs/forensics/B2.1-P3 Remediation Evidence Pack.md
+++ b/docs/forensics/B2.1-P3 Remediation Evidence Pack.md
@@ -35,7 +35,7 @@ Out-of-scope surfaces were intentionally not reopened (`/compare`, `/export`, Ba
 
 ## 3. Remediations Implemented
 
-### R01 — Projection-scoped allocation identity
+### R01 - Projection-scoped allocation identity
 
 Files:
 - `backend/app/tasks/attribution.py`
@@ -46,7 +46,7 @@ Changes:
   - `{tenant_id}:{event_id}:{recompute_job_id}:{model_version}:{channel_code}`
 - Both baseline and strategy call sites pass `recompute_job_id`.
 
-### R02 — Upsert conflict semantics hardened against projection theft
+### R02 - Upsert conflict semantics hardened against projection theft
 
 Files:
 - `backend/app/tasks/attribution.py`
@@ -57,7 +57,7 @@ Changes:
   - `attribution_allocations.recompute_job_id = EXCLUDED.recompute_job_id`
 - Result: conflict updates are idempotent only within the same projection identity.
 
-### R03 — Job model version aligned to projection window identity
+### R03 - Job model version aligned to projection window identity
 
 Files:
 - `backend/app/attribution/semantics.py`
@@ -66,10 +66,11 @@ Files:
 
 Changes:
 - `job_model_version()` now encodes `window_start` and `window_end`.
-- `recompute_window` passes `job_model_version` into allocation writers (baseline + strategy).
+- `recompute_window` retains canonical base `model_version` in allocation rows to preserve upstream runtime-query compatibility and prior-phase contract semantics.
+- Projection isolation remains enforced by `recompute_job_id`-scoped allocation ids plus upsert projection guards.
 - P1 replay-identity semantics test extended to assert window tokens.
 
-### R04 — Authoritative channels 422 contract parity
+### R04 - Authoritative channels 422 contract parity
 
 Files:
 - `api-contracts/openapi/v1/attribution.yaml`
@@ -82,7 +83,7 @@ Changes:
 - Rebundled canonical contract artifacts.
 - Regenerated frontend API types from canonical bundled contract; `getChannelAttribution` now includes typed 422 response.
 
-### R05 — Runtime + contract + generated convergence proofs strengthened
+### R05 - Runtime + contract + generated convergence proofs strengthened
 
 Files:
 - `tests/contract/test_route_fidelity.py`
@@ -94,7 +95,7 @@ Changes:
   - `test_b21_p3_sequential_recompute_preserves_projection_row_ownership`
 - Test proves projection A remains readable after projection B run; both projection IDs return truthful channels data.
 
-### R06 — Governance lock hardened and made non-vacuous for residual defects
+### R06 - Governance lock hardened and made non-vacuous for residual defects
 
 Files:
 - `scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py`

--- a/docs/forensics/B2.1-P3 Remediation Evidence Pack.md
+++ b/docs/forensics/B2.1-P3 Remediation Evidence Pack.md
@@ -32,6 +32,7 @@ Out-of-scope surfaces were intentionally not reopened (`/compare`, `/export`, Ba
 
 5. Governance gaps remained for these exact residuals.
 - Existing lock/enforcer coverage did not conclusively fail on projection reassignment regression or missing channels 422 contract parity.
+- Existing DB-side sum-equality validation remained model-version scoped and could double-count projection rows after projection identity alignment.
 
 ## 3. Remediations Implemented
 
@@ -116,37 +117,57 @@ Changes:
   - projection reassignment regression,
   - missing route projection guard and other lock regressions.
 
+### R07 - Sum-equality trigger aligned to projection identity
+
+Files:
+- `alembic/versions/007_skeldir_foundation/202604171330_b21_p3_projection_sum_validation_alignment.py`
+- `db/schema/canonical_schema.sql`
+- `db/schema/canonical_schema.yaml`
+- `scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py`
+- `backend/tests/test_b21_p3_persistence_read_surface_lock_enforcer.py`
+
+Changes:
+- Added migration `202604171330` to align statement-level sum-validation functions with projection identity:
+  - when `recompute_job_id IS NOT NULL`, allocation sum checks are scoped to `(tenant_id, event_id, recompute_job_id)`,
+  - legacy behavior for rows with `recompute_job_id IS NULL` remains scoped by `(tenant_id, event_id, model_version)`.
+- Added supporting partial index for projection-scoped validation:
+  - `idx_attribution_allocations_tenant_event_projection` on `(tenant_id, event_id, recompute_job_id)` where `recompute_job_id IS NOT NULL`.
+- Canonical schema artifacts updated to match runtime/migration truth.
+- Enforcer now requires projection-scope trigger tokens across all three statement-level trigger functions, with a dedicated negative control.
+
 ## 4. Falsifiable Validation (Local)
 
 Executed from `C:\Users\ayewhy\II SKELDIR II`.
 
-1. Enforcer pass
+1. P3 lock enforcer pass
 - Command: `python scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py`
 - Result: `PASS`.
 
-2. Enforcer negative controls
+2. P3 lock enforcer negative controls
 - Command: `python -m pytest backend/tests/test_b21_p3_persistence_read_surface_lock_enforcer.py -q`
-- Result: `7 passed`.
+- Result: `8 passed`.
 
-3. Contract compile/type safety gate
-- Command: `npm --prefix frontend run contract:compile`
-- Result: pass.
+3. P1 lock enforcer negative controls
+- Command: `python -m pytest backend/tests/test_b21_p1_semantic_replay_lock_enforcer.py -q`
+- Result: `6 passed`.
 
 4. Route fidelity convergence
 - Command: `python -m pytest tests/contract/test_route_fidelity.py -q`
 - Result: `7 passed`.
 
-5. Contract semantics suite
-- Command: `$env:DATABASE_URL='postgresql+asyncpg://postgres:postgres@localhost:5432/postgres'; python -m pytest tests/contract/test_contract_semantics.py -q`
-- Result: `17 passed, 5 skipped`.
-
-6. Replay identity semantics regression check
-- Command: `python -m pytest backend/tests/test_b21_p1_attribution_semantics.py -q`
+5. P1 runtime proof suite on fresh migrated DB
+- Commands:
+  - `createdb ... skeldir_b21_p1_fix` (fresh DB)
+  - `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/skeldir_b21_p1_fix MIGRATION_DATABASE_URL=... python -m alembic upgrade head`
+  - `DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/skeldir_b21_p1_fix python -m pytest backend/tests/integration/test_b21_p1_semantic_replay_runtime.py -q`
 - Result: `4 passed`.
 
-7. P3 runtime proof suite (local env)
-- Command: `python -m pytest backend/tests/integration/test_b21_p3_persistence_read_surface_runtime.py -q`
-- Result: `4 skipped` in this local environment (runtime DB fixtures not present); proofs are still enforced in CI jobs.
+6. P3 runtime proof suite on fresh migrated DB
+- Commands:
+  - `createdb ... skeldir_b21_p3_fix` (fresh DB)
+  - `DATABASE_URL=postgresql://postgres:postgres@127.0.0.1:5432/skeldir_b21_p3_fix MIGRATION_DATABASE_URL=... python -m alembic upgrade head`
+  - `DATABASE_URL=postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/skeldir_b21_p3_fix python -m pytest backend/tests/integration/test_b21_p3_persistence_read_surface_runtime.py -q`
+- Result: `4 passed`.
 
 ## 5. Exit Gate Adjudication (Corrective Cycle)
 
@@ -169,6 +190,7 @@ Executed from `C:\Users\ayewhy\II SKELDIR II`.
 - `backend/app/attribution/semantics.py`
 - `backend/app/tasks/attribution.py`
 - `alembic/versions/007_skeldir_foundation/202604171200_b21_p3_projection_uniqueness_alignment.py`
+- `alembic/versions/007_skeldir_foundation/202604171330_b21_p3_projection_sum_validation_alignment.py`
 - `backend/tests/integration/test_b21_p3_persistence_read_surface_runtime.py`
 - `backend/tests/test_b21_p1_attribution_semantics.py`
 - `backend/tests/test_b21_p3_persistence_read_surface_lock_enforcer.py`

--- a/docs/forensics/B2.1-P3 Remediation Evidence Pack.md
+++ b/docs/forensics/B2.1-P3 Remediation Evidence Pack.md
@@ -1,327 +1,183 @@
-﻿# B2.1-P3 Remediation Evidence Pack
+# B2.1-P3 Remediation Evidence Pack
 
-Generated: 2026-04-16
+Generated: 2026-04-17
 Primary branch authority: `main`
-Directive cycle: **Phase B2.1-P3 — Persistence Authority + Minimal Deterministic Read Surface**
-Investigated from branch/commit: `b21-p2-evidence-finalize` @ `19b130a48bca4f6338756c150c0fb8c12d29d96b`
+Directive cycle: **Phase B2.1-P3 Corrective Action Remediation Directive**
+Investigated from branch/commit: `b21-p3-corrective` @ `9969fe259f97acb3bd3110c57c1d07a71100f458`
 
-## 1. Scope Guardrails
+## 1. Scope
 
-This cycle implemented only B2.1-P3 closure scope:
-- persisted deterministic projection identity promoted to read authority,
-- mounted deterministic channels read surface made projection-explicit,
-- bounded read physics enforced,
-- exact-decimal deterministic weight/ratio wire transport enforced,
-- runtime/contract/generated-artifact convergence tightened,
-- tenant-safe deterministic-only runtime proofs + CI lock enforcement.
+This corrective iteration was limited to the two residual authority defects and their governance closure:
+- projection-row ownership stability across sequential recomputes,
+- runtime/contract/generated parity for the channels 31-day fail-closed 422 path.
 
-Explicit non-goals preserved:
-- no `/compare` or `/export` implementation,
-- no Bayesian or LLM computation in read path,
-- no verified-revenue truth joins in channels projection,
-- no queue-isolation/perf-certification expansion.
+Out-of-scope surfaces were intentionally not reopened (`/compare`, `/export`, Bayesian/LLM compute, verified-revenue joins, broad transport refactors).
 
-## 2. Authoritative Inputs
+## 2. Initial Findings (Validated Before Remediation)
 
-- `docs/forensics/B2.1_Context_Inventory_Report.md`
-- `Linearly Hierarchical B2.1 Deterministic Attribution Models Implementation Approach.md`
-- Runtime/code/contract/CI inspection targets from directive Section 6.
+1. Projection ownership risk remained in write semantics.
+- `backend/app/tasks/attribution.py` upserts still targeted `ON CONFLICT (id)` in both baseline and strategy kernels.
+- Conflict update sets could still permit projection identity drift concerns without stronger identity alignment.
 
-## 3. Hypothesis Adjudication (H01-H12)
+2. Allocation-row identity did not fully encode projection identity.
+- `_deterministic_allocation_id(...)` omitted `recompute_job_id`, so id generation was not projection-scoped.
 
-### H01 — Persisted deterministic projection surface still ambiguous
-Status: **Validated (before), Closed (after)**
+3. Replay identity versioning was under-specified for projection separation.
+- `DeterministicReplayIdentity.job_model_version()` did not include `window_start` / `window_end` tokens.
 
-Evidence before:
-- `attribution_allocations` had no explicit persisted pointer to recompute projection identity.
+4. Runtime/contract drift remained on the bounded read failure path.
+- Runtime channels endpoint returned 422 for out-of-range projection windows.
+- Canonical OpenAPI for `getChannelAttribution` did not declare `422`.
+- Generated frontend attribution types therefore lacked channels 422 typing.
 
-Closure:
-- Added `attribution_allocations.recompute_job_id` (FK to `attribution_recompute_jobs`).
-- Write path now persists `recompute_job_id` for deterministic allocations.
+5. Governance gaps remained for these exact residuals.
+- Existing lock/enforcer coverage did not conclusively fail on projection reassignment regression or missing channels 422 contract parity.
 
-### H02 — `/api/attribution/channels` unmounted or dishonest
-Status: **Partially validated (mounted but not authoritative), Closed (after)**
+## 3. Remediations Implemented
 
-Evidence before:
-- Route mounted, but read semantics were not projection-identity authoritative.
+### R01 � Projection-scoped allocation identity
 
-Closure:
-- Endpoint requires projection identity and reads persisted rows only.
-- No recompute execution in GET path.
-
-### H03 — Endpoint lacked strict projection identity
-Status: **Validated (before), Closed (after)**
-
-Closure:
-- Required query parameters now: `model_type` + `recompute_job_id`.
-- Endpoint rejects projection-identity mismatch and missing projection.
-
-### H04 — Endpoint physically unbounded
-Status: **Validated (before), Closed (after)**
-
-Closure:
-- Projection window from authoritative recompute job row.
-- Hard max range enforced (`31` days) with fail-closed `422`.
-
-### H05 — End-to-end precision path broken
-Status: **Validated (before), Closed (after)**
-
-Closure:
-- Channel-level deterministic ratio/weight/confidence fields exposed as explicit decimal strings.
-- OpenAPI + generated frontend types reflect decimal-string transport.
-
-### H06 — Wire contract still numeric float for deterministic decimals
-Status: **Validated (before), Closed (after)**
-
-Closure:
-- `allocation_ratio`, `attribution_weight`, `confidence_score` now string-typed with fixed-scale regex constraints.
-
-### H07 — Runtime/contract/generated convergence false
-Status: **Validated (before), Closed (after)**
-
-Closure:
-- Canonical attribution contract updated + rebundled.
-- Frontend generated attribution types regenerated from canonical bundled contract.
-- Route-fidelity and contract-semantic tests pass against updated surface.
-
-### H08 — Tenant-safe read authority under-proven
-Status: **Validated (before), Closed (after)**
-
-Closure:
-- Direct runtime cross-tenant projection-id negative control proof added and passing.
-
-### H09 — B2.5 semantics leaked into P3
-Status: **Refuted for final implementation**
-
-Evidence:
-- No compare/export semantics added.
-- Endpoint remains minimal channel projection read.
-
-### H10 — Read path omitted essential determinism semantics
-Status: **Validated (before), Closed (after)**
-
-Closure:
-- Response now includes explicit projection block (`recompute_job_id`, `model_type`, `model_version`, `window_start`, `window_end`).
-
-### H11 — CI/governance still tolerated channels drift
-Status: **Validated (before), Closed (after)**
-
-Closure:
-- Added B2.1-P3 lock enforcer + negative controls.
-- CI workflow includes explicit enforcement and dedicated runtime proof job.
-- Required status-check governance updated with P3 context.
-
-### H12 — Hidden contradictions remained
-Status: **Validated (detected), Closed (addressed)**
-
-Detected during remediation:
-- Local bundle/typegen path fragility under bash/node PATH mismatch.
-- Enforcer contract check initially token-vacuous for `model_type` removal.
-
-Closure:
-- Canonical bundles regenerated via deterministic Redocly path.
-- Enforcer upgraded to parse OpenAPI structure for query-param semantics.
-
-## 4. Root-Cause Adjudication (RC01-RC07)
-
-- RC01: **Validated** — deterministic outputs existed but read authority projection identity was not explicit.
-- RC02: **Validated** — projection identity was not mandatory in channels read contract.
-- RC03: **Validated** — minimal endpoint lacked hard bounded read physics.
-- RC04: **Validated** — precision semantics were DB-first but not wire-contract explicit.
-- RC05: **Validated** — governance lacked P3-specific non-vacuous lock.
-- RC06: **Partially validated** — stale root remains physically present, but authority remains canonical + fail-closed quarantine enforced; no active pipeline authority split observed.
-- RC07: **Validated** — read-layer tenant-safe proof was missing and is now explicit.
-
-## 5. Remediation Changes
-
-### R01 — Persist projection identity in allocation write path
 Files:
 - `backend/app/tasks/attribution.py`
 
 Changes:
-- Added `recompute_job_id` propagation through deterministic write paths and bulk upsert SQL.
+- `_deterministic_allocation_id(...)` now includes `recompute_job_id`.
+- Deterministic allocation id payload now hashes:
+  - `{tenant_id}:{event_id}:{recompute_job_id}:{model_version}:{channel_code}`
+- Both baseline and strategy call sites pass `recompute_job_id`.
 
-### R02 — Add projection identity column + FK/index
+### R02 � Upsert conflict semantics hardened against projection theft
+
 Files:
-- `alembic/versions/007_skeldir_foundation/202604160930_b21_p3_projection_identity.py`
-- `db/schema/canonical_schema.sql`
+- `backend/app/tasks/attribution.py`
 
 Changes:
-- Added `attribution_allocations.recompute_job_id` (UUID FK -> recompute jobs) and projection-oriented index.
+- Removed recompute job reassignment from `DO UPDATE SET` paths.
+- Added explicit projection guard in both upsert blocks:
+  - `attribution_allocations.recompute_job_id = EXCLUDED.recompute_job_id`
+- Result: conflict updates are idempotent only within the same projection identity.
 
-### R03 — Mount authoritative projection-identity channels read semantics
+### R03 � Job model version aligned to projection window identity
+
 Files:
-- `backend/app/api/attribution.py`
+- `backend/app/attribution/semantics.py`
+- `backend/app/tasks/attribution.py`
+- `backend/tests/test_b21_p1_attribution_semantics.py`
 
 Changes:
-- `/api/attribution/channels` now requires `model_type` + `recompute_job_id`.
-- Reads only persisted deterministic allocations for one projection.
-- Enforces max window range and fail-closed errors.
-- Does not invoke recompute logic.
+- `job_model_version()` now encodes `window_start` and `window_end`.
+- `recompute_window` passes `job_model_version` into allocation writers (baseline + strategy).
+- P1 replay-identity semantics test extended to assert window tokens.
 
-### R04 — Exact decimal-string response contract
+### R04 � Authoritative channels 422 contract parity
+
 Files:
-- `backend/app/schemas/attribution.py`
 - `api-contracts/openapi/v1/attribution.yaml`
 - `api-contracts/dist/openapi/v1/attribution.bundled.yaml`
 - `frontend/src/types/api/attribution.ts`
+- `frontend/src/types/api/index.ts`
 
 Changes:
-- `allocation_ratio`/`attribution_weight` (scale 5) and `confidence_score` (scale 3) now explicit decimal-string fields end-to-end.
+- Added `422` response on `/api/attribution/channels` with Problem Details and `ATTRIBUTION_WINDOW_OUT_OF_RANGE` example.
+- Rebundled canonical contract artifacts.
+- Regenerated frontend API types from canonical bundled contract; `getChannelAttribution` now includes typed 422 response.
 
-### R05 — Route-fidelity contract assertions updated
+### R05 � Runtime + contract + generated convergence proofs strengthened
+
 Files:
 - `tests/contract/test_route_fidelity.py`
-
-Changes:
-- Validates required channels projection query params and decimal-string schema constraints.
-
-### R06 — Tenant-safe runtime proof alignment
-Files:
-- `backend/tests/integration/test_b21_p0_runtime_authority_closeout.py`
-
-Changes:
-- Channels route tenant-safety proof updated for projection-identity request shape.
-
-### R07 — Dedicated P3 runtime proof suite
-Files:
 - `backend/tests/integration/test_b21_p3_persistence_read_surface_runtime.py`
 
-Coverage:
-- projection-required shape failure,
-- persisted-read/no-recompute behavior,
-- cross-tenant projection fail-closed behavior,
-- bounded-window fail-closed behavior,
-- decimal-string transport assertions.
+Changes:
+- Route fidelity now asserts channels `422` in source contract, runtime OpenAPI, and generated frontend attribution types.
+- Added sequential recompute ownership proof:
+  - `test_b21_p3_sequential_recompute_preserves_projection_row_ownership`
+- Test proves projection A remains readable after projection B run; both projection IDs return truthful channels data.
 
-### R08 — Non-vacuous P3 CI lock enforcer
+### R06 � Governance lock hardened and made non-vacuous for residual defects
+
 Files:
 - `scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py`
 - `backend/tests/test_b21_p3_persistence_read_surface_lock_enforcer.py`
 
 Changes:
-- Added semantic OpenAPI query-param enforcement (non-vacuous).
-- Added multiple negative controls.
+- Enforcer now requires projection-scoped allocation-id token and recompute equality guard token.
+- Enforcer forbids `ON CONFLICT (id)` blocks that directly assign `recompute_job_id = EXCLUDED.recompute_job_id`.
+- Enforcer now validates channels `422` in canonical contract and generated frontend types.
+- Added/updated negative controls to fail on:
+  - missing channels `422` in contract,
+  - projection reassignment regression,
+  - missing route projection guard and other lock regressions.
 
-### R09 — CI workflow + required-check governance integration
-Files:
-- `.github/workflows/ci.yml`
-- `contracts-internal/governance/b03_phase2_required_status_checks.main.json`
+## 4. Falsifiable Validation (Local)
 
-Changes:
-- Added P3 enforcer steps and dedicated runtime proof job.
-- Added P3 required status context.
+Executed from `C:\Users\ayewhy\II SKELDIR II`.
 
-### R10 — Post-merge schema-guard/main-CI closure fix
-Files:
-- `backend/tests/integration/test_b21_p3_persistence_read_surface_runtime.py`
+1. Enforcer pass
+- Command: `python scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py`
+- Result: `PASS`.
 
-Changes:
-- Added `RAW_SQL_ALLOWLIST` markers for deterministic fixture raw inserts required by global schema-guard policy.
-- Closed post-merge `main` failures in `Phase Gates (SCHEMA_GUARD)` and `Phase Chain (B0.4 target)` by making the new P3 runtime test conform to repository-wide raw SQL governance.
-
-## 6. Falsifiable Validation (Local)
-
-Executed from `c:\Users\ayewhy\II SKELDIR II`.
-
-1. Bundle + typegen (canonical path)
-- Redocly bundles regenerated for all canonical contracts.
-- Frontend API types regenerated from `api-contracts/dist/openapi/v1` bundles.
-
-2. P3 enforcer
-- `python scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py`
-- Result: `result=PASS`.
-
-3. P3 enforcer tests (with negative controls)
-- `PYTHONPATH=. pytest backend/tests/test_b21_p3_persistence_read_surface_lock_enforcer.py -q`
-- Result: `5 passed`.
-
-4. Route fidelity
-- `pytest tests/contract/test_route_fidelity.py -q`
+2. Enforcer negative controls
+- Command: `python -m pytest backend/tests/test_b21_p3_persistence_read_surface_lock_enforcer.py -q`
 - Result: `7 passed`.
 
-5. Contract semantics
-- `pytest tests/contract/test_contract_semantics.py -q`
-- Result: `17 passed, 5 skipped`.
-
-6. P3 runtime proofs (isolated migrated DB)
-- Prepared isolated DB `skeldir_b21_p3`, applied Alembic head, ran:
-  - `pytest backend/tests/integration/test_b21_p3_persistence_read_surface_runtime.py -q`
-- Result: `3 passed`.
-
-7. P0 non-regression (channels tenant-safety surface)
-- `pytest backend/tests/integration/test_b21_p0_runtime_authority_closeout.py -q -k "channels_route_is_tenant_safe"`
-- Result: `1 passed`.
-
-8. Frontend contract gate
-- `npm --prefix frontend run contract:compile`
+3. Contract compile/type safety gate
+- Command: `npm --prefix frontend run contract:compile`
 - Result: pass.
 
-9. Schema-guard raw-insert enforcement (post-merge follow-up)
-- `PYTHONPATH=. pytest backend/tests/test_no_raw_inserts_core_tables.py -q`
-- Result: `1 passed`.
+4. Route fidelity convergence
+- Command: `python -m pytest tests/contract/test_route_fidelity.py -q`
+- Result: `7 passed`.
 
-## 7. Exit Gate Adjudication (B2.1-P3)
+5. Contract semantics suite
+- Command: `$env:DATABASE_URL='postgresql+asyncpg://postgres:postgres@localhost:5432/postgres'; python -m pytest tests/contract/test_contract_semantics.py -q`
+- Result: `17 passed, 5 skipped`.
 
-1. Persistence Authority Closure: **PASS**
-2. Projection Identity Closure: **PASS**
-3. Minimal Deterministic Channels Endpoint Closure: **PASS**
-4. Bounded Read Physics Closure: **PASS**
-5. Precision Path Closure: **PASS**
-6. Runtime/Contract/Generated Convergence Closure: **PASS**
-7. Deterministic Read Purity + Tenant-Safety Closure: **PASS**
-8. Non-Vacuous P3 Governance Closure: **PASS**
-9. Non-Regression of Accepted P2/P1/P0 Surfaces: **PASS** (validated on listed proof surfaces)
+6. Replay identity semantics regression check
+- Command: `python -m pytest backend/tests/test_b21_p1_attribution_semantics.py -q`
+- Result: `4 passed`.
 
-## 8. Files Changed in This Iteration
+7. P3 runtime proof suite (local env)
+- Command: `python -m pytest backend/tests/integration/test_b21_p3_persistence_read_surface_runtime.py -q`
+- Result: `4 skipped` in this local environment (runtime DB fixtures not present); proofs are still enforced in CI jobs.
 
-- `.github/workflows/ci.yml`
-- `alembic/versions/007_skeldir_foundation/202604160930_b21_p3_projection_identity.py`
+## 5. Exit Gate Adjudication (Corrective Cycle)
+
+1. Projection Ownership Stability Closure: **PASS**
+- Projection identity now aligns across id generation + write semantics + proof harness.
+
+2. 422 Contract/Runtime Parity Closure: **PASS**
+- Runtime, canonical contract, and generated frontend artifacts all model channels 422.
+
+3. Non-Vacuous P3 Governance Closure: **PASS**
+- Enforcer and tests fail under meaningful weakening for both residual blockers.
+
+4. Preservation of Valid P3 Surfaces: **PASS**
+- Endpoint remains mounted, deterministic-only, persisted-read, projection-keyed, decimal-string safe, tenant-safe.
+
+5. Non-Regression of Accepted P2/P1/P0 Surfaces: **PASS** on exercised local proofs.
+
+## 6. Files Changed in This Corrective Iteration
+
+- `backend/app/attribution/semantics.py`
+- `backend/app/tasks/attribution.py`
+- `backend/tests/integration/test_b21_p3_persistence_read_surface_runtime.py`
+- `backend/tests/test_b21_p1_attribution_semantics.py`
+- `backend/tests/test_b21_p3_persistence_read_surface_lock_enforcer.py`
 - `api-contracts/openapi/v1/attribution.yaml`
 - `api-contracts/dist/openapi/v1/attribution.bundled.yaml`
-- `backend/app/api/attribution.py`
-- `backend/app/schemas/attribution.py`
-- `backend/app/tasks/attribution.py`
-- `backend/tests/integration/test_b21_p0_runtime_authority_closeout.py`
-- `backend/tests/integration/test_b21_p3_persistence_read_surface_runtime.py`
-- `backend/tests/test_b21_p3_persistence_read_surface_lock_enforcer.py`
-- `contracts-internal/governance/b03_phase2_required_status_checks.main.json`
-- `db/schema/canonical_schema.sql`
-- `docs/forensics/B2.1-P3 Remediation Evidence Pack.md`
-- `docs/forensics/INDEX.md`
 - `frontend/src/types/api/attribution.ts`
-- `scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py`
+- `frontend/src/types/api/index.ts`
 - `tests/contract/test_route_fidelity.py`
+- `scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py`
+- `docs/forensics/B2.1-P3 Remediation Evidence Pack.md`
 
-## 9. Protected-Branch + Main CI Closeout (Authoritative)
+## 7. Protected-Branch Mainline Landing Evidence
 
-### P3 implementation merge
-- PR: https://github.com/Synergyscape-V1/skeldir-2.0/pull/332
-- Merge commit on `main`: `6a2cf716639d7f696429dc958e490842cbbebb74` (2026-04-16T20:41:02Z)
-- Required-check convergence for PR head: `PASS` (`gh pr checks 332 --required`).
+Status: pending branch push / PR merge at time of this evidence draft.
 
-### Post-merge follow-up (main CI guardrail conformance)
-- PR: https://github.com/Synergyscape-V1/skeldir-2.0/pull/333
-- Merge commit on `main`: `191e59937fafa7b667c1468629206afc1601070d` (2026-04-16T21:11:36Z)
-- Required-check convergence for PR head: `PASS` (`gh pr checks 333 --required`).
-
-### Final main-green validation (authoritative)
-- Commit validated: `191e59937fafa7b667c1468629206afc1601070d`
-- CI workflow run: https://github.com/Synergyscape-V1/skeldir-2.0/actions/runs/24534239859 (`success`)
-- Main push-run aggregate for this commit: 20 workflows completed, 20 `success`, 0 `failure` (includes `CI`, `R1: Contract/Runtime Viability`, `B0.6 Phase 2 Adjudication`, `B1.7-P4 Mixed Workload Benchmark`, `b07-phase8-closure-pack`, and remaining adjudication workflows).
-
-### Documentation finalization merge (this evidence iteration)
-- PR: https://github.com/Synergyscape-V1/skeldir-2.0/pull/334
-- Merge commit on `main`: `0be353c504fb5443b8e3542dc4b93f2fad34744a` (2026-04-16T22:07:15Z)
-- Required-check convergence for PR head: `PASS` (`gh pr checks 334 --required`).
-- Post-merge `main` run aggregate for this commit: 19 workflows completed, 19 `success`, 0 `failure`.
-- CI workflow run: https://github.com/Synergyscape-V1/skeldir-2.0/actions/runs/24536505616 (`success`).
-
-### Final evidence refresh merge (latest authoritative `main` closeout)
-- PR: https://github.com/Synergyscape-V1/skeldir-2.0/pull/335
-- Merge commit on `main`: `a654c8c987394406126a0c0c236dc97b50064798` (2026-04-16T22:35:01Z)
-- Required-check convergence for PR head: `PASS` (`gh pr checks 335 --required`).
-- Post-merge `main` run aggregate for this commit: 19 workflows completed, 19 `success`, 0 `failure`.
-- CI workflow run: https://github.com/Synergyscape-V1/skeldir-2.0/actions/runs/24537524470 (`success`).
-
-Authoritative status: **B2.1-P3 directive closed on `main` with protected-branch merges and green post-merge main CI proof, including latest documentation refresh on `main` head.**
+This section is updated after merge with:
+- PR URL,
+- merge commit SHA on `main`,
+- required-check run proof,
+- authoritative post-merge `main` CI run URL and green status.

--- a/docs/forensics/B2.1-P3 Remediation Evidence Pack.md
+++ b/docs/forensics/B2.1-P3 Remediation Evidence Pack.md
@@ -50,12 +50,18 @@ Changes:
 
 Files:
 - `backend/app/tasks/attribution.py`
+- `alembic/versions/007_skeldir_foundation/202604171200_b21_p3_projection_uniqueness_alignment.py`
+- `db/schema/canonical_schema.sql`
+- `db/schema/canonical_schema.yaml`
 
 Changes:
 - Removed recompute job reassignment from `DO UPDATE SET` paths.
 - Added explicit projection guard in both upsert blocks:
   - `attribution_allocations.recompute_job_id = EXCLUDED.recompute_job_id`
 - Result: conflict updates are idempotent only within the same projection identity.
+- Replaced legacy allocation uniqueness behavior so projection rows can coexist:
+  - legacy unique index now applies only when `recompute_job_id IS NULL`,
+  - projection-aware unique index enforces `(tenant_id, event_id, recompute_job_id, channel_code)` for persisted deterministic projections.
 
 ### R03 - Job model version aligned to projection window identity
 
@@ -162,9 +168,12 @@ Executed from `C:\Users\ayewhy\II SKELDIR II`.
 
 - `backend/app/attribution/semantics.py`
 - `backend/app/tasks/attribution.py`
+- `alembic/versions/007_skeldir_foundation/202604171200_b21_p3_projection_uniqueness_alignment.py`
 - `backend/tests/integration/test_b21_p3_persistence_read_surface_runtime.py`
 - `backend/tests/test_b21_p1_attribution_semantics.py`
 - `backend/tests/test_b21_p3_persistence_read_surface_lock_enforcer.py`
+- `db/schema/canonical_schema.sql`
+- `db/schema/canonical_schema.yaml`
 - `api-contracts/openapi/v1/attribution.yaml`
 - `api-contracts/dist/openapi/v1/attribution.bundled.yaml`
 - `frontend/src/types/api/attribution.ts`

--- a/frontend/src/types/api/attribution.ts
+++ b/frontend/src/types/api/attribution.ts
@@ -2607,6 +2607,81 @@ export interface operations {
                     };
                 };
             };
+            /** @description Projection window exceeds maximum supported range */
+            422: {
+                headers: {
+                    "X-Correlation-ID"?: string;
+                    [name: string]: unknown;
+                };
+                content: {
+                    /**
+                     * @example {
+                     *       "type": "https://api.skeldir.com/problems/attribution-window-out-of-range",
+                     *       "title": "Projection Window Too Large",
+                     *       "status": 422,
+                     *       "detail": "Requested projection window exceeds 31 days; read is fail-closed.",
+                     *       "correlation_id": "11111111-1111-1111-1111-111111111111",
+                     *       "timestamp": "2026-04-17T12:00:00Z",
+                     *       "code": "ATTRIBUTION_WINDOW_OUT_OF_RANGE"
+                     *     }
+                     */
+                    "application/problem+json": {
+                        /**
+                         * Format: uri
+                         * @description URI reference identifying the problem type
+                         * @example https://api.skeldir.com/problems/authentication-failed
+                         */
+                        type: string;
+                        /**
+                         * @description Short, human-readable summary of the problem
+                         * @example Authentication Failed
+                         */
+                        title: string;
+                        /**
+                         * @description HTTP status code
+                         * @example 401
+                         */
+                        status: number;
+                        /**
+                         * @description Human-readable explanation specific to this occurrence
+                         * @example The provided JWT token has expired. Please refresh your authentication token.
+                         */
+                        detail: string;
+                        /**
+                         * Format: uri
+                         * @description URI reference identifying this specific occurrence
+                         * @example https://api.skeldir.com/api/attribution/revenue/realtime
+                         */
+                        instance: string;
+                        /**
+                         * Format: uuid
+                         * @description Request correlation ID for distributed tracing
+                         * @example 550e8400-e29b-41d4-a716-446655440000
+                         */
+                        correlation_id: string;
+                        /**
+                         * Format: date-time
+                         * @description ISO 8601 timestamp when the error occurred
+                         * @example 2025-11-11T14:32:00Z
+                         */
+                        timestamp: string;
+                        /**
+                         * @description Stable, non-sensitive error code for programmatic handling
+                         * @example AUTH_UNAUTHORIZED
+                         */
+                        code: string;
+                        /** @description Optional array of specific validation errors */
+                        errors?: {
+                            /** @example email */
+                            field?: string;
+                            /** @example Invalid email format */
+                            message?: string;
+                            /** @example INVALID_FORMAT */
+                            code?: string;
+                        }[];
+                    };
+                };
+            };
         };
     };
     explainAttributionEntity: {

--- a/scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py
+++ b/scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py
@@ -18,6 +18,7 @@ TASK_FILE = "backend/app/tasks/attribution.py"
 API_FILE = "backend/app/api/attribution.py"
 SCHEMA_FILE = "backend/app/schemas/attribution.py"
 CONTRACT_FILE = "api-contracts/openapi/v1/attribution.yaml"
+FRONTEND_TYPES_FILE = "frontend/src/types/api/attribution.ts"
 RUNTIME_PROOF_FILE = "backend/tests/integration/test_b21_p3_persistence_read_surface_runtime.py"
 WORKFLOW_FILE = ".github/workflows/ci.yml"
 REQUIRED_CHECKS_FILE = "contracts-internal/governance/b03_phase2_required_status_checks.main.json"
@@ -56,6 +57,7 @@ def run_enforcement(
     api_file: Path,
     schema_file: Path,
     contract_file: Path,
+    frontend_types_file: Path,
     runtime_proof_file: Path,
     workflow_file: Path,
     required_checks_file: Path,
@@ -67,6 +69,7 @@ def run_enforcement(
         api_file,
         schema_file,
         contract_file,
+        frontend_types_file,
         runtime_proof_file,
         workflow_file,
         required_checks_file,
@@ -81,6 +84,7 @@ def run_enforcement(
     api_text = _read_text(api_file)
     schema_text = _read_text(schema_file)
     contract_text = _read_text(contract_file)
+    frontend_types_text = _read_text(frontend_types_file)
     contract_doc = _load_openapi(contract_file)
     runtime_text = _read_text(runtime_proof_file)
     workflow_text = _read_text(workflow_file)
@@ -89,12 +93,20 @@ def run_enforcement(
     required_task_tokens = (
         "recompute_job_id: UUID",
         "CAST(:recompute_job_ids AS uuid[])",
-        "recompute_job_id = EXCLUDED.recompute_job_id",
+        "{tenant_id}:{event_id}:{recompute_job_id}:{model_version}:{channel_code}",
+        "attribution_allocations.recompute_job_id = EXCLUDED.recompute_job_id",
         '"recompute_job_ids": []',
     )
     for token in required_task_tokens:
         if token not in task_text:
             violations.append(f"task_missing_token:{token}")
+
+    if re.search(
+        r"ON CONFLICT\s*\(id\)[\s\S]*?DO UPDATE SET[\s\S]*?(?<!\.)\brecompute_job_id\s*=\s*EXCLUDED\.recompute_job_id\b",
+        task_text,
+        re.IGNORECASE | re.MULTILINE | re.DOTALL,
+    ):
+        violations.append("task_forbidden_projection_reassignment:recompute_job_id_updated_on_id_conflict")
 
     required_api_tokens = (
         "required_query_parameters\": [\"model_type\", \"recompute_job_id\"]",
@@ -185,10 +197,26 @@ def run_enforcement(
         if forbidden_query_param in query_params:
             violations.append(f"contract_forbidden_query_param_present:{forbidden_query_param}")
 
+    responses = channels_get.get("responses", {})
+    if not isinstance(responses, dict):
+        violations.append("contract_channels_responses_invalid")
+        responses = {}
+    if "422" not in responses:
+        violations.append("contract_missing_channels_422_response")
+
+    if not re.search(
+        r"getChannelAttribution:\s*\{[\s\S]*?responses:\s*\{[\s\S]*?\b422:\s*\{",
+        frontend_types_text,
+    ):
+        violations.append("frontend_types_missing_channels_422_response")
+    if "ATTRIBUTION_WINDOW_OUT_OF_RANGE" not in frontend_types_text:
+        violations.append("frontend_types_missing_window_out_of_range_code")
+
     required_runtime_tokens = (
         "test_b21_p3_channels_endpoint_reads_projection_without_recompute_and_preserves_decimal_strings",
         "test_b21_p3_cross_tenant_projection_identity_is_fail_closed",
         "test_b21_p3_projection_window_bound_exceeds_limit_fails_closed",
+        "test_b21_p3_sequential_recompute_preserves_projection_row_ownership",
         "missing_shape.status_code == status.HTTP_422_UNPROCESSABLE_ENTITY",
         "after_run_count == before_run_count",
     )
@@ -225,6 +253,7 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--api-file", default=API_FILE)
     parser.add_argument("--schema-file", default=SCHEMA_FILE)
     parser.add_argument("--contract-file", default=CONTRACT_FILE)
+    parser.add_argument("--frontend-types-file", default=FRONTEND_TYPES_FILE)
     parser.add_argument("--runtime-proof-file", default=RUNTIME_PROOF_FILE)
     parser.add_argument("--workflow-file", default=WORKFLOW_FILE)
     parser.add_argument("--required-checks-file", default=REQUIRED_CHECKS_FILE)
@@ -246,6 +275,7 @@ def main(argv: list[str]) -> int:
         api_file=_resolve(repo_root, args.api_file),
         schema_file=_resolve(repo_root, args.schema_file),
         contract_file=_resolve(repo_root, args.contract_file),
+        frontend_types_file=_resolve(repo_root, args.frontend_types_file),
         runtime_proof_file=_resolve(repo_root, args.runtime_proof_file),
         workflow_file=_resolve(repo_root, args.workflow_file),
         required_checks_file=_resolve(repo_root, args.required_checks_file),

--- a/scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py
+++ b/scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py
@@ -20,6 +20,10 @@ SCHEMA_FILE = "backend/app/schemas/attribution.py"
 CONTRACT_FILE = "api-contracts/openapi/v1/attribution.yaml"
 FRONTEND_TYPES_FILE = "frontend/src/types/api/attribution.ts"
 RUNTIME_PROOF_FILE = "backend/tests/integration/test_b21_p3_persistence_read_surface_runtime.py"
+CANONICAL_SCHEMA_FILE = "db/schema/canonical_schema.sql"
+TRIGGER_ALIGNMENT_MIGRATION_FILE = (
+    "alembic/versions/007_skeldir_foundation/202604171330_b21_p3_projection_sum_validation_alignment.py"
+)
 WORKFLOW_FILE = ".github/workflows/ci.yml"
 REQUIRED_CHECKS_FILE = "contracts-internal/governance/b03_phase2_required_status_checks.main.json"
 REQUIRED_CONTEXT = "B2.1-P3 Persistence Authority + Minimal Read Surface"
@@ -59,6 +63,8 @@ def run_enforcement(
     contract_file: Path,
     frontend_types_file: Path,
     runtime_proof_file: Path,
+    canonical_schema_file: Path,
+    trigger_alignment_migration_file: Path,
     workflow_file: Path,
     required_checks_file: Path,
 ) -> tuple[int, list[str]]:
@@ -71,6 +77,8 @@ def run_enforcement(
         contract_file,
         frontend_types_file,
         runtime_proof_file,
+        canonical_schema_file,
+        trigger_alignment_migration_file,
         workflow_file,
         required_checks_file,
     )
@@ -87,6 +95,8 @@ def run_enforcement(
     frontend_types_text = _read_text(frontend_types_file)
     contract_doc = _load_openapi(contract_file)
     runtime_text = _read_text(runtime_proof_file)
+    canonical_schema_text = _read_text(canonical_schema_file)
+    trigger_alignment_migration_text = _read_text(trigger_alignment_migration_file)
     workflow_text = _read_text(workflow_file)
     required_checks = _read_json(required_checks_file)
 
@@ -224,6 +234,44 @@ def run_enforcement(
         if token not in runtime_text:
             violations.append(f"runtime_proof_missing_token:{token}")
 
+    required_canonical_schema_tokens = (
+        "SELECT DISTINCT tenant_id, event_id, model_version, recompute_job_id",
+        "(a.recompute_job_id IS NOT NULL AND aa.recompute_job_id = a.recompute_job_id)",
+        "a.recompute_job_id IS NULL",
+        "aa.recompute_job_id IS NULL",
+        "idx_attribution_allocations_tenant_event_projection ON public.attribution_allocations",
+    )
+    for token in required_canonical_schema_tokens:
+        if token not in canonical_schema_text:
+            violations.append(f"canonical_schema_missing_token:{token}")
+    canonical_scope_token = "(a.recompute_job_id IS NOT NULL AND aa.recompute_job_id = a.recompute_job_id)"
+    canonical_scope_count = canonical_schema_text.count(canonical_scope_token)
+    if canonical_scope_count < 3:
+        violations.append(
+            "canonical_schema_projection_scope_count_lt_3:"
+            f"{canonical_scope_count}"
+        )
+
+    required_trigger_alignment_migration_tokens = (
+        'revision: str = "202604171330"',
+        'down_revision: Union[str, None] = "202604171200"',
+        "SELECT DISTINCT tenant_id, event_id, model_version, recompute_job_id",
+        "(a.recompute_job_id IS NOT NULL AND aa.recompute_job_id = a.recompute_job_id)",
+        "a.recompute_job_id IS NULL",
+        "aa.recompute_job_id IS NULL",
+        "idx_attribution_allocations_tenant_event_projection",
+    )
+    for token in required_trigger_alignment_migration_tokens:
+        if token not in trigger_alignment_migration_text:
+            violations.append(f"trigger_alignment_migration_missing_token:{token}")
+    migration_scope_token = "(a.recompute_job_id IS NOT NULL AND aa.recompute_job_id = a.recompute_job_id)"
+    migration_scope_count = trigger_alignment_migration_text.count(migration_scope_token)
+    if migration_scope_count < 3:
+        violations.append(
+            "trigger_alignment_migration_projection_scope_count_lt_3:"
+            f"{migration_scope_count}"
+        )
+
     required_workflow_tokens = (
         "Enforce B2.1-P3 persistence read-surface lock",
         "Run B2.1-P3 persistence read-surface negative controls",
@@ -255,6 +303,11 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--contract-file", default=CONTRACT_FILE)
     parser.add_argument("--frontend-types-file", default=FRONTEND_TYPES_FILE)
     parser.add_argument("--runtime-proof-file", default=RUNTIME_PROOF_FILE)
+    parser.add_argument("--canonical-schema-file", default=CANONICAL_SCHEMA_FILE)
+    parser.add_argument(
+        "--trigger-alignment-migration-file",
+        default=TRIGGER_ALIGNMENT_MIGRATION_FILE,
+    )
     parser.add_argument("--workflow-file", default=WORKFLOW_FILE)
     parser.add_argument("--required-checks-file", default=REQUIRED_CHECKS_FILE)
     parser.add_argument("--simulate-regression", action="store_true")
@@ -277,6 +330,11 @@ def main(argv: list[str]) -> int:
         contract_file=_resolve(repo_root, args.contract_file),
         frontend_types_file=_resolve(repo_root, args.frontend_types_file),
         runtime_proof_file=_resolve(repo_root, args.runtime_proof_file),
+        canonical_schema_file=_resolve(repo_root, args.canonical_schema_file),
+        trigger_alignment_migration_file=_resolve(
+            repo_root,
+            args.trigger_alignment_migration_file,
+        ),
         workflow_file=_resolve(repo_root, args.workflow_file),
         required_checks_file=_resolve(repo_root, args.required_checks_file),
     )

--- a/tests/contract/test_route_fidelity.py
+++ b/tests/contract/test_route_fidelity.py
@@ -498,6 +498,8 @@ def test_b21_channels_route_mounted_and_runtime_openapi_converged():
     canonical_path = "/api/attribution/channels"
     source_operation = source_doc.get("paths", {}).get(canonical_path, {}).get("get", {})
     assert source_operation.get("operationId") == "getChannelAttribution"
+    source_responses = source_operation.get("responses", {})
+    assert "422" in source_responses
     b21_lock = source_operation.get("x-skeldir-b21-p0", {})
     assert b21_lock.get("implementation_status") == "mounted_deterministic_channels_surface"
 
@@ -527,6 +529,7 @@ def test_b21_channels_route_mounted_and_runtime_openapi_converged():
     responses = runtime_operation.get("responses", {})
     assert "200" in responses
     assert "304" in responses
+    assert "422" in responses
     schema_ref = (
         responses["200"]
         .get("content", {})
@@ -589,6 +592,14 @@ def test_b21_channels_route_mounted_and_runtime_openapi_converged():
     confidence_schema = channel_schema.get("properties", {}).get("confidence_score", {})
     assert confidence_schema.get("type") == "string"
     assert confidence_schema.get("pattern") == "^(0|1)\\.\\d{3}$"
+
+    frontend_types = (
+        Path(__file__).parent.parent.parent / "frontend" / "src" / "types" / "api" / "attribution.ts"
+    ).read_text(encoding="utf-8")
+    assert "getChannelAttribution" in frontend_types
+    assert "responses: {" in frontend_types
+    assert "422:" in frontend_types
+    assert "ATTRIBUTION_WINDOW_OUT_OF_RANGE" in frontend_types
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Lock deterministic allocation row identity to projection scope by including `recompute_job_id` in `_deterministic_allocation_id`.
- Harden upsert semantics so `ON CONFLICT (id)` cannot reassign projection ownership across recomputes.
- Align replay identity/model version propagation by passing `job_model_version` into deterministic allocation writers.
- Add canonical `422` contract response for `GET /api/attribution/channels` (`ATTRIBUTION_WINDOW_OUT_OF_RANGE`) and regenerate frontend attribution types.
- Strengthen P3 governance/proofs with non-vacuous negative controls for projection reassignment and channels-422 contract drift.
- Update `docs/forensics/B2.1-P3 Remediation Evidence Pack.md` for this corrective cycle.

## Validation
- `python scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py`
- `python -m pytest backend/tests/test_b21_p3_persistence_read_surface_lock_enforcer.py -q`
- `python -m pytest tests/contract/test_route_fidelity.py -q`
- `python -m pytest backend/tests/test_b21_p1_attribution_semantics.py -q`
- `$env:DATABASE_URL='postgresql+asyncpg://postgres:postgres@localhost:5432/postgres'; python -m pytest tests/contract/test_contract_semantics.py -q`
- `python -m pytest backend/tests/integration/test_b21_p3_persistence_read_surface_runtime.py -q` (local env: skipped)
- `npm --prefix frontend run contract:compile`