### PR TITLE
Fix B1.5-P3 negative-control YAML mutation for main CI stability

### DIFF
--- a/backend/tests/test_b15_p3_runtime_route_binding_enforcer.py
+++ b/backend/tests/test_b15_p3_runtime_route_binding_enforcer.py
@@ -6,6 +6,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+import yaml
+
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
@@ -40,16 +42,17 @@ def test_b15_p3_enforcer_negative_control_synthetic_regression() -> None:
 
 
 def test_b15_p3_enforcer_negative_control_skip_allowlist_regression(tmp_path: Path) -> None:
-    original_skip = (
+    original_skip_text = (
         _repo_root() / "tests" / "contract" / "semantics_skip_allowlist.yaml"
     ).read_text(encoding="utf-8")
+    original_skip = yaml.safe_load(original_skip_text) or {}
+    bundles = original_skip.get("bundles")
+    if not isinstance(bundles, dict):
+        bundles = {}
+    bundles["llm-investigations.bundled.yaml"] = "regression"
+    original_skip["bundles"] = bundles
     mutated_skip = tmp_path / "semantics_skip_allowlist.regression.yaml"
-    mutated_skip.write_text(
-        original_skip
-        + "\n"
-        + "  llm-investigations.bundled.yaml: \"regression\"\n",
-        encoding="utf-8",
-    )
+    mutated_skip.write_text(yaml.safe_dump(original_skip, sort_keys=False), encoding="utf-8")
     result = subprocess.run(
         [
             sys.executable,


### PR DESCRIPTION
## Summary
- make `test_b15_p3_enforcer_negative_control_skip_allowlist_regression` mutate YAML structurally instead of appending brittle text
- keep the negative-control assertion unchanged (`semantics_allowlist_still_skips_bundle`)
- restore compatibility after `tests/contract/semantics_skip_allowlist.yaml` moved to `bundles: {}`

## Validation
- `pytest backend/tests/test_b15_p3_runtime_route_binding_enforcer.py -q`