### PR TITLE
Regularize B2.2-P4 duplicate orchestration + ACK matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,7 @@ jobs:
       PYTHONPATH: ${{ github.workspace }}:${{ github.workspace }}/backend
       SKELDIR_B22_P2_REQUIRE_DB_PROOFS: "1"
       SKELDIR_B22_P3_REQUIRE_DB_PROOFS: "1"
+      SKELDIR_B22_P4_REQUIRE_DB_PROOFS: "1"
       TESTING: "1"
       CI: "true"
     steps:
@@ -270,6 +271,18 @@ jobs:
       - name: Run B2.2-P3 canonical identity envelope runtime proofs
         run: |
           pytest backend/tests/test_b22_p3_canonical_identity_envelope.py -q
+
+      - name: Enforce B2.2-P4 idempotent ACK + orchestration lock
+        run: |
+          python scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py
+
+      - name: Run B2.2-P4 idempotent ACK + orchestration negative controls
+        run: |
+          pytest backend/tests/test_b22_p4_idempotent_ack_orchestration_enforcer.py -q
+
+      - name: Run B2.2-P4 idempotent ACK + orchestration runtime proofs
+        run: |
+          pytest backend/tests/test_b22_p4_idempotent_ack_orchestration.py -q
 
       - name: Enforce contract semantic drift gate
         run: |

--- a/backend/app/ingestion/event_service.py
+++ b/backend/app/ingestion/event_service.py
@@ -9,8 +9,10 @@ B0.4.4 Enhancement: Integrated DLQHandler with error classification and retry lo
 
 import logging
 import hashlib
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from decimal import Decimal, InvalidOperation
+from enum import Enum
 import time
 from typing import Any, Dict, Mapping, Optional
 from uuid import UUID, uuid4
@@ -89,6 +91,25 @@ class ValidationError(Exception):
 
 class AuthoritativeIngressInvariantError(RuntimeError):
     """Raised when authoritative webhook ingress substrate invariants are violated."""
+
+
+class IngestionResultState(str, Enum):
+    """Canonical ingestion outcomes surfaced to orchestration callers."""
+
+    INSERTED = "inserted"
+    DUPLICATE = "duplicate"
+
+
+@dataclass(frozen=True)
+class IngestionDecision:
+    """Explicit ingestion decision contract for orchestration boundaries."""
+
+    event: AttributionEvent
+    state: IngestionResultState
+
+    @property
+    def is_duplicate(self) -> bool:
+        return self.state == IngestionResultState.DUPLICATE
 
 
 def _first_non_empty_resolution_token(*values: Any) -> str | None:
@@ -383,7 +404,7 @@ class EventIngestionService:
         """Initialize service with DLQ handler."""
         self.dlq_handler = DLQHandler()
 
-    async def ingest_event(
+    async def ingest_event_with_decision(
         self,
         session: AsyncSession,
         tenant_id: UUID,
@@ -392,7 +413,7 @@ class EventIngestionService:
         source: str = "webhook",
         identity_payload: Mapping[str, Any] | None = None,
         request_headers: Mapping[str, str] | None = None,
-    ) -> AttributionEvent:
+    ) -> IngestionDecision:
         """
         Ingest event with idempotency guarantee and validation.
 
@@ -404,7 +425,7 @@ class EventIngestionService:
             source: Event source identifier (e.g., 'shopify', 'stripe')
 
         Returns:
-            AttributionEvent instance (new or existing if duplicate)
+            IngestionDecision with event + explicit duplicate/inserted state.
 
         Raises:
             ValidationError: Event data fails schema validation (routes to DLQ)
@@ -449,7 +470,6 @@ class EventIngestionService:
         # 1. Idempotency check - return existing event if duplicate
         existing = await self._check_duplicate(session, tenant_id, idempotency_key)
         if existing:
-            setattr(existing, "_ingestion_duplicate", True)
             await upsert_ephemeral_resolution_links(
                 session=session,
                 tenant_id=tenant_id,
@@ -472,7 +492,10 @@ class EventIngestionService:
             )
             # B0.5.6.3: No labels on event metrics (bounded cardinality)
             events_duplicate_total.inc()
-            return existing
+            return IngestionDecision(
+                event=existing,
+                state=IngestionResultState.DUPLICATE,
+            )
 
         session_resolution = await resolve_session_authority(
             session=session,
@@ -587,8 +610,10 @@ class EventIngestionService:
             # B0.5.6.3: No labels on event metrics (bounded cardinality)
             events_ingested_total.inc()
             ingestion_duration_seconds.observe(duration)
-            setattr(event, "_ingestion_duplicate", False)
-            return event
+            return IngestionDecision(
+                event=event,
+                state=IngestionResultState.INSERTED,
+            )
 
         except ValidationError as e:
             # Route validation failures to dead-letter queue
@@ -632,7 +657,6 @@ class EventIngestionService:
                 session, tenant_id=tenant_id, idempotency_key=idempotency_key
             )
             if existing_after_race:
-                setattr(existing_after_race, "_ingestion_duplicate", True)
                 logger.info(
                     "duplicate_event_detected_race",
                     extra={
@@ -647,7 +671,10 @@ class EventIngestionService:
                 )
                 # B0.5.6.3: No labels on event metrics (bounded cardinality)
                 events_duplicate_total.inc()
-                return existing_after_race
+                return IngestionDecision(
+                    event=existing_after_race,
+                    state=IngestionResultState.DUPLICATE,
+                )
 
             raise
         except ProgrammingError as e:
@@ -657,6 +684,30 @@ class EventIngestionService:
                     f"(source={source}, tenant_id={tenant_id}, idempotency_key={idempotency_key})."
                 ) from e
             raise
+
+    async def ingest_event(
+        self,
+        session: AsyncSession,
+        tenant_id: UUID,
+        event_data: dict,
+        idempotency_key: str,
+        source: str = "webhook",
+        identity_payload: Mapping[str, Any] | None = None,
+        request_headers: Mapping[str, str] | None = None,
+    ) -> AttributionEvent:
+        """
+        Backward-compatible API returning only the ingestion event.
+        """
+        decision = await self.ingest_event_with_decision(
+            session=session,
+            tenant_id=tenant_id,
+            event_data=event_data,
+            idempotency_key=idempotency_key,
+            source=source,
+            identity_payload=identity_payload,
+            request_headers=request_headers,
+        )
+        return decision.event
 
     async def _check_duplicate(
         self, session: AsyncSession, tenant_id: UUID, idempotency_key: str
@@ -863,7 +914,7 @@ async def ingest_with_transaction(
     async with get_session(tenant_id=tenant_id) as session:
         try:
             service = EventIngestionService()
-            event = await service.ingest_event(
+            decision = await service.ingest_event_with_decision(
                 session=session,
                 tenant_id=tenant_id,
                 event_data=event_data,
@@ -872,6 +923,7 @@ async def ingest_with_transaction(
                 identity_payload=identity_payload,
                 request_headers=request_headers,
             )
+            event = decision.event
 
             # Commit handled by get_session context manager
             return {
@@ -880,7 +932,8 @@ async def ingest_with_transaction(
                 "session_id": str(event.session_id),
                 "channel": event.channel,
                 "idempotency_key": event.idempotency_key,
-                "is_duplicate": bool(getattr(event, "_ingestion_duplicate", False)),
+                "is_duplicate": decision.is_duplicate,
+                "ingestion_state": decision.state.value,
             }
 
         except ValidationError as e:
@@ -911,6 +964,7 @@ async def ingest_with_transaction(
                         "channel": existing.channel,
                         "idempotency_key": existing.idempotency_key,
                         "is_duplicate": True,
+                        "ingestion_state": IngestionResultState.DUPLICATE.value,
                     }
 
             # Database constraint violation (should be rare with validation)

--- a/backend/tests/test_b22_p4_idempotent_ack_orchestration.py
+++ b/backend/tests/test_b22_p4_idempotent_ack_orchestration.py
@@ -146,6 +146,7 @@ async def test_b22_p4_duplicate_replay_suppresses_downstream_tasks_for_all_suppo
     shopify_id = int(uuid4().int % 1_000_000)
     woo_id = int(uuid4().int % 1_000_000)
     stripe_pi_id = f"pi_{uuid4().hex[:12]}"
+    stripe_alias_pi_id = f"pi_{uuid4().hex[:12]}"
     stripe_event_id = f"evt_{uuid4().hex[:12]}"
     paypal_txn_id = f"txn_{uuid4().hex[:10]}"
 
@@ -174,7 +175,7 @@ async def test_b22_p4_duplicate_replay_suppresses_downstream_tasks_for_all_suppo
         {
             "id": stripe_event_id,
             "created": int(datetime.now(timezone.utc).timestamp()),
-            "data": {"object": {"id": stripe_pi_id, "amount": 5500, "currency": "usd"}},
+            "data": {"object": {"id": stripe_alias_pi_id, "amount": 5500, "currency": "usd"}},
         }
     ).encode()
     paypal_body = json.dumps(

--- a/backend/tests/test_b22_p4_idempotent_ack_orchestration.py
+++ b/backend/tests/test_b22_p4_idempotent_ack_orchestration.py
@@ -1,0 +1,482 @@
+from __future__ import annotations
+
+import asyncio
+import base64
+import hashlib
+import hmac
+import json
+import os
+from datetime import datetime, timezone
+from uuid import uuid4
+
+import asyncpg
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import func, select
+
+import app.api.webhooks as webhooks_api
+from app.core.secrets import get_database_url
+from app.db.session import get_session
+from app.main import app
+from app.models import AttributionEvent
+from tests.helpers.paypal_signature import build_paypal_auth_headers, install_paypal_cert_fetcher
+from tests.helpers.webhook_secret_seed import (
+    webhook_secret_insert_columns,
+    webhook_secret_insert_params,
+)
+
+
+def _require_authoritative_db_proofs() -> bool:
+    return os.getenv("SKELDIR_B22_P4_REQUIRE_DB_PROOFS", "0").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+@pytest_asyncio.fixture(scope="session")
+async def event_loop():
+    loop = asyncio.new_event_loop()
+    asyncio.set_event_loop(loop)
+    yield loop
+    loop.close()
+
+
+@pytest.fixture(autouse=True)
+def _paypal_signature_material(monkeypatch: pytest.MonkeyPatch) -> None:
+    install_paypal_cert_fetcher(monkeypatch)
+
+
+async def create_tenant_with_secrets():
+    tenant_id = uuid4()
+    api_key = f"b22_p4_api_key_{uuid4()}"
+    api_key_hash = hashlib.sha256(api_key.encode()).hexdigest()
+    secrets = {
+        "shopify_webhook_secret": "shopify_secret",
+        "stripe_webhook_secret": "stripe_secret",
+        "paypal_webhook_secret": "paypal_secret",
+        "woocommerce_webhook_secret": "woo_secret",
+    }
+    try:
+        conn = await asyncpg.connect(get_database_url())
+    except Exception as exc:
+        if _require_authoritative_db_proofs():
+            pytest.fail(f"B2.2-P4 authoritative runtime proof DB is unreachable: {exc}")
+        pytest.skip(f"B2.2-P4 runtime proofs require reachable Postgres: {exc}")
+    table_ready = await conn.fetchval(
+        """
+        SELECT EXISTS (
+            SELECT 1
+            FROM information_schema.tables
+            WHERE table_schema = 'public'
+              AND table_name = 'webhook_ingress_identities'
+        )
+        """
+    )
+    if not bool(table_ready):
+        await conn.close()
+        if _require_authoritative_db_proofs():
+            pytest.fail(
+                "B2.2-P4 authoritative runtime proof table webhook_ingress_identities is missing."
+            )
+        pytest.skip("B2.2-P4 runtime proofs require migrated webhook_ingress_identities table.")
+    secret_insert = webhook_secret_insert_params(
+        shopify_secret=secrets["shopify_webhook_secret"],
+        stripe_secret=secrets["stripe_webhook_secret"],
+        paypal_secret=secrets["paypal_webhook_secret"],
+        woocommerce_secret=secrets["woocommerce_webhook_secret"],
+    )
+    # RAW_SQL_ALLOWLIST: test-only tenant bootstrap for webhook signature fixtures.
+    await conn.execute(
+        """
+        INSERT INTO tenants (id, api_key_hash, name, notification_email,
+                             """
+        + webhook_secret_insert_columns()
+        + """,
+                             created_at, updated_at)
+        VALUES ($1, $2, $3, $4,
+                pgp_sym_encrypt($5, $9), $10,
+                pgp_sym_encrypt($6, $9), $10,
+                pgp_sym_encrypt($7, $9), $10,
+                pgp_sym_encrypt($8, $9), $10,
+                NOW(), NOW())
+        """,
+        str(tenant_id),
+        api_key_hash,
+        f"B22P4 Tenant {str(tenant_id)[:8]}",
+        f"b22p4_{str(tenant_id)[:8]}@test.local",
+        secrets["shopify_webhook_secret"],
+        secrets["stripe_webhook_secret"],
+        secrets["paypal_webhook_secret"],
+        secrets["woocommerce_webhook_secret"],
+        secret_insert["webhook_secret_key"],
+        secret_insert["webhook_secret_key_id"],
+    )
+    await conn.close()
+    return tenant_id, api_key, secrets
+
+
+def sign_shopify(body: bytes, secret: str) -> str:
+    return base64.b64encode(hmac.new(secret.encode(), body, hashlib.sha256).digest()).decode()
+
+
+def sign_stripe(body: bytes, secret: str) -> str:
+    ts = int(datetime.now(timezone.utc).timestamp())
+    signed_payload = f"{ts}.{body.decode()}".encode()
+    sig = hmac.new(secret.encode(), signed_payload, hashlib.sha256).hexdigest()
+    return f"t={ts},v1={sig}"
+
+
+def sign_woocommerce(body: bytes, secret: str) -> str:
+    return base64.b64encode(hmac.new(secret.encode(), body, hashlib.sha256).digest()).decode()
+
+
+def paypal_auth_headers(body: bytes, secret: str) -> dict[str, str]:
+    return build_paypal_auth_headers(raw_body=body, webhook_id=secret)
+
+
+@pytest.mark.asyncio
+async def test_b22_p4_duplicate_replay_suppresses_downstream_tasks_for_all_supported_providers(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    tenant_id, api_key, secrets = await create_tenant_with_secrets()
+    now_iso = datetime.now(timezone.utc).isoformat()
+    shopify_id = int(uuid4().int % 1_000_000)
+    woo_id = int(uuid4().int % 1_000_000)
+    stripe_pi_id = f"pi_{uuid4().hex[:12]}"
+    stripe_event_id = f"evt_{uuid4().hex[:12]}"
+    paypal_txn_id = f"txn_{uuid4().hex[:10]}"
+
+    shopify_body = json.dumps(
+        {"id": shopify_id, "total_price": "20.00", "currency": "USD", "created_at": now_iso}
+    ).encode()
+    woo_body = json.dumps(
+        {
+            "id": woo_id,
+            "total": "30.00",
+            "currency": "USD",
+            "status": "completed",
+            "date_completed": now_iso,
+        }
+    ).encode()
+    stripe_v1_body = json.dumps(
+        {
+            "id": stripe_pi_id,
+            "amount": 5500,
+            "currency": "usd",
+            "created": int(datetime.now(timezone.utc).timestamp()),
+            "status": "succeeded",
+        }
+    ).encode()
+    stripe_v2_body = json.dumps(
+        {
+            "id": stripe_event_id,
+            "created": int(datetime.now(timezone.utc).timestamp()),
+            "data": {"object": {"id": stripe_pi_id, "amount": 5500, "currency": "usd"}},
+        }
+    ).encode()
+    paypal_body = json.dumps(
+        {"id": paypal_txn_id, "amount": {"total": "15.00", "currency": "USD"}, "create_time": now_iso}
+    ).encode()
+
+    observed_calls: list[str] = []
+
+    def _capture_schedule_downstream_tasks(*, tenant_id, event_timestamp, session_id, correlation_id):
+        observed_calls.append(str(correlation_id))
+
+    monkeypatch.setattr(webhooks_api, "_schedule_downstream_tasks", _capture_schedule_downstream_tasks)
+
+    cases = [
+        (
+            "/api/webhooks/shopify/order_create",
+            shopify_body,
+            {"X-Shopify-Hmac-Sha256": sign_shopify(shopify_body, secrets["shopify_webhook_secret"])},
+        ),
+        (
+            "/api/webhooks/woocommerce/order_completed",
+            woo_body,
+            {"X-WC-Webhook-Signature": sign_woocommerce(woo_body, secrets["woocommerce_webhook_secret"])},
+        ),
+        (
+            "/api/webhooks/stripe/payment_intent_succeeded",
+            stripe_v1_body,
+            {"Stripe-Signature": sign_stripe(stripe_v1_body, secrets["stripe_webhook_secret"])},
+        ),
+        (
+            "/api/webhooks/stripe/payment_intent/succeeded",
+            stripe_v2_body,
+            {"Stripe-Signature": sign_stripe(stripe_v2_body, secrets["stripe_webhook_secret"])},
+        ),
+        (
+            "/api/webhooks/paypal/sale_completed",
+            paypal_body,
+            paypal_auth_headers(paypal_body, secrets["paypal_webhook_secret"]),
+        ),
+    ]
+
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        for route, body, auth_headers in cases:
+            first = await client.post(
+                route,
+                content=body,
+                headers={
+                    **auth_headers,
+                    "X-Skeldir-Tenant-Key": api_key,
+                    "Content-Type": "application/json",
+                },
+            )
+            second = await client.post(
+                route,
+                content=body,
+                headers={
+                    **auth_headers,
+                    "X-Skeldir-Tenant-Key": api_key,
+                    "Content-Type": "application/json",
+                },
+            )
+            assert first.status_code == 200, first.text
+            assert second.status_code == 200, second.text
+            assert first.json()["status"] == "success"
+            assert second.json()["status"] == "success"
+            assert first.json()["event_id"] == second.json()["event_id"]
+
+    assert len(observed_calls) == len(cases)
+
+    async with get_session(tenant_id=tenant_id) as session:
+        event_count = await session.scalar(
+            select(func.count()).select_from(AttributionEvent).where(AttributionEvent.tenant_id == tenant_id)
+        )
+    assert event_count == len(cases)
+
+
+@pytest.mark.asyncio
+async def test_b22_p4_duplicate_replay_preserves_single_durable_event_row():
+    tenant_id, api_key, secrets = await create_tenant_with_secrets()
+    body = json.dumps(
+        {
+            "id": int(uuid4().int % 1_000_000),
+            "total_price": "11.00",
+            "currency": "USD",
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+    ).encode()
+    signature = sign_shopify(body, secrets["shopify_webhook_secret"])
+
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        first = await client.post(
+            "/api/webhooks/shopify/order_create",
+            content=body,
+            headers={
+                "X-Shopify-Hmac-Sha256": signature,
+                "X-Skeldir-Tenant-Key": api_key,
+                "Content-Type": "application/json",
+            },
+        )
+        second = await client.post(
+            "/api/webhooks/shopify/order_create",
+            content=body,
+            headers={
+                "X-Shopify-Hmac-Sha256": signature,
+                "X-Skeldir-Tenant-Key": api_key,
+                "Content-Type": "application/json",
+            },
+        )
+    assert first.status_code == 200, first.text
+    assert second.status_code == 200, second.text
+    assert first.json()["status"] == "success"
+    assert second.json()["status"] == "success"
+    assert first.json()["event_id"] == second.json()["event_id"]
+
+    async with get_session(tenant_id=tenant_id) as session:
+        event_count = await session.scalar(
+            select(func.count()).select_from(AttributionEvent).where(AttributionEvent.tenant_id == tenant_id)
+        )
+    assert event_count == 1
+
+
+@pytest.mark.asyncio
+async def test_b22_p4_ack_matrix_is_stable_for_success_duplicate_forged_malformed_oversized_tenant_and_unsupported_outcomes(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    _, api_key, secrets = await create_tenant_with_secrets()
+    observed_calls: list[str] = []
+
+    def _capture_schedule_downstream_tasks(*, tenant_id, event_timestamp, session_id, correlation_id):
+        observed_calls.append(str(correlation_id))
+
+    monkeypatch.setattr(webhooks_api, "_schedule_downstream_tasks", _capture_schedule_downstream_tasks)
+
+    valid_body = json.dumps(
+        {
+            "id": int(uuid4().int % 1_000_000),
+            "total_price": "17.00",
+            "currency": "USD",
+            "created_at": datetime.now(timezone.utc).isoformat(),
+        }
+    ).encode()
+    valid_signature = sign_shopify(valid_body, secrets["shopify_webhook_secret"])
+
+    malformed_signed_body = b"{not-json"
+    malformed_signature = sign_stripe(malformed_signed_body, secrets["stripe_webhook_secret"])
+
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        success = await client.post(
+            "/api/webhooks/shopify/order_create",
+            content=valid_body,
+            headers={
+                "X-Shopify-Hmac-Sha256": valid_signature,
+                "X-Skeldir-Tenant-Key": api_key,
+                "Content-Type": "application/json",
+            },
+        )
+        duplicate = await client.post(
+            "/api/webhooks/shopify/order_create",
+            content=valid_body,
+            headers={
+                "X-Shopify-Hmac-Sha256": valid_signature,
+                "X-Skeldir-Tenant-Key": api_key,
+                "Content-Type": "application/json",
+            },
+        )
+        forged = await client.post(
+            "/api/webhooks/shopify/order_create",
+            content=valid_body,
+            headers={
+                "X-Shopify-Hmac-Sha256": "invalid",
+                "X-Skeldir-Tenant-Key": api_key,
+                "Content-Type": "application/json",
+            },
+        )
+        malformed = await client.post(
+            "/api/webhooks/stripe/payment_intent/succeeded",
+            content=malformed_signed_body,
+            headers={
+                "Stripe-Signature": malformed_signature,
+                "X-Skeldir-Tenant-Key": api_key,
+                "Content-Type": "application/json",
+            },
+        )
+        oversized = await client.post(
+            "/api/webhooks/shopify/order_create",
+            content=valid_body,
+            headers={
+                "X-Shopify-Hmac-Sha256": valid_signature,
+                "X-Skeldir-Tenant-Key": api_key,
+                "Content-Type": "application/json",
+                "Content-Length": str(10_000_000),
+            },
+        )
+        missing_tenant = await client.post(
+            "/api/webhooks/shopify/order_create",
+            content=valid_body,
+            headers={
+                "X-Shopify-Hmac-Sha256": valid_signature,
+                "Content-Type": "application/json",
+            },
+        )
+        wrong_tenant = await client.post(
+            "/api/webhooks/shopify/order_create",
+            content=valid_body,
+            headers={
+                "X-Shopify-Hmac-Sha256": valid_signature,
+                "X-Skeldir-Tenant-Key": f"wrong_{uuid4()}",
+                "Content-Type": "application/json",
+            },
+        )
+        unsupported = await client.post(
+            "/api/webhooks/shopify/orders_paid",
+            content=valid_body,
+            headers={
+                "X-Shopify-Hmac-Sha256": valid_signature,
+                "X-Skeldir-Tenant-Key": api_key,
+                "Content-Type": "application/json",
+            },
+        )
+
+    assert success.status_code == 200, success.text
+    assert success.json()["status"] == "success"
+    assert duplicate.status_code == 200, duplicate.text
+    assert duplicate.json()["status"] == "success"
+    assert duplicate.json()["event_id"] == success.json()["event_id"]
+    assert forged.status_code == 401, forged.text
+    assert malformed.status_code == 200, malformed.text
+    assert malformed.json()["status"] == "dlq_routed"
+    assert oversized.status_code == 413, oversized.text
+    assert missing_tenant.status_code == 401, missing_tenant.text
+    assert wrong_tenant.status_code == 401, wrong_tenant.text
+    assert unsupported.status_code == 404, unsupported.text
+    assert len(observed_calls) == 1
+
+
+@pytest.mark.asyncio
+async def test_b22_p4_stripe_alias_and_canonical_routes_share_ack_semantics():
+    _, api_key, secrets = await create_tenant_with_secrets()
+    pi_id = f"pi_{uuid4().hex[:12]}"
+    now_ts = int(datetime.now(timezone.utc).timestamp())
+    canonical_body = json.dumps(
+        {
+            "id": pi_id,
+            "amount": 6100,
+            "currency": "usd",
+            "created": now_ts,
+            "status": "succeeded",
+        }
+    ).encode()
+    alias_body = json.dumps(
+        {
+            "id": f"evt_{uuid4().hex[:12]}",
+            "created": now_ts,
+            "data": {"object": {"id": pi_id, "amount": 6100, "currency": "usd"}},
+        }
+    ).encode()
+
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        canonical_ok = await client.post(
+            "/api/webhooks/stripe/payment_intent_succeeded",
+            content=canonical_body,
+            headers={
+                "Stripe-Signature": sign_stripe(canonical_body, secrets["stripe_webhook_secret"]),
+                "X-Skeldir-Tenant-Key": api_key,
+                "Content-Type": "application/json",
+            },
+        )
+        alias_ok = await client.post(
+            "/api/webhooks/stripe/payment_intent/succeeded",
+            content=alias_body,
+            headers={
+                "Stripe-Signature": sign_stripe(alias_body, secrets["stripe_webhook_secret"]),
+                "X-Skeldir-Tenant-Key": api_key,
+                "Content-Type": "application/json",
+            },
+        )
+        canonical_forged = await client.post(
+            "/api/webhooks/stripe/payment_intent_succeeded",
+            content=canonical_body,
+            headers={
+                "Stripe-Signature": "t=0,v1=invalid",
+                "X-Skeldir-Tenant-Key": api_key,
+                "Content-Type": "application/json",
+            },
+        )
+        alias_forged = await client.post(
+            "/api/webhooks/stripe/payment_intent/succeeded",
+            content=alias_body,
+            headers={
+                "Stripe-Signature": "t=0,v1=invalid",
+                "X-Skeldir-Tenant-Key": api_key,
+                "Content-Type": "application/json",
+            },
+        )
+
+    assert canonical_ok.status_code == 200, canonical_ok.text
+    assert canonical_ok.json()["status"] == "success"
+    assert alias_ok.status_code == 200, alias_ok.text
+    assert alias_ok.json()["status"] == "success"
+    assert canonical_forged.status_code == 401, canonical_forged.text
+    assert alias_forged.status_code == 401, alias_forged.text

--- a/backend/tests/test_b22_p4_idempotent_ack_orchestration_enforcer.py
+++ b/backend/tests/test_b22_p4_idempotent_ack_orchestration_enforcer.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENFORCER = REPO_ROOT / "scripts" / "ci" / "enforce_b22_p4_idempotent_ack_orchestration.py"
+_SPEC = importlib.util.spec_from_file_location("b22_p4_enforcer_module", ENFORCER)
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+run_enforcement = _MODULE.run_enforcement
+
+GOVERNANCE_CONTRACT = (
+    REPO_ROOT
+    / "contracts-internal"
+    / "governance"
+    / "b22_p4_idempotent_ack_orchestration.main.json"
+)
+EVENT_SERVICE_FILE = REPO_ROOT / "backend" / "app" / "ingestion" / "event_service.py"
+WEBHOOKS_FILE = REPO_ROOT / "backend" / "app" / "api" / "webhooks.py"
+CI_WORKFLOW = REPO_ROOT / ".github" / "workflows" / "ci.yml"
+P4_TEST_FILE = REPO_ROOT / "backend" / "tests" / "test_b22_p4_idempotent_ack_orchestration.py"
+P4_ENFORCER_TEST_FILE = (
+    REPO_ROOT / "backend" / "tests" / "test_b22_p4_idempotent_ack_orchestration_enforcer.py"
+)
+
+
+def _run(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        [sys.executable, str(ENFORCER), *args],
+        cwd=REPO_ROOT,
+        text=True,
+        capture_output=True,
+        check=False,
+    )
+
+
+def test_b22_p4_idempotent_ack_orchestration_enforcer_passes_repo_state() -> None:
+    status, violations = run_enforcement(
+        governance_contract=GOVERNANCE_CONTRACT,
+        event_service_file=EVENT_SERVICE_FILE,
+        webhooks_file=WEBHOOKS_FILE,
+        ci_workflow=CI_WORKFLOW,
+        p4_test_file=P4_TEST_FILE,
+        p4_enforcer_test_file=P4_ENFORCER_TEST_FILE,
+    )
+    assert status == 0, f"unexpected enforcement violations: {violations}"
+
+
+def test_b22_p4_idempotent_ack_orchestration_enforcer_negative_control_forced_regression() -> None:
+    proc = _run("--simulate-regression")
+    assert proc.returncode != 0
+    assert "synthetic_regression=forced_failure_path" in (proc.stdout + proc.stderr)
+
+
+def test_b22_p4_idempotent_ack_orchestration_enforcer_negative_control_private_duplicate_marker_detected(
+    tmp_path: Path,
+) -> None:
+    mutated_event_service = tmp_path / "event_service.regression.py"
+    mutated_event_service.write_text(
+        EVENT_SERVICE_FILE.read_text(encoding="utf-8")
+        + "\n# regression marker\n_ingestion_duplicate = True\n",
+        encoding="utf-8",
+    )
+    proc = _run("--event-service-file", str(mutated_event_service))
+    assert proc.returncode != 0
+    assert "event_service_forbidden_token_present:_ingestion_duplicate" in (proc.stdout + proc.stderr)
+
+
+def test_b22_p4_idempotent_ack_orchestration_enforcer_negative_control_ci_wiring_missing(
+    tmp_path: Path,
+) -> None:
+    mutated_workflow = tmp_path / "ci.regression.yml"
+    mutated_workflow.write_text(
+        CI_WORKFLOW.read_text(encoding="utf-8").replace(
+            "python scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py",
+            "python scripts/ci/enforce_b22_p4_regressed.py",
+            1,
+        ),
+        encoding="utf-8",
+    )
+    proc = _run("--ci-workflow", str(mutated_workflow))
+    assert proc.returncode != 0
+    assert "ci_missing_b22_p4_token" in (proc.stdout + proc.stderr)
+
+
+def test_b22_p4_idempotent_ack_orchestration_enforcer_negative_control_contract_ack_outcome_drift(
+    tmp_path: Path,
+) -> None:
+    payload = json.loads(GOVERNANCE_CONTRACT.read_text(encoding="utf-8"))
+    payload["ack_matrix_contract"].pop("unsupported_event_family")
+    mutated_contract = tmp_path / "b22_p4.regression.contract.json"
+    mutated_contract.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+
+    proc = _run("--governance-contract", str(mutated_contract))
+    assert proc.returncode != 0
+    assert "contract_ack_outcome_set_mismatch" in (proc.stdout + proc.stderr)

--- a/contracts-internal/governance/b22_p4_idempotent_ack_orchestration.main.json
+++ b/contracts-internal/governance/b22_p4_idempotent_ack_orchestration.main.json
@@ -1,0 +1,63 @@
+{
+  "contract_id": "b22.p4.idempotent_ack_orchestration.main",
+  "contract_version": "1.0.0",
+  "repository": "Synergyscape-V1/skeldir-2.0",
+  "branch": "main",
+  "phase": "B2.2-P4",
+  "description": "Explicit webhook orchestration idempotency + ACK protocol matrix lock with duplicate side-effect isolation.",
+  "supported_providers": [
+    "shopify",
+    "woocommerce",
+    "stripe",
+    "paypal"
+  ],
+  "duplicate_signal_contract": {
+    "ingestion_decision_type": "IngestionDecision",
+    "state_enum": [
+      "inserted",
+      "duplicate"
+    ],
+    "webhook_orchestration_gate_field": "is_duplicate",
+    "forbid_private_orm_duplicate_marker": true
+  },
+  "ack_matrix_contract": {
+    "success": {
+      "http_status": 200,
+      "response_status": "success"
+    },
+    "duplicate": {
+      "http_status": 200,
+      "response_status": "success"
+    },
+    "forged_signature": {
+      "http_status": 401
+    },
+    "malformed_authenticated_payload": {
+      "http_status": 200,
+      "response_status": "dlq_routed"
+    },
+    "oversized_payload": {
+      "http_status": 413
+    },
+    "missing_tenant_key": {
+      "http_status": 401
+    },
+    "wrong_tenant_key": {
+      "http_status": 401
+    },
+    "unsupported_event_family": {
+      "http_status": 404
+    }
+  },
+  "required_runtime_proofs": [
+    "backend/tests/test_b22_p4_idempotent_ack_orchestration.py::test_b22_p4_duplicate_replay_suppresses_downstream_tasks_for_all_supported_providers",
+    "backend/tests/test_b22_p4_idempotent_ack_orchestration.py::test_b22_p4_duplicate_replay_preserves_single_durable_event_row",
+    "backend/tests/test_b22_p4_idempotent_ack_orchestration.py::test_b22_p4_ack_matrix_is_stable_for_success_duplicate_forged_malformed_oversized_tenant_and_unsupported_outcomes",
+    "backend/tests/test_b22_p4_idempotent_ack_orchestration.py::test_b22_p4_stripe_alias_and_canonical_routes_share_ack_semantics"
+  ],
+  "required_ci_wiring": [
+    "python scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py",
+    "pytest backend/tests/test_b22_p4_idempotent_ack_orchestration_enforcer.py -q",
+    "pytest backend/tests/test_b22_p4_idempotent_ack_orchestration.py -q"
+  ]
+}

--- a/docs/forensics/Phase B2.2-P4 Remediation Evidence Pack.md
+++ b/docs/forensics/Phase B2.2-P4 Remediation Evidence Pack.md
@@ -45,5 +45,7 @@ Directive: Idempotent ACK semantics + webhook-orchestration side-effect isolatio
 
 ## 5) Protected-branch landing status
 
+- PR opened against `main`: `https://github.com/Synergyscape-V1/skeldir-2.0/pull/367`
+- Current head branch: `b22-p4-idempotent-ack-orchestration`
 - Local remediation is implemented and test/enforcer surfaces are wired.
-- Protected-branch merge and post-merge green `main` CI evidence is not yet attached in this local iteration.
+- Protected-branch merge and post-merge green `main` CI evidence is pending completion of required checks on PR #367.

--- a/docs/forensics/Phase B2.2-P4 Remediation Evidence Pack.md
+++ b/docs/forensics/Phase B2.2-P4 Remediation Evidence Pack.md
@@ -1,0 +1,49 @@
+# Phase B2.2-P4 Remediation Evidence Pack
+
+Date: 2026-04-21  
+Branch basis: `main` (local working state)  
+Directive: Idempotent ACK semantics + webhook-orchestration side-effect isolation
+
+## 1) Initial forensic findings on `main`
+
+- Duplicate side-effect suppression was already functionally present for webhook success paths: downstream scheduling was gated by `result["is_duplicate"]`.
+- The duplicate signal was still carried through private ORM-instance mutation (`_ingestion_duplicate`) in `event_service`, which is architecturally brittle and phase-opaque.
+- ACK protocol behavior was already consistent with prior inventory: auth/tenant failures returned `401`, malformed authenticated payloads were DLQ-routed with `200` + `status: dlq_routed`, and duplicates returned idempotent `200` success.
+- Stripe canonical and alias routes both existed, but P4 merge-protected adjudication for orchestration idempotency + ACK matrix was not yet wired as a dedicated gate.
+
+## 2) Remediations implemented
+
+- Replaced hidden duplicate signaling in `backend/app/ingestion/event_service.py`:
+  - Added explicit typed contract surface `IngestionResultState` (`inserted`, `duplicate`) and `IngestionDecision`.
+  - Added `ingest_event_with_decision(...)` to return event + explicit state.
+  - Kept `ingest_event(...)` as backward-compatible wrapper returning the event only.
+  - Updated `ingest_with_transaction(...)` to consume typed decision and return explicit `is_duplicate` plus `ingestion_state`.
+  - Removed private `_ingestion_duplicate` marker usage from authoritative ingestion path.
+- Added P4 governance + merge-blocking adjudication surface:
+  - `contracts-internal/governance/b22_p4_idempotent_ack_orchestration.main.json`
+  - `scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py`
+  - `backend/tests/test_b22_p4_idempotent_ack_orchestration_enforcer.py`
+  - CI wiring in `.github/workflows/ci.yml`.
+- Added runtime P4 proof suite:
+  - `backend/tests/test_b22_p4_idempotent_ack_orchestration.py`
+  - Proves duplicate replay emits one durable row and one downstream schedule only.
+  - Proves ACK matrix outcomes for success, duplicate, forged, malformed authenticated payload, oversized payload, missing/wrong tenant key, and unsupported family.
+  - Proves stripe canonical and alias route ACK parity for success + forged outcomes.
+
+## 3) Falsifiable proof outcomes (local run)
+
+- `python scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py` -> **PASS**
+- `pytest backend/tests/test_b22_p4_idempotent_ack_orchestration_enforcer.py -q` -> **5 passed**
+- `pytest backend/tests/test_b22_p4_idempotent_ack_orchestration.py -q` -> **4 skipped** (authoritative local DB lacks migrated `webhook_ingress_identities`; suite is configured to skip locally unless `SKELDIR_B22_P4_REQUIRE_DB_PROOFS=1`)
+
+## 4) Exit gate adjudication snapshot
+
+- Exit Gate 1 (Duplicate-Suppression Mechanism): **Addressed** with explicit typed decision contract replacing hidden private marker propagation.
+- Exit Gate 2 (B0.4 Non-Regression): **Guarded** by backward-compatible `ingest_event(...)` wrapper + unchanged B0.4 call surface.
+- Exit Gate 3 (ACK Protocol): **Guarded** by dedicated ACK matrix runtime proofs and CI enforcer.
+- Exit Gate 4 (Merge-Blocking Adjudication): **Wired** via dedicated P4 enforcer + tests in CI workflow.
+
+## 5) Protected-branch landing status
+
+- Local remediation is implemented and test/enforcer surfaces are wired.
+- Protected-branch merge and post-merge green `main` CI evidence is not yet attached in this local iteration.

--- a/scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py
+++ b/scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""B2.2-P4 idempotent ACK semantics + orchestration side-effect isolation enforcer."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GOVERNANCE_CONTRACT = (
+    "contracts-internal/governance/b22_p4_idempotent_ack_orchestration.main.json"
+)
+EVENT_SERVICE_FILE = "backend/app/ingestion/event_service.py"
+WEBHOOKS_FILE = "backend/app/api/webhooks.py"
+CI_WORKFLOW = ".github/workflows/ci.yml"
+P4_TEST_FILE = "backend/tests/test_b22_p4_idempotent_ack_orchestration.py"
+P4_ENFORCER_TEST_FILE = "backend/tests/test_b22_p4_idempotent_ack_orchestration_enforcer.py"
+
+EXPECTED_PROVIDERS = {"shopify", "woocommerce", "stripe", "paypal"}
+EXPECTED_OUTCOMES = {
+    "success",
+    "duplicate",
+    "forged_signature",
+    "malformed_authenticated_payload",
+    "oversized_payload",
+    "missing_tenant_key",
+    "wrong_tenant_key",
+    "unsupported_event_family",
+}
+
+
+def _resolve(repo_root: Path, raw: str) -> Path:
+    candidate = Path(raw)
+    if candidate.is_absolute():
+        return candidate
+    return (repo_root / candidate).resolve()
+
+
+def _read_text(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _read_json(path: Path) -> dict[str, Any]:
+    payload = json.loads(_read_text(path))
+    if not isinstance(payload, dict):
+        raise ValueError(f"JSON payload must be an object: {path}")
+    return payload
+
+
+def _validate_contract(contract: dict[str, Any], violations: list[str]) -> None:
+    providers = {str(item).strip() for item in contract.get("supported_providers", [])}
+    if providers != EXPECTED_PROVIDERS:
+        violations.append("contract_provider_set_mismatch:" + "|".join(sorted(providers)))
+
+    duplicate_contract = contract.get("duplicate_signal_contract")
+    if not isinstance(duplicate_contract, dict):
+        violations.append("contract_missing_duplicate_signal_contract")
+    else:
+        if duplicate_contract.get("ingestion_decision_type") != "IngestionDecision":
+            violations.append("contract_duplicate_signal_type_mismatch")
+        states = {str(item).strip() for item in duplicate_contract.get("state_enum", [])}
+        if states != {"inserted", "duplicate"}:
+            violations.append("contract_duplicate_state_enum_mismatch")
+        if duplicate_contract.get("webhook_orchestration_gate_field") != "is_duplicate":
+            violations.append("contract_duplicate_gate_field_mismatch")
+        if duplicate_contract.get("forbid_private_orm_duplicate_marker") is not True:
+            violations.append("contract_private_marker_policy_mismatch")
+
+    ack_matrix = contract.get("ack_matrix_contract")
+    if not isinstance(ack_matrix, dict):
+        violations.append("contract_missing_ack_matrix")
+        return
+    outcomes = {str(key).strip() for key in ack_matrix.keys()}
+    if outcomes != EXPECTED_OUTCOMES:
+        violations.append("contract_ack_outcome_set_mismatch:" + "|".join(sorted(outcomes)))
+
+
+def _validate_event_service(path: Path, violations: list[str]) -> None:
+    text = _read_text(path)
+    required_tokens = (
+        "class IngestionResultState(str, Enum):",
+        "class IngestionDecision:",
+        "async def ingest_event_with_decision(",
+        "\"ingestion_state\": decision.state.value",
+        "IngestionResultState.DUPLICATE",
+        "IngestionResultState.INSERTED",
+    )
+    for token in required_tokens:
+        if token not in text:
+            violations.append(f"event_service_missing_token:{token}")
+    forbidden_tokens = (
+        "_ingestion_duplicate",
+        "getattr(event, \"_ingestion_duplicate\"",
+    )
+    for token in forbidden_tokens:
+        if token in text:
+            violations.append(f"event_service_forbidden_token_present:{token}")
+
+
+def _validate_webhooks(path: Path, violations: list[str]) -> None:
+    text = _read_text(path)
+    required_tokens = (
+        "not bool(result.get(\"is_duplicate\"))",
+        "\"status\": \"dlq_routed\"",
+        "status.HTTP_413_REQUEST_ENTITY_TOO_LARGE",
+        "/webhooks/stripe/payment_intent_succeeded",
+        "/webhooks/stripe/payment_intent/succeeded",
+    )
+    for token in required_tokens:
+        if token not in text:
+            violations.append(f"webhooks_missing_token:{token}")
+
+
+def _validate_ci(path: Path, violations: list[str]) -> None:
+    text = _read_text(path)
+    required_tokens = (
+        "SKELDIR_B22_P4_REQUIRE_DB_PROOFS: \"1\"",
+        "python scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py",
+        "pytest backend/tests/test_b22_p4_idempotent_ack_orchestration_enforcer.py -q",
+        "pytest backend/tests/test_b22_p4_idempotent_ack_orchestration.py -q",
+    )
+    for token in required_tokens:
+        if token not in text:
+            violations.append(f"ci_missing_b22_p4_token:{token}")
+
+
+def _validate_test_surfaces(*, p4_test: Path, p4_enforcer_test: Path, violations: list[str]) -> None:
+    p4_text = _read_text(p4_test)
+    p4_required_tests = (
+        "test_b22_p4_duplicate_replay_suppresses_downstream_tasks_for_all_supported_providers",
+        "test_b22_p4_duplicate_replay_preserves_single_durable_event_row",
+        "test_b22_p4_ack_matrix_is_stable_for_success_duplicate_forged_malformed_oversized_tenant_and_unsupported_outcomes",
+        "test_b22_p4_stripe_alias_and_canonical_routes_share_ack_semantics",
+    )
+    for token in p4_required_tests:
+        if token not in p4_text:
+            violations.append(f"p4_test_missing_token:{token}")
+
+    enforcer_text = _read_text(p4_enforcer_test)
+    enforcer_required_tests = (
+        "test_b22_p4_idempotent_ack_orchestration_enforcer_passes_repo_state",
+        "test_b22_p4_idempotent_ack_orchestration_enforcer_negative_control_forced_regression",
+    )
+    for token in enforcer_required_tests:
+        if token not in enforcer_text:
+            violations.append(f"p4_enforcer_test_missing_token:{token}")
+
+
+def run_enforcement(
+    *,
+    governance_contract: Path,
+    event_service_file: Path,
+    webhooks_file: Path,
+    ci_workflow: Path,
+    p4_test_file: Path,
+    p4_enforcer_test_file: Path,
+) -> tuple[int, list[str]]:
+    violations: list[str] = []
+    required_paths = (
+        governance_contract,
+        event_service_file,
+        webhooks_file,
+        ci_workflow,
+        p4_test_file,
+        p4_enforcer_test_file,
+    )
+    for path in required_paths:
+        if not path.exists():
+            violations.append(f"missing_required_file:{path}")
+    if violations:
+        return 1, violations
+
+    contract = _read_json(governance_contract)
+    _validate_contract(contract, violations)
+    _validate_event_service(event_service_file, violations)
+    _validate_webhooks(webhooks_file, violations)
+    _validate_ci(ci_workflow, violations)
+    _validate_test_surfaces(
+        p4_test=p4_test_file,
+        p4_enforcer_test=p4_enforcer_test_file,
+        violations=violations,
+    )
+    return (1 if violations else 0), violations
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(
+        description="Enforce B2.2-P4 idempotent ACK semantics and webhook side-effect isolation."
+    )
+    parser.add_argument("--repo-root", default=str(REPO_ROOT))
+    parser.add_argument("--governance-contract", default=GOVERNANCE_CONTRACT)
+    parser.add_argument("--event-service-file", default=EVENT_SERVICE_FILE)
+    parser.add_argument("--webhooks-file", default=WEBHOOKS_FILE)
+    parser.add_argument("--ci-workflow", default=CI_WORKFLOW)
+    parser.add_argument("--p4-test-file", default=P4_TEST_FILE)
+    parser.add_argument("--p4-enforcer-test-file", default=P4_ENFORCER_TEST_FILE)
+    parser.add_argument("--simulate-regression", action="store_true")
+    args = parser.parse_args(argv[1:])
+
+    if args.simulate_regression:
+        sys.stdout.write(
+            "b22_p4_idempotent_ack_orchestration_enforcer\n"
+            "result=FAIL\n"
+            "synthetic_regression=forced_failure_path\n"
+        )
+        return 1
+
+    repo_root = _resolve(REPO_ROOT, args.repo_root)
+    status, violations = run_enforcement(
+        governance_contract=_resolve(repo_root, args.governance_contract),
+        event_service_file=_resolve(repo_root, args.event_service_file),
+        webhooks_file=_resolve(repo_root, args.webhooks_file),
+        ci_workflow=_resolve(repo_root, args.ci_workflow),
+        p4_test_file=_resolve(repo_root, args.p4_test_file),
+        p4_enforcer_test_file=_resolve(repo_root, args.p4_enforcer_test_file),
+    )
+
+    lines = ["b22_p4_idempotent_ack_orchestration_enforcer"]
+    if status != 0:
+        lines.append("result=FAIL")
+        lines.extend(violations)
+    else:
+        lines.append("result=PASS")
+        lines.append("enforcement=explicit_duplicate_signal_and_ack_matrix_side_effect_isolation")
+    sys.stdout.write("\n".join(lines) + "\n")
+    return status
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv))


### PR DESCRIPTION
## Summary
- replace hidden `_ingestion_duplicate` ORM mutation with explicit typed ingestion decision contract (`IngestionDecision` + `IngestionResultState`) while preserving backward-compatible `ingest_event(...)` behavior
- add B2.2-P4 governance, enforcer, and runtime proof suites for duplicate side-effect isolation and ACK outcome matrix invariants across supported webhook providers/routes
- wire B2.2-P4 enforcement/runtime proofs into CI and add `docs/forensics/Phase B2.2-P4 Remediation Evidence Pack.md` with forensic findings and remediation evidence

## Test plan
- [x] `python scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py`
- [x] `pytest backend/tests/test_b22_p4_idempotent_ack_orchestration_enforcer.py -q`
- [x] `pytest backend/tests/test_b22_p4_idempotent_ack_orchestration.py -q` (local environment: skipped pending migrated `webhook_ingress_identities` table)