### PR TITLE
R5: fix missing recompute_job_id in deterministic harness scripts

### DIFF
--- a/scripts/r5/r5_probes.py
+++ b/scripts/r5/r5_probes.py
@@ -28,7 +28,7 @@ from urllib.parse import urlsplit
 from uuid import NAMESPACE_URL, UUID, uuid5
 
 import asyncpg
-from sqlalchemy import event as sa_event
+from sqlalchemy import event as sa_event, text
 
 
 def _import_db_secret_access():
@@ -47,10 +47,9 @@ def _import_db_secret_access():
 resolve_runtime_database_url = _import_db_secret_access()
 
 # PYTHONPATH=backend
-from app.db.session import engine  # noqa: E402
+from app.db.session import engine, set_tenant_guc  # noqa: E402
 from app.tasks.attribution import (  # noqa: E402
     _compute_allocations_deterministic_baseline,
-    _upsert_job_identity,
 )
 
 
@@ -87,6 +86,14 @@ def _uuid_det(*parts: str) -> UUID:
 
 
 async def _ensure_recompute_job_id(*, tenant_id: UUID, window_start: datetime, window_end: datetime) -> UUID:
+    job_id = _uuid_det(
+        "r5",
+        "recompute_job",
+        str(tenant_id),
+        window_start.isoformat(),
+        window_end.isoformat(),
+        "1.0.0",
+    )
     correlation_id = str(
         _uuid_det(
             "r5",
@@ -97,14 +104,58 @@ async def _ensure_recompute_job_id(*, tenant_id: UUID, window_start: datetime, w
             "1.0.0",
         )
     )
-    job_id, _, _, _ = await _upsert_job_identity(
-        tenant_id=tenant_id,
-        window_start=window_start,
-        window_end=window_end,
-        model_version="1.0.0",
-        correlation_id=correlation_id,
-        replay_event_created_ceiling=window_end,
-    )
+    async with engine.begin() as conn:
+        await set_tenant_guc(conn, tenant_id, local=True)
+        await conn.execute(
+            text(
+                """
+                INSERT INTO attribution_recompute_jobs (
+                    id,
+                    tenant_id,
+                    window_start,
+                    window_end,
+                    model_version,
+                    status,
+                    run_count,
+                    last_correlation_id,
+                    replay_event_created_ceiling,
+                    created_at,
+                    updated_at,
+                    started_at
+                ) VALUES (
+                    :job_id,
+                    :tenant_id,
+                    :window_start,
+                    :window_end,
+                    :model_version,
+                    'running',
+                    1,
+                    :correlation_id,
+                    :replay_event_created_ceiling,
+                    CURRENT_TIMESTAMP,
+                    CURRENT_TIMESTAMP,
+                    CURRENT_TIMESTAMP
+                )
+                ON CONFLICT (tenant_id, window_start, window_end, model_version)
+                DO UPDATE SET
+                    status = 'running',
+                    run_count = attribution_recompute_jobs.run_count + 1,
+                    last_correlation_id = EXCLUDED.last_correlation_id,
+                    replay_event_created_ceiling = EXCLUDED.replay_event_created_ceiling,
+                    updated_at = CURRENT_TIMESTAMP,
+                    started_at = CURRENT_TIMESTAMP
+                """
+            ),
+            {
+                "job_id": str(job_id),
+                "tenant_id": str(tenant_id),
+                "window_start": window_start,
+                "window_end": window_end,
+                "model_version": "1.0.0",
+                "correlation_id": correlation_id,
+                "replay_event_created_ceiling": window_end,
+            },
+        )
     return job_id
 
 

--- a/scripts/r5/r5_probes.py
+++ b/scripts/r5/r5_probes.py
@@ -48,7 +48,10 @@ resolve_runtime_database_url = _import_db_secret_access()
 
 # PYTHONPATH=backend
 from app.db.session import engine  # noqa: E402
-from app.tasks.attribution import _compute_allocations_deterministic_baseline  # noqa: E402
+from app.tasks.attribution import (  # noqa: E402
+    _compute_allocations_deterministic_baseline,
+    _upsert_job_identity,
+)
 
 
 def _env(name: str, default: str | None = None) -> str:
@@ -83,15 +86,26 @@ def _uuid_det(*parts: str) -> UUID:
     return uuid5(NAMESPACE_URL, ":".join(parts))
 
 
-def _recompute_job_id_for_window(*, tenant_id: UUID, window_start: datetime, window_end: datetime) -> UUID:
-    return _uuid_det(
-        "r5",
-        "recompute_job",
-        str(tenant_id),
-        window_start.isoformat(),
-        window_end.isoformat(),
-        "1.0.0",
+async def _ensure_recompute_job_id(*, tenant_id: UUID, window_start: datetime, window_end: datetime) -> UUID:
+    correlation_id = str(
+        _uuid_det(
+            "r5",
+            "correlation",
+            str(tenant_id),
+            window_start.isoformat(),
+            window_end.isoformat(),
+            "1.0.0",
+        )
     )
+    job_id, _, _, _ = await _upsert_job_identity(
+        tenant_id=tenant_id,
+        window_start=window_start,
+        window_end=window_end,
+        model_version="1.0.0",
+        correlation_id=correlation_id,
+        replay_event_created_ceiling=window_end,
+    )
+    return job_id
 
 
 def _sha256_hex(data: bytes) -> str:
@@ -409,7 +423,7 @@ async def _run_compute_with_count(
     window_start: datetime,
     window_end: datetime,
 ) -> dict[str, Any]:
-    recompute_job_id = _recompute_job_id_for_window(
+    recompute_job_id = await _ensure_recompute_job_id(
         tenant_id=tenant_id,
         window_start=window_start,
         window_end=window_end,

--- a/scripts/r5/r5_probes.py
+++ b/scripts/r5/r5_probes.py
@@ -83,6 +83,17 @@ def _uuid_det(*parts: str) -> UUID:
     return uuid5(NAMESPACE_URL, ":".join(parts))
 
 
+def _recompute_job_id_for_window(*, tenant_id: UUID, window_start: datetime, window_end: datetime) -> UUID:
+    return _uuid_det(
+        "r5",
+        "recompute_job",
+        str(tenant_id),
+        window_start.isoformat(),
+        window_end.isoformat(),
+        "1.0.0",
+    )
+
+
 def _sha256_hex(data: bytes) -> str:
     return hashlib.sha256(data).hexdigest()
 
@@ -398,12 +409,21 @@ async def _run_compute_with_count(
     window_start: datetime,
     window_end: datetime,
 ) -> dict[str, Any]:
+    recompute_job_id = _recompute_job_id_for_window(
+        tenant_id=tenant_id,
+        window_start=window_start,
+        window_end=window_end,
+    )
     counter = StatementCounter()
     sa_event.listen(engine.sync_engine, "before_cursor_execute", counter.before_cursor_execute)
     t0 = time.perf_counter()
     try:
         meta = await _compute_allocations_deterministic_baseline(
-            tenant_id=tenant_id, window_start=window_start, window_end=window_end, model_version="1.0.0"
+            tenant_id=tenant_id,
+            window_start=window_start,
+            window_end=window_end,
+            recompute_job_id=recompute_job_id,
+            model_version="1.0.0",
         )
     finally:
         t1 = time.perf_counter()

--- a/scripts/r5/r5_verification.py
+++ b/scripts/r5/r5_verification.py
@@ -33,7 +33,10 @@ from sqlalchemy import event as sa_event
 
 # PYTHONPATH=backend
 from app.db.session import engine  # noqa: E402
-from app.tasks.attribution import _compute_allocations_deterministic_baseline  # noqa: E402
+from app.tasks.attribution import (  # noqa: E402
+    _compute_allocations_deterministic_baseline,
+    _upsert_job_identity,
+)
 
 
 def _env(name: str, default: str | None = None) -> str:
@@ -103,21 +106,32 @@ def _ru_maxrss_kb() -> int:
     return int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
 
 
-def _recompute_job_id_for_window(
+async def _ensure_recompute_job_id(
     *,
     tenant_id: UUID,
     window_start: datetime,
     window_end: datetime,
     model_version: str,
 ) -> UUID:
-    return _uuid_det(
-        "r5",
-        "recompute_job",
-        str(tenant_id),
-        window_start.isoformat(),
-        window_end.isoformat(),
-        model_version,
+    correlation_id = str(
+        _uuid_det(
+            "r5",
+            "correlation",
+            str(tenant_id),
+            window_start.isoformat(),
+            window_end.isoformat(),
+            model_version,
+        )
     )
+    job_id, _, _, _ = await _upsert_job_identity(
+        tenant_id=tenant_id,
+        window_start=window_start,
+        window_end=window_end,
+        model_version=model_version,
+        correlation_id=correlation_id,
+        replay_event_created_ceiling=window_end,
+    )
+    return job_id
 
 
 class StatementCounter:
@@ -584,12 +598,14 @@ async def _run_compute_with_count(
     model_version: str,
     recompute_job_id: UUID | None = None,
 ) -> dict[str, Any]:
-    effective_recompute_job_id = recompute_job_id or _recompute_job_id_for_window(
-        tenant_id=tenant_id,
-        window_start=window_start,
-        window_end=window_end,
-        model_version=model_version,
-    )
+    effective_recompute_job_id = recompute_job_id
+    if effective_recompute_job_id is None:
+        effective_recompute_job_id = await _ensure_recompute_job_id(
+            tenant_id=tenant_id,
+            window_start=window_start,
+            window_end=window_end,
+            model_version=model_version,
+        )
     counter = StatementCounter()
     sa_event.listen(engine.sync_engine, "before_cursor_execute", counter.before_cursor_execute)
     t0 = time.perf_counter()
@@ -620,7 +636,7 @@ async def _run_compute_concurrency(
     model_version: str,
     concurrency: int,
 ) -> dict[str, Any]:
-    recompute_job_id = _recompute_job_id_for_window(
+    recompute_job_id = await _ensure_recompute_job_id(
         tenant_id=tenant_id,
         window_start=window_start,
         window_end=window_end,
@@ -905,7 +921,7 @@ async def main() -> int:
         )
         expected_binding = _enforce_binding("retry_injected", binding, expected_binding)
         print("R5_RUN_MODE=retry_injected R5_RETRY_ATTEMPT=1")
-        retry_recompute_job_id = _recompute_job_id_for_window(
+        retry_recompute_job_id = await _ensure_recompute_job_id(
             tenant_id=tenant_det,
             window_start=window_start,
             window_end=window_end,

--- a/scripts/r5/r5_verification.py
+++ b/scripts/r5/r5_verification.py
@@ -29,13 +29,12 @@ from urllib.parse import urlsplit
 from uuid import NAMESPACE_URL, UUID, uuid5
 
 import asyncpg
-from sqlalchemy import event as sa_event
+from sqlalchemy import event as sa_event, text
 
 # PYTHONPATH=backend
-from app.db.session import engine  # noqa: E402
+from app.db.session import engine, set_tenant_guc  # noqa: E402
 from app.tasks.attribution import (  # noqa: E402
     _compute_allocations_deterministic_baseline,
-    _upsert_job_identity,
 )
 
 
@@ -113,6 +112,14 @@ async def _ensure_recompute_job_id(
     window_end: datetime,
     model_version: str,
 ) -> UUID:
+    job_id = _uuid_det(
+        "r5",
+        "recompute_job",
+        str(tenant_id),
+        window_start.isoformat(),
+        window_end.isoformat(),
+        model_version,
+    )
     correlation_id = str(
         _uuid_det(
             "r5",
@@ -123,14 +130,58 @@ async def _ensure_recompute_job_id(
             model_version,
         )
     )
-    job_id, _, _, _ = await _upsert_job_identity(
-        tenant_id=tenant_id,
-        window_start=window_start,
-        window_end=window_end,
-        model_version=model_version,
-        correlation_id=correlation_id,
-        replay_event_created_ceiling=window_end,
-    )
+    async with engine.begin() as conn:
+        await set_tenant_guc(conn, tenant_id, local=True)
+        await conn.execute(
+            text(
+                """
+                INSERT INTO attribution_recompute_jobs (
+                    id,
+                    tenant_id,
+                    window_start,
+                    window_end,
+                    model_version,
+                    status,
+                    run_count,
+                    last_correlation_id,
+                    replay_event_created_ceiling,
+                    created_at,
+                    updated_at,
+                    started_at
+                ) VALUES (
+                    :job_id,
+                    :tenant_id,
+                    :window_start,
+                    :window_end,
+                    :model_version,
+                    'running',
+                    1,
+                    :correlation_id,
+                    :replay_event_created_ceiling,
+                    CURRENT_TIMESTAMP,
+                    CURRENT_TIMESTAMP,
+                    CURRENT_TIMESTAMP
+                )
+                ON CONFLICT (tenant_id, window_start, window_end, model_version)
+                DO UPDATE SET
+                    status = 'running',
+                    run_count = attribution_recompute_jobs.run_count + 1,
+                    last_correlation_id = EXCLUDED.last_correlation_id,
+                    replay_event_created_ceiling = EXCLUDED.replay_event_created_ceiling,
+                    updated_at = CURRENT_TIMESTAMP,
+                    started_at = CURRENT_TIMESTAMP
+                """
+            ),
+            {
+                "job_id": str(job_id),
+                "tenant_id": str(tenant_id),
+                "window_start": window_start,
+                "window_end": window_end,
+                "model_version": model_version,
+                "correlation_id": correlation_id,
+                "replay_event_created_ceiling": window_end,
+            },
+        )
     return job_id
 
 

--- a/scripts/r5/r5_verification.py
+++ b/scripts/r5/r5_verification.py
@@ -103,6 +103,23 @@ def _ru_maxrss_kb() -> int:
     return int(resource.getrusage(resource.RUSAGE_SELF).ru_maxrss)
 
 
+def _recompute_job_id_for_window(
+    *,
+    tenant_id: UUID,
+    window_start: datetime,
+    window_end: datetime,
+    model_version: str,
+) -> UUID:
+    return _uuid_det(
+        "r5",
+        "recompute_job",
+        str(tenant_id),
+        window_start.isoformat(),
+        window_end.isoformat(),
+        model_version,
+    )
+
+
 class StatementCounter:
     def __init__(self) -> None:
         self.count = 0
@@ -565,7 +582,14 @@ async def _run_compute_with_count(
     window_start: datetime,
     window_end: datetime,
     model_version: str,
+    recompute_job_id: UUID | None = None,
 ) -> dict[str, Any]:
+    effective_recompute_job_id = recompute_job_id or _recompute_job_id_for_window(
+        tenant_id=tenant_id,
+        window_start=window_start,
+        window_end=window_end,
+        model_version=model_version,
+    )
     counter = StatementCounter()
     sa_event.listen(engine.sync_engine, "before_cursor_execute", counter.before_cursor_execute)
     t0 = time.perf_counter()
@@ -574,6 +598,7 @@ async def _run_compute_with_count(
             tenant_id=tenant_id,
             window_start=window_start,
             window_end=window_end,
+            recompute_job_id=effective_recompute_job_id,
             model_version=model_version,
         )
     finally:
@@ -595,6 +620,12 @@ async def _run_compute_concurrency(
     model_version: str,
     concurrency: int,
 ) -> dict[str, Any]:
+    recompute_job_id = _recompute_job_id_for_window(
+        tenant_id=tenant_id,
+        window_start=window_start,
+        window_end=window_end,
+        model_version=model_version,
+    )
     counter = StatementCounter()
     sa_event.listen(engine.sync_engine, "before_cursor_execute", counter.before_cursor_execute)
     t0 = time.perf_counter()
@@ -605,6 +636,7 @@ async def _run_compute_concurrency(
                 tenant_id=tenant_id,
                 window_start=window_start,
                 window_end=window_end,
+                recompute_job_id=recompute_job_id,
                 model_version=model_version,
             )
             finished = time.perf_counter()
@@ -873,11 +905,18 @@ async def main() -> int:
         )
         expected_binding = _enforce_binding("retry_injected", binding, expected_binding)
         print("R5_RUN_MODE=retry_injected R5_RETRY_ATTEMPT=1")
+        retry_recompute_job_id = _recompute_job_id_for_window(
+            tenant_id=tenant_det,
+            window_start=window_start,
+            window_end=window_end,
+            model_version=model_version,
+        )
         try:
             await _compute_allocations_deterministic_baseline(
                 tenant_id=tenant_det,
                 window_start=window_start,
                 window_end=window_end,
+                recompute_job_id=retry_recompute_job_id,
                 model_version=model_version,
                 inject_fail_once_key=f"r5:{candidate_sha}:DET_SHARED",
                 inject_fail_after_batches=1,


### PR DESCRIPTION
## Summary
- fix `scripts/r5/r5_verification.py` to pass deterministic `recompute_job_id` on every direct baseline compute call
- fix `scripts/r5/r5_probes.py` to pass deterministic `recompute_job_id` for probe compute calls
- preserve deterministic hash semantics by deriving a stable job id from tenant/window/model version

## Root cause
`_compute_allocations_deterministic_baseline(...)` now requires `recompute_job_id`, but R5 harness scripts still called it without that argument. This caused `TypeError` in `R7: Final Winning State` (R5 phase) on main.

## Validation
- `python -m py_compile scripts/r5/r5_verification.py scripts/r5/r5_probes.py`
- CI run on this PR (expected): `R7: Final Winning State` succeeds