### PR TITLE
B2.1-P3: finalize remediation evidence pack mainline proof

### DIFF
--- a/docs/forensics/B2.1-P3 Remediation Evidence Pack.md
+++ b/docs/forensics/B2.1-P3 Remediation Evidence Pack.md
@@ -206,10 +206,19 @@ Executed from `C:\Users\ayewhy\II SKELDIR II`.
 
 ## 7. Protected-Branch Mainline Landing Evidence
 
-Status: pending branch push / PR merge at time of this evidence draft.
+Status: **COMPLETE**.
 
-This section is updated after merge with:
-- PR URL,
-- merge commit SHA on `main`,
-- required-check run proof,
-- authoritative post-merge `main` CI run URL and green status.
+- PR URL: `https://github.com/Synergyscape-V1/skeldir-2.0/pull/337`
+- PR state: `MERGED` at `2026-04-17T11:46:09Z`
+- Merge commit on `main`: `e5f13abaaa08b65ba2f674bf6403ca86e66c8cfe`
+- Branch head commits carrying corrective closure:
+  - `f01d1f106d75384c60bc10b9fc471752e99f95d0` (`B2.1-P3: align sum validation to projection identity`)
+  - `f088be86351a914d18c550aa19dc84f3184a1090` (`Fix canonical schema index order parity for projection index`)
+- Required PR checks: `gh pr checks 337 --required` returned all required checks `pass`.
+- Authoritative post-merge `main` CI run:
+  - Run ID: `24563428121`
+  - URL: `https://github.com/Synergyscape-V1/skeldir-2.0/actions/runs/24563428121`
+  - Branch/SHA: `main` @ `e5f13abaaa08b65ba2f674bf6403ca86e66c8cfe`
+  - Status: `completed`
+  - Conclusion: `success`
+  - Window: `2026-04-17T11:46:12Z` -> `2026-04-17T12:03:42Z`


### PR DESCRIPTION
## Summary
- update B2.1-P3 evidence pack Section 7 from pending to complete
- record authoritative PR #337 merge metadata and post-merge main CI success
- preserve all previously landed corrective code; doc-only closure

## Validation
- python scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py

## Scope
- docs only (docs/forensics/B2.1-P3 Remediation Evidence Pack.md)
