### PR TITLE
B2.1-P3: lock bundled channels 422 contract convergence

### DIFF
--- a/backend/tests/test_b21_p3_persistence_read_surface_lock_enforcer.py
+++ b/backend/tests/test_b21_p3_persistence_read_surface_lock_enforcer.py
@@ -13,7 +13,13 @@ TASK_FILE = REPO_ROOT / "backend" / "app" / "tasks" / "attribution.py"
 API_FILE = REPO_ROOT / "backend" / "app" / "api" / "attribution.py"
 SCHEMA_FILE = REPO_ROOT / "backend" / "app" / "schemas" / "attribution.py"
 CONTRACT_FILE = REPO_ROOT / "api-contracts" / "openapi" / "v1" / "attribution.yaml"
+BUNDLED_CONTRACT_FILE = (
+    REPO_ROOT / "api-contracts" / "dist" / "openapi" / "v1" / "attribution.bundled.yaml"
+)
 FRONTEND_TYPES_FILE = REPO_ROOT / "frontend" / "src" / "types" / "api" / "attribution.ts"
+FRONTEND_TYPEGEN_SCRIPT_FILE = REPO_ROOT / "scripts" / "contracts" / "generate_frontend_types.sh"
+CONTRACT_BUNDLE_SCRIPT_FILE = REPO_ROOT / "scripts" / "contracts" / "bundle.sh"
+CONTRACT_ENTRYPOINTS_FILE = REPO_ROOT / "scripts" / "contracts" / "entrypoints.json"
 RUNTIME_FILE = REPO_ROOT / "backend" / "tests" / "integration" / "test_b21_p3_persistence_read_surface_runtime.py"
 CANONICAL_SCHEMA_FILE = REPO_ROOT / "db" / "schema" / "canonical_schema.sql"
 TRIGGER_ALIGNMENT_MIGRATION_FILE = (
@@ -34,7 +40,11 @@ def test_b21_p3_persistence_read_surface_lock_enforcer_passes_repo_state() -> No
         api_file=API_FILE,
         schema_file=SCHEMA_FILE,
         contract_file=CONTRACT_FILE,
+        bundled_contract_file=BUNDLED_CONTRACT_FILE,
         frontend_types_file=FRONTEND_TYPES_FILE,
+        frontend_typegen_script_file=FRONTEND_TYPEGEN_SCRIPT_FILE,
+        contract_bundle_script_file=CONTRACT_BUNDLE_SCRIPT_FILE,
+        contract_entrypoints_file=CONTRACT_ENTRYPOINTS_FILE,
         runtime_proof_file=RUNTIME_FILE,
         canonical_schema_file=CANONICAL_SCHEMA_FILE,
         trigger_alignment_migration_file=TRIGGER_ALIGNMENT_MIGRATION_FILE,
@@ -141,6 +151,67 @@ def test_b21_p3_persistence_read_surface_lock_enforcer_negative_control_missing_
     assert proc.returncode != 0
     combined = f"{proc.stdout}\n{proc.stderr}"
     assert "contract_missing_channels_422_response" in combined
+
+
+def test_b21_p3_persistence_read_surface_lock_enforcer_negative_control_missing_bundled_contract_422_response(
+    tmp_path: Path,
+) -> None:
+    bundled_contract_regression = tmp_path / "attribution_bundled_422.regression.yaml"
+    bundled_contract_regression.write_text(
+        BUNDLED_CONTRACT_FILE.read_text(encoding="utf-8").replace(
+            "'422':",
+            "'422_removed':",
+            1,
+        ),
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(ENFORCER),
+            "--bundled-contract-file",
+            str(bundled_contract_regression),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode != 0
+    combined = f"{proc.stdout}\n{proc.stderr}"
+    assert "bundled_contract_missing_channels_422_response" in combined
+
+
+def test_b21_p3_persistence_read_surface_lock_enforcer_negative_control_typegen_not_sourced_from_bundle(
+    tmp_path: Path,
+) -> None:
+    typegen_script_regression = tmp_path / "generate_frontend_types.regression.sh"
+    typegen_script_regression.write_text(
+        FRONTEND_TYPEGEN_SCRIPT_FILE.read_text(encoding="utf-8").replace(
+            'generate "attribution.bundled.yaml" "attribution.ts"',
+            'generate "attribution.yaml" "attribution.ts"',
+            1,
+        ),
+        encoding="utf-8",
+    )
+    proc = subprocess.run(
+        [
+            sys.executable,
+            str(ENFORCER),
+            "--frontend-typegen-script-file",
+            str(typegen_script_regression),
+        ],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+    assert proc.returncode != 0
+    combined = f"{proc.stdout}\n{proc.stderr}"
+    assert (
+        'frontend_typegen_script_missing_token:generate "attribution.bundled.yaml" "attribution.ts"'
+        in combined
+    )
 
 
 def test_b21_p3_persistence_read_surface_lock_enforcer_negative_control_projection_reassignment_on_conflict(

--- a/docs/forensics/B2.1-P3 Remediation Evidence Pack.md
+++ b/docs/forensics/B2.1-P3 Remediation Evidence Pack.md
@@ -222,3 +222,73 @@ Status: **COMPLETE**.
   - Status: `completed`
   - Conclusion: `success`
   - Window: `2026-04-17T11:46:12Z` -> `2026-04-17T12:03:42Z`
+
+## 8. Corrective Iteration 2 (Bundled 422 Convergence Governance)
+
+Cycle date: `2026-04-17`  
+Investigated from `origin/main` commit: `6fd703ac2a1b40ba137ddfb2723e48206dbf704b`
+
+### 8.1 Initial Findings
+
+1. Bundled artifact semantic absence claim was **refuted**.
+- `api-contracts/openapi/v1/attribution.yaml` contains channels `422` and `ATTRIBUTION_WINDOW_OUT_OF_RANGE`.
+- `api-contracts/dist/openapi/v1/attribution.bundled.yaml` also contains the same channels `422` and `ATTRIBUTION_WINDOW_OUT_OF_RANGE`.
+- `frontend/src/types/api/attribution.ts` includes `getChannelAttribution` response `422` and `ATTRIBUTION_WINDOW_OUT_OF_RANGE`.
+
+2. Governance blind spot was **validated**.
+- `scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py` previously checked source contract + generated types, but did not assert bundled-layer channels `422` parity.
+- `tests/contract/test_route_fidelity.py::test_b21_channels_route_mounted_and_runtime_openapi_converged` previously asserted source/runtime/types but not bundled channels `422` parity.
+
+3. Typegen-from-bundle pathway existed but was under-enforced in P3 lock.
+- `scripts/contracts/generate_frontend_types.sh` already generates `attribution.ts` from `attribution.bundled.yaml`.
+- P3 enforcer lacked explicit fail-closed assertions for this path.
+
+### 8.2 Remediations
+
+1. P3 lock enforcer now includes bundled-artifact channels 422 governance.
+- Added bundled contract authority input:
+  - `api-contracts/dist/openapi/v1/attribution.bundled.yaml`
+- Enforced on bundled `/api/attribution/channels`:
+  - operation exists,
+  - required query params `model_type` + `recompute_job_id` remain required,
+  - forbidden params `start_date` / `end_date` absent,
+  - `422` response exists,
+  - `ATTRIBUTION_WINDOW_OUT_OF_RANGE` token present.
+
+2. P3 lock enforcer now includes explicit typegen pipeline authority checks.
+- Added enforcement for:
+  - `scripts/contracts/generate_frontend_types.sh` canonical bundle input path (`api-contracts/dist/openapi/v1`),
+  - `generate "attribution.bundled.yaml" "attribution.ts"` token,
+  - canonical bundle production token in `scripts/contracts/bundle.sh`,
+  - attribution source/bundle mapping in `scripts/contracts/entrypoints.json`.
+
+3. Non-vacuous negative controls extended for remaining blocker.
+- Added failing negative control when bundled `422` is removed.
+- Added failing negative control when typegen is changed away from bundled attribution input.
+
+4. Route-fidelity contract convergence extended to bundled layer.
+- `test_b21_channels_route_mounted_and_runtime_openapi_converged` now explicitly validates bundled channels operation parity for:
+  - operationId,
+  - required query params,
+  - `422` response presence,
+  - `ATTRIBUTION_WINDOW_OUT_OF_RANGE` example code parity with source contract.
+
+### 8.3 Validation (Local)
+
+Executed from `C:\Users\ayewhy\II SKELDIR II`:
+
+1. `python scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py`  
+Result: `PASS`
+
+2. `python -m pytest backend/tests/test_b21_p3_persistence_read_surface_lock_enforcer.py -q`  
+Result: `10 passed`
+
+3. `python -m pytest tests/contract/test_route_fidelity.py -q`  
+Result: `7 passed`
+
+### 8.4 Files Changed in Iteration 2
+
+- `scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py`
+- `backend/tests/test_b21_p3_persistence_read_surface_lock_enforcer.py`
+- `tests/contract/test_route_fidelity.py`
+- `docs/forensics/B2.1-P3 Remediation Evidence Pack.md`

--- a/scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py
+++ b/scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py
@@ -18,7 +18,11 @@ TASK_FILE = "backend/app/tasks/attribution.py"
 API_FILE = "backend/app/api/attribution.py"
 SCHEMA_FILE = "backend/app/schemas/attribution.py"
 CONTRACT_FILE = "api-contracts/openapi/v1/attribution.yaml"
+BUNDLED_CONTRACT_FILE = "api-contracts/dist/openapi/v1/attribution.bundled.yaml"
 FRONTEND_TYPES_FILE = "frontend/src/types/api/attribution.ts"
+FRONTEND_TYPEGEN_SCRIPT_FILE = "scripts/contracts/generate_frontend_types.sh"
+CONTRACT_BUNDLE_SCRIPT_FILE = "scripts/contracts/bundle.sh"
+CONTRACT_ENTRYPOINTS_FILE = "scripts/contracts/entrypoints.json"
 RUNTIME_PROOF_FILE = "backend/tests/integration/test_b21_p3_persistence_read_surface_runtime.py"
 CANONICAL_SCHEMA_FILE = "db/schema/canonical_schema.sql"
 TRIGGER_ALIGNMENT_MIGRATION_FILE = (
@@ -61,7 +65,11 @@ def run_enforcement(
     api_file: Path,
     schema_file: Path,
     contract_file: Path,
+    bundled_contract_file: Path,
     frontend_types_file: Path,
+    frontend_typegen_script_file: Path,
+    contract_bundle_script_file: Path,
+    contract_entrypoints_file: Path,
     runtime_proof_file: Path,
     canonical_schema_file: Path,
     trigger_alignment_migration_file: Path,
@@ -75,7 +83,11 @@ def run_enforcement(
         api_file,
         schema_file,
         contract_file,
+        bundled_contract_file,
         frontend_types_file,
+        frontend_typegen_script_file,
+        contract_bundle_script_file,
+        contract_entrypoints_file,
         runtime_proof_file,
         canonical_schema_file,
         trigger_alignment_migration_file,
@@ -92,8 +104,13 @@ def run_enforcement(
     api_text = _read_text(api_file)
     schema_text = _read_text(schema_file)
     contract_text = _read_text(contract_file)
+    bundled_contract_text = _read_text(bundled_contract_file)
     frontend_types_text = _read_text(frontend_types_file)
+    frontend_typegen_script_text = _read_text(frontend_typegen_script_file)
+    contract_bundle_script_text = _read_text(contract_bundle_script_file)
     contract_doc = _load_openapi(contract_file)
+    bundled_contract_doc = _load_openapi(bundled_contract_file)
+    contract_entrypoints = _read_json(contract_entrypoints_file)
     runtime_text = _read_text(runtime_proof_file)
     canonical_schema_text = _read_text(canonical_schema_file)
     trigger_alignment_migration_text = _read_text(trigger_alignment_migration_file)
@@ -214,6 +231,51 @@ def run_enforcement(
     if "422" not in responses:
         violations.append("contract_missing_channels_422_response")
 
+    bundled_channels_get = (
+        bundled_contract_doc.get("paths", {})
+        .get("/api/attribution/channels", {})
+        .get("get", {})
+    )
+    if not isinstance(bundled_channels_get, dict):
+        violations.append("bundled_contract_missing_channels_get_operation")
+        bundled_channels_get = {}
+
+    bundled_parameters = bundled_channels_get.get("parameters", [])
+    if not isinstance(bundled_parameters, list):
+        violations.append("bundled_contract_channels_parameters_invalid")
+        bundled_parameters = []
+
+    bundled_query_params: dict[str, dict[str, Any]] = {}
+    for item in bundled_parameters:
+        if not isinstance(item, dict):
+            continue
+        if item.get("in") != "query":
+            continue
+        name = item.get("name")
+        if isinstance(name, str):
+            bundled_query_params[name] = item
+
+    for required_query_param in ("model_type", "recompute_job_id"):
+        param = bundled_query_params.get(required_query_param)
+        if not isinstance(param, dict):
+            violations.append(f"bundled_contract_missing_required_query_param:{required_query_param}")
+            continue
+        if param.get("required") is not True:
+            violations.append(f"bundled_contract_query_param_not_required:{required_query_param}")
+
+    for forbidden_query_param in ("start_date", "end_date"):
+        if forbidden_query_param in bundled_query_params:
+            violations.append(f"bundled_contract_forbidden_query_param_present:{forbidden_query_param}")
+
+    bundled_responses = bundled_channels_get.get("responses", {})
+    if not isinstance(bundled_responses, dict):
+        violations.append("bundled_contract_channels_responses_invalid")
+        bundled_responses = {}
+    if "422" not in bundled_responses:
+        violations.append("bundled_contract_missing_channels_422_response")
+    if "ATTRIBUTION_WINDOW_OUT_OF_RANGE" not in bundled_contract_text:
+        violations.append("bundled_contract_missing_window_out_of_range_code")
+
     if not re.search(
         r"getChannelAttribution:\s*\{[\s\S]*?responses:\s*\{[\s\S]*?\b422:\s*\{",
         frontend_types_text,
@@ -221,6 +283,42 @@ def run_enforcement(
         violations.append("frontend_types_missing_channels_422_response")
     if "ATTRIBUTION_WINDOW_OUT_OF_RANGE" not in frontend_types_text:
         violations.append("frontend_types_missing_window_out_of_range_code")
+
+    required_typegen_tokens = (
+        'RELATIVE_BUNDLES_DIR="api-contracts/dist/openapi/v1"',
+        'generate "attribution.bundled.yaml" "attribution.ts"',
+        '"$OPENAPI_TYPESCRIPT_BIN" "$input_path" -o "$output_path"',
+    )
+    for token in required_typegen_tokens:
+        if token not in frontend_typegen_script_text:
+            violations.append(f"frontend_typegen_script_missing_token:{token}")
+
+    required_bundle_script_tokens = (
+        'bundle_one "$REDOCLY_BIN" attribution dist/openapi/v1/attribution.bundled.yaml',
+    )
+    for token in required_bundle_script_tokens:
+        if token not in contract_bundle_script_text:
+            violations.append(f"bundle_script_missing_token:{token}")
+
+    entrypoints = contract_entrypoints.get("entrypoints", [])
+    if not isinstance(entrypoints, list):
+        violations.append("contract_entrypoints_invalid")
+        entrypoints = []
+    attribution_entry = next(
+        (
+            item
+            for item in entrypoints
+            if isinstance(item, dict) and item.get("id") == "attribution"
+        ),
+        None,
+    )
+    if not isinstance(attribution_entry, dict):
+        violations.append("contract_entrypoints_missing_attribution_entry")
+    else:
+        if attribution_entry.get("source") != "api-contracts/openapi/v1/attribution.yaml":
+            violations.append("contract_entrypoints_attribution_source_mismatch")
+        if attribution_entry.get("bundle") != "api-contracts/dist/openapi/v1/attribution.bundled.yaml":
+            violations.append("contract_entrypoints_attribution_bundle_mismatch")
 
     required_runtime_tokens = (
         "test_b21_p3_channels_endpoint_reads_projection_without_recompute_and_preserves_decimal_strings",
@@ -301,7 +399,11 @@ def main(argv: list[str]) -> int:
     parser.add_argument("--api-file", default=API_FILE)
     parser.add_argument("--schema-file", default=SCHEMA_FILE)
     parser.add_argument("--contract-file", default=CONTRACT_FILE)
+    parser.add_argument("--bundled-contract-file", default=BUNDLED_CONTRACT_FILE)
     parser.add_argument("--frontend-types-file", default=FRONTEND_TYPES_FILE)
+    parser.add_argument("--frontend-typegen-script-file", default=FRONTEND_TYPEGEN_SCRIPT_FILE)
+    parser.add_argument("--contract-bundle-script-file", default=CONTRACT_BUNDLE_SCRIPT_FILE)
+    parser.add_argument("--contract-entrypoints-file", default=CONTRACT_ENTRYPOINTS_FILE)
     parser.add_argument("--runtime-proof-file", default=RUNTIME_PROOF_FILE)
     parser.add_argument("--canonical-schema-file", default=CANONICAL_SCHEMA_FILE)
     parser.add_argument(
@@ -328,7 +430,11 @@ def main(argv: list[str]) -> int:
         api_file=_resolve(repo_root, args.api_file),
         schema_file=_resolve(repo_root, args.schema_file),
         contract_file=_resolve(repo_root, args.contract_file),
+        bundled_contract_file=_resolve(repo_root, args.bundled_contract_file),
         frontend_types_file=_resolve(repo_root, args.frontend_types_file),
+        frontend_typegen_script_file=_resolve(repo_root, args.frontend_typegen_script_file),
+        contract_bundle_script_file=_resolve(repo_root, args.contract_bundle_script_file),
+        contract_entrypoints_file=_resolve(repo_root, args.contract_entrypoints_file),
         runtime_proof_file=_resolve(repo_root, args.runtime_proof_file),
         canonical_schema_file=_resolve(repo_root, args.canonical_schema_file),
         trigger_alignment_migration_file=_resolve(

--- a/tests/contract/test_route_fidelity.py
+++ b/tests/contract/test_route_fidelity.py
@@ -494,12 +494,54 @@ def test_b21_channels_route_mounted_and_runtime_openapi_converged():
     )
     with open(attribution_source, "r", encoding="utf-8") as handle:
         source_doc = yaml.safe_load(handle) or {}
+    attribution_bundle = (
+        Path(__file__).parent.parent.parent
+        / "api-contracts"
+        / "dist"
+        / "openapi"
+        / "v1"
+        / "attribution.bundled.yaml"
+    )
+    with open(attribution_bundle, "r", encoding="utf-8") as handle:
+        bundled_doc = yaml.safe_load(handle) or {}
 
     canonical_path = "/api/attribution/channels"
     source_operation = source_doc.get("paths", {}).get(canonical_path, {}).get("get", {})
     assert source_operation.get("operationId") == "getChannelAttribution"
     source_responses = source_operation.get("responses", {})
     assert "422" in source_responses
+    source_422_example_code = (
+        source_responses.get("422", {})
+        .get("content", {})
+        .get("application/problem+json", {})
+        .get("example", {})
+        .get("code")
+    )
+    assert source_422_example_code == "ATTRIBUTION_WINDOW_OUT_OF_RANGE"
+    bundle_operation = bundled_doc.get("paths", {}).get(canonical_path, {}).get("get", {})
+    assert bundle_operation.get("operationId") == "getChannelAttribution"
+    bundle_query_params = {
+        item.get("name"): item
+        for item in bundle_operation.get("parameters", [])
+        if item.get("in") == "query"
+    }
+    assert "model_type" in bundle_query_params
+    assert "recompute_job_id" in bundle_query_params
+    assert bundle_query_params["model_type"].get("required") is True
+    assert bundle_query_params["recompute_job_id"].get("required") is True
+    assert "start_date" not in bundle_query_params
+    assert "end_date" not in bundle_query_params
+    bundle_responses = bundle_operation.get("responses", {})
+    assert "422" in bundle_responses
+    bundle_422_example_code = (
+        bundle_responses.get("422", {})
+        .get("content", {})
+        .get("application/problem+json", {})
+        .get("example", {})
+        .get("code")
+    )
+    assert bundle_422_example_code == "ATTRIBUTION_WINDOW_OUT_OF_RANGE"
+    assert bundle_422_example_code == source_422_example_code
     b21_lock = source_operation.get("x-skeldir-b21-p0", {})
     assert b21_lock.get("implementation_status") == "mounted_deterministic_channels_surface"
 


### PR DESCRIPTION
## Summary
- enforce bundled attribution contract parity for /api/attribution/channels 422 path in the B2.1-P3 lock enforcer
- enforce canonical typegen authority from bundled attribution artifact (ttribution.bundled.yaml)
- add non-vacuous negative controls for bundled-422 drift and typegen-source drift
- extend route-fidelity channels gate to require source/runtime/bundle/generated 422 convergence
- update B2.1-P3 remediation evidence pack with investigation findings and remediations

## Validation
- python scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py
- python -m pytest backend/tests/test_b21_p3_persistence_read_surface_lock_enforcer.py -q
- python -m pytest tests/contract/test_route_fidelity.py -q
