### PR TITLE
CI follow-up: scope confidence_score invariant exception to attribution precision transport

### DIFF
--- a/api-contracts/governance/invariants.yaml
+++ b/api-contracts/governance/invariants.yaml
@@ -42,6 +42,16 @@ domain_invariants:
       - contract: "Future attribution endpoints (B2.4+)"
       - pydantic: "Field validator with range check"
       - tests: "Boundary testing at 0, 0.5, 1, and invalid values"
+    exceptions:
+      - platform: "attribution"
+        path_pattern: "^ChannelAttribution\\.confidence_score$"
+        type: string
+        pattern: "^(0|1)\\.\\d{3}$"
+        unset:
+          - format
+          - minimum
+          - maximum
+        rationale: "B2.1/B2.2 attribution channel projection uses deterministic decimal-string precision transport (scale=3)."
   
   credible_interval_lower:
     type: number

--- a/scripts/governance/validate_invariants.py
+++ b/scripts/governance/validate_invariants.py
@@ -94,7 +94,11 @@ def find_nested_fields(properties: Dict, parent_path: str) -> List[Tuple[str, Di
     
     return fields
 
-def apply_invariant_exceptions(invariant_def: Dict, contract_name: str) -> Dict:
+def apply_invariant_exceptions(
+    invariant_def: Dict,
+    contract_name: str,
+    field_path: str | None = None,
+) -> Dict:
     """Return invariant definition adjusted for contract-specific exceptions."""
     # Copy base definition excluding exceptions metadata
     effective_def = {
@@ -107,12 +111,23 @@ def apply_invariant_exceptions(invariant_def: Dict, contract_name: str) -> Dict:
     
     for exception in exceptions:
         platform = exception.get('platform')
-        if platform and platform.lower() in contract_name_lower:
-            for key, value in exception.items():
-                if key == 'platform':
-                    continue
-                effective_def[key] = value
-            break
+        if platform and platform.lower() not in contract_name_lower:
+            continue
+
+        path_pattern = exception.get('path_pattern')
+        if path_pattern and field_path:
+            if not re.search(path_pattern, field_path):
+                continue
+        elif path_pattern and not field_path:
+            continue
+
+        for key, value in exception.items():
+            if key in {'platform', 'path_pattern'}:
+                continue
+            effective_def[key] = value
+        for key_to_remove in exception.get('unset', []):
+            effective_def.pop(key_to_remove, None)
+        break
     
     return effective_def
 
@@ -246,7 +261,7 @@ def validate_invariants(repo_root: Path, verbose: bool = False) -> Tuple[bool, L
                     stats['invariant_checks_performed'] += 1
                     
                     effective_invariant = apply_invariant_exceptions(
-                        invariant_def, contract_file.name
+                        invariant_def, contract_file.name, field_path
                     )
                     
                     field_violations = validate_field_against_invariant(


### PR DESCRIPTION
## Purpose
Restore full-green `main` CI after PR #352 merge by fixing a governance invariant mismatch detected in `API Contract Validation` on `main` push run `24633225021`.

## Root cause
`validate_invariants.py` applies contract-level exceptions uniformly by contract name.
`confidence_score` invariant expected `number` globally, while `ChannelAttribution.confidence_score` is intentionally `decimal_string_scale_3` in attribution precision transport.
A broad exception would incorrectly affect other attribution confidence fields that are numeric.

## Change
- `scripts/governance/validate_invariants.py`
  - Extended exception handling to support optional `path_pattern` and `unset` keys.
  - Applied exception overrides only when both contract and field path match.
- `api-contracts/governance/invariants.yaml`
  - Added a targeted exception for `confidence_score` scoped to:
    - `platform: attribution`
    - `path_pattern: ^ChannelAttribution\.confidence_score$`
    - `type: string`, `pattern: ^(0|1)\.\d{3}$`
    - `unset: [format, minimum, maximum]`

## Local verification
- `python scripts/governance/validate_invariants.py --json` -> success=true, violations=0
- `python scripts/governance/validate_coverage.py --verbose` -> OK
- `python scripts/ci/enforce_b22_p1_authenticity_semantics_lock.py` -> PASS

## Scope
No webhook/auth runtime behavior changes; this is a governance validation scoping fix only.