### PR TITLE
B2.2-P4 corrective: route-stable malformed ACK semantics

### DIFF
--- a/backend/app/api/webhooks.py
+++ b/backend/app/api/webhooks.py
@@ -17,10 +17,9 @@ from types import MappingProxyType
 from uuid import UUID, uuid4, uuid5, NAMESPACE_URL
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Security, status
-from fastapi import Body
 from fastapi.security import APIKeyHeader
 from fastapi.responses import JSONResponse
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationError
 from typing import Any, Mapping, Optional
 
 from app.api.problem_details import ProblemDetails
@@ -361,6 +360,55 @@ def _identity_payload_from_request(request: Request) -> dict[str, Any] | None:
     return parsed
 
 
+def _parse_json_object(raw_body: bytes) -> tuple[dict[str, Any] | None, str | None]:
+    try:
+        parsed = json.loads(raw_body.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        return None, str(exc)
+    if not isinstance(parsed, dict):
+        return None, "payload root must be a JSON object"
+    return parsed, None
+
+
+def _malformed_idempotency_key(*, source: str, raw_body: bytes, suffix: str) -> str:
+    body_sha256 = hashlib.sha256(raw_body).hexdigest()
+    return str(uuid5(NAMESPACE_URL, f"{source}_{suffix}_{body_sha256}"))
+
+
+async def _route_authenticated_malformed_payload(
+    *,
+    tenant_id: UUID | str,
+    source: str,
+    idempotency_key: str,
+    error_message: str,
+    vendor_payload: dict[str, Any],
+    identity_payload: dict[str, Any],
+    request_headers: dict[str, str],
+) -> dict[str, str | None]:
+    correlation_id = str(_make_correlation_uuid(idempotency_key))
+    dead = await _route_to_dlq_direct(
+        tenant_id=tenant_id,
+        source=source,
+        correlation_id=correlation_id,
+        payload={
+            "event_type": "purchase",
+            "vendor": source,
+            "idempotency_key": idempotency_key,
+            "correlation_id": correlation_id,
+            "vendor_payload": vendor_payload,
+        },
+        error_message=error_message,
+        error_type="validation_error",
+        identity_payload=identity_payload,
+        request_headers=request_headers,
+    )
+    return {
+        "status": "dlq_routed",
+        "dead_event_id": str(dead.id),
+        "error": "validation_error",
+    }
+
+
 def _compute_recompute_window(event_timestamp: str) -> tuple[str, str]:
     """
     Normalize an event timestamp into a UTC day window (start inclusive, end exclusive).
@@ -535,11 +583,52 @@ async def _handle_ingestion(
 )
 async def shopify_order_create(
     request: Request,
-    payload: ShopifyOrderCreateRequest = Body(...),
     tenant_info=Depends(shopify_webhook_auth),
 ):
-    if not payload.id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing order id")
+    raw_body = await _resolve_raw_body_for_webhook_auth(request)
+    request_headers = _request_headers_for_privacy_boundary(request)
+    identity_payload, parse_error = _parse_json_object(raw_body)
+    if parse_error is not None:
+        idempotency_key = _malformed_idempotency_key(
+            source="shopify",
+            raw_body=raw_body,
+            suffix="order_create_invalid_json",
+        )
+        set_business_correlation_id(idempotency_key)
+        return await _route_authenticated_malformed_payload(
+            tenant_id=tenant_info["tenant_id"],
+            source="shopify",
+            idempotency_key=idempotency_key,
+            error_message=f"invalid_json_payload:{parse_error}",
+            vendor_payload={
+                "raw_body_sha256": hashlib.sha256(raw_body).hexdigest(),
+                "raw_body_bytes": len(raw_body),
+                "parse_error": parse_error,
+            },
+            identity_payload={"raw_body_sha256": hashlib.sha256(raw_body).hexdigest()},
+            request_headers=request_headers,
+        )
+
+    try:
+        payload = ShopifyOrderCreateRequest.model_validate(identity_payload)
+        if not payload.id:
+            raise ValueError("Missing order id")
+    except (ValidationError, ValueError) as exc:
+        idempotency_key = _malformed_idempotency_key(
+            source="shopify",
+            raw_body=raw_body,
+            suffix="order_create_schema_invalid",
+        )
+        set_business_correlation_id(idempotency_key)
+        return await _route_authenticated_malformed_payload(
+            tenant_id=tenant_info["tenant_id"],
+            source="shopify",
+            idempotency_key=idempotency_key,
+            error_message=f"schema_validation_error:{exc}",
+            vendor_payload=identity_payload,
+            identity_payload=identity_payload,
+            request_headers=request_headers,
+        )
 
     idempotency_key = str(uuid5(NAMESPACE_URL, f"shopify_order_create_{payload.id}"))
     set_business_correlation_id(idempotency_key)
@@ -578,8 +667,8 @@ async def shopify_order_create(
         idempotency_key,
         source="shopify",
         verified_at=_resolve_verified_at(tenant_info),
-        identity_payload=_identity_payload_from_request(request) or payload.model_dump(mode="json"),
-        request_headers=_request_headers_for_privacy_boundary(request),
+        identity_payload=identity_payload,
+        request_headers=request_headers,
     )
 
 
@@ -591,12 +680,53 @@ async def shopify_order_create(
 )
 async def stripe_payment_intent_succeeded(
     request: Request,
-    payload: StripePaymentIntentSucceededRequest = Body(...),
     x_idempotency_key: Optional[str] = Header(None, alias="X-Idempotency-Key"),
     tenant_info=Depends(stripe_webhook_auth),
 ):
-    if not payload.id and not x_idempotency_key:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing payment intent id")
+    raw_body = await _resolve_raw_body_for_webhook_auth(request)
+    request_headers = _request_headers_for_privacy_boundary(request)
+    identity_payload, parse_error = _parse_json_object(raw_body)
+    if parse_error is not None:
+        idempotency_key = x_idempotency_key or _malformed_idempotency_key(
+            source="stripe",
+            raw_body=raw_body,
+            suffix="payment_intent_succeeded_invalid_json",
+        )
+        set_business_correlation_id(idempotency_key)
+        return await _route_authenticated_malformed_payload(
+            tenant_id=tenant_info["tenant_id"],
+            source="stripe",
+            idempotency_key=idempotency_key,
+            error_message=f"invalid_json_payload:{parse_error}",
+            vendor_payload={
+                "raw_body_sha256": hashlib.sha256(raw_body).hexdigest(),
+                "raw_body_bytes": len(raw_body),
+                "parse_error": parse_error,
+            },
+            identity_payload={"raw_body_sha256": hashlib.sha256(raw_body).hexdigest()},
+            request_headers=request_headers,
+        )
+
+    try:
+        payload = StripePaymentIntentSucceededRequest.model_validate(identity_payload)
+        if not payload.id and not x_idempotency_key:
+            raise ValueError("Missing payment intent id")
+    except (ValidationError, ValueError) as exc:
+        idempotency_key = x_idempotency_key or _malformed_idempotency_key(
+            source="stripe",
+            raw_body=raw_body,
+            suffix="payment_intent_succeeded_schema_invalid",
+        )
+        set_business_correlation_id(idempotency_key)
+        return await _route_authenticated_malformed_payload(
+            tenant_id=tenant_info["tenant_id"],
+            source="stripe",
+            idempotency_key=idempotency_key,
+            error_message=f"schema_validation_error:{exc}",
+            vendor_payload=identity_payload,
+            identity_payload=identity_payload,
+            request_headers=request_headers,
+        )
 
     idempotency_key = x_idempotency_key or str(uuid5(NAMESPACE_URL, f"stripe_payment_intent_succeeded_{payload.id}"))
     set_business_correlation_id(idempotency_key)
@@ -632,8 +762,8 @@ async def stripe_payment_intent_succeeded(
         idempotency_key,
         source="stripe",
         verified_at=_resolve_verified_at(tenant_info),
-        identity_payload=_identity_payload_from_request(request) or payload.model_dump(mode="json"),
-        request_headers=_request_headers_for_privacy_boundary(request),
+        identity_payload=identity_payload,
+        request_headers=request_headers,
     )
 
 
@@ -899,11 +1029,52 @@ async def stripe_payment_intent_succeeded_v2(
 )
 async def paypal_sale_completed(
     request: Request,
-    payload: PayPalSaleCompletedRequest = Body(...),
     tenant_info=Depends(paypal_webhook_auth),
 ):
-    if not payload.id or not payload.amount:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing transaction id or amount")
+    raw_body = await _resolve_raw_body_for_webhook_auth(request)
+    request_headers = _request_headers_for_privacy_boundary(request)
+    identity_payload, parse_error = _parse_json_object(raw_body)
+    if parse_error is not None:
+        idempotency_key = _malformed_idempotency_key(
+            source="paypal",
+            raw_body=raw_body,
+            suffix="sale_completed_invalid_json",
+        )
+        set_business_correlation_id(idempotency_key)
+        return await _route_authenticated_malformed_payload(
+            tenant_id=tenant_info["tenant_id"],
+            source="paypal",
+            idempotency_key=idempotency_key,
+            error_message=f"invalid_json_payload:{parse_error}",
+            vendor_payload={
+                "raw_body_sha256": hashlib.sha256(raw_body).hexdigest(),
+                "raw_body_bytes": len(raw_body),
+                "parse_error": parse_error,
+            },
+            identity_payload={"raw_body_sha256": hashlib.sha256(raw_body).hexdigest()},
+            request_headers=request_headers,
+        )
+
+    try:
+        payload = PayPalSaleCompletedRequest.model_validate(identity_payload)
+        if not payload.id or not payload.amount:
+            raise ValueError("Missing transaction id or amount")
+    except (ValidationError, ValueError) as exc:
+        idempotency_key = _malformed_idempotency_key(
+            source="paypal",
+            raw_body=raw_body,
+            suffix="sale_completed_schema_invalid",
+        )
+        set_business_correlation_id(idempotency_key)
+        return await _route_authenticated_malformed_payload(
+            tenant_id=tenant_info["tenant_id"],
+            source="paypal",
+            idempotency_key=idempotency_key,
+            error_message=f"schema_validation_error:{exc}",
+            vendor_payload=identity_payload,
+            identity_payload=identity_payload,
+            request_headers=request_headers,
+        )
 
     idempotency_key = str(uuid5(NAMESPACE_URL, f"paypal_sale_completed_{payload.id}"))
     set_business_correlation_id(idempotency_key)
@@ -945,8 +1116,8 @@ async def paypal_sale_completed(
         idempotency_key,
         source="paypal",
         verified_at=_resolve_verified_at(tenant_info),
-        identity_payload=_identity_payload_from_request(request) or payload.model_dump(mode="json"),
-        request_headers=_request_headers_for_privacy_boundary(request),
+        identity_payload=identity_payload,
+        request_headers=request_headers,
     )
 
 
@@ -957,11 +1128,52 @@ async def paypal_sale_completed(
 )
 async def woocommerce_order_completed(
     request: Request,
-    payload: WooCommerceOrderCompletedRequest = Body(...),
     tenant_info=Depends(woocommerce_webhook_auth),
 ):
-    if not payload.id:
-        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Missing order id")
+    raw_body = await _resolve_raw_body_for_webhook_auth(request)
+    request_headers = _request_headers_for_privacy_boundary(request)
+    identity_payload, parse_error = _parse_json_object(raw_body)
+    if parse_error is not None:
+        idempotency_key = _malformed_idempotency_key(
+            source="woocommerce",
+            raw_body=raw_body,
+            suffix="order_completed_invalid_json",
+        )
+        set_business_correlation_id(idempotency_key)
+        return await _route_authenticated_malformed_payload(
+            tenant_id=tenant_info["tenant_id"],
+            source="woocommerce",
+            idempotency_key=idempotency_key,
+            error_message=f"invalid_json_payload:{parse_error}",
+            vendor_payload={
+                "raw_body_sha256": hashlib.sha256(raw_body).hexdigest(),
+                "raw_body_bytes": len(raw_body),
+                "parse_error": parse_error,
+            },
+            identity_payload={"raw_body_sha256": hashlib.sha256(raw_body).hexdigest()},
+            request_headers=request_headers,
+        )
+
+    try:
+        payload = WooCommerceOrderCompletedRequest.model_validate(identity_payload)
+        if not payload.id:
+            raise ValueError("Missing order id")
+    except (ValidationError, ValueError) as exc:
+        idempotency_key = _malformed_idempotency_key(
+            source="woocommerce",
+            raw_body=raw_body,
+            suffix="order_completed_schema_invalid",
+        )
+        set_business_correlation_id(idempotency_key)
+        return await _route_authenticated_malformed_payload(
+            tenant_id=tenant_info["tenant_id"],
+            source="woocommerce",
+            idempotency_key=idempotency_key,
+            error_message=f"schema_validation_error:{exc}",
+            vendor_payload=identity_payload,
+            identity_payload=identity_payload,
+            request_headers=request_headers,
+        )
 
     idempotency_key = str(uuid5(NAMESPACE_URL, f"woocommerce_order_completed_{payload.id}"))
     set_business_correlation_id(idempotency_key)
@@ -1001,6 +1213,6 @@ async def woocommerce_order_completed(
         idempotency_key,
         source="woocommerce",
         verified_at=_resolve_verified_at(tenant_info),
-        identity_payload=_identity_payload_from_request(request) or payload.model_dump(mode="json"),
-        request_headers=_request_headers_for_privacy_boundary(request),
+        identity_payload=identity_payload,
+        request_headers=request_headers,
     )

--- a/backend/tests/test_b12_p8_error_contract_normalization.py
+++ b/backend/tests/test_b12_p8_error_contract_normalization.py
@@ -708,6 +708,15 @@ async def test_eg8422_business_validation_after_valid_auth_is_problem_details_an
         raise unauthorized_auth_error()
 
     monkeypatch.setattr(webhooks_api, "get_tenant_with_webhook_secrets", _tenant_lookup)
+    dlq_id = uuid4()
+
+    class _DeadEventStub:
+        id = dlq_id
+
+    async def _fake_route_to_dlq_direct(*, tenant_id, source, correlation_id, payload, error_message, **kwargs):
+        return _DeadEventStub()
+
+    monkeypatch.setattr(webhooks_api, "_route_to_dlq_direct", _fake_route_to_dlq_direct)
 
     invalid_body = b"[]"
     signature = _shopify_signature(invalid_body, "shopify_secret")
@@ -725,12 +734,10 @@ async def test_eg8422_business_validation_after_valid_auth_is_problem_details_an
             },
         )
 
-    problem = _assert_problem_response_shape(response, expected_status=422)
-    assert problem["code"] == "REQUEST_VALIDATION_FAILED"
-    serialized = json.dumps(problem, sort_keys=True).lower()
-    assert "loc" not in serialized
-    assert "input" not in serialized
-    assert "validationerror" not in serialized
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert payload["status"] == "dlq_routed"
+    assert payload.get("dead_event_id") == str(dlq_id)
 
 
 @pytest.mark.asyncio

--- a/backend/tests/test_b22_p4_idempotent_ack_orchestration.py
+++ b/backend/tests/test_b22_p4_idempotent_ack_orchestration.py
@@ -321,8 +321,37 @@ async def test_b22_p4_ack_matrix_is_stable_for_success_duplicate_forged_malforme
     ).encode()
     valid_signature = sign_shopify(valid_body, secrets["shopify_webhook_secret"])
 
-    malformed_signed_body = b"{not-json"
-    malformed_signature = sign_stripe(malformed_signed_body, secrets["stripe_webhook_secret"])
+    malformed_shopify_body = b"{not-json"
+    malformed_stripe_body = b"{not-json"
+    malformed_paypal_body = b"{not-json"
+    malformed_woo_body = b"{not-json"
+    malformed_cases = [
+        (
+            "/api/webhooks/shopify/order_create",
+            malformed_shopify_body,
+            {"X-Shopify-Hmac-Sha256": sign_shopify(malformed_shopify_body, secrets["shopify_webhook_secret"])},
+        ),
+        (
+            "/api/webhooks/stripe/payment_intent_succeeded",
+            malformed_stripe_body,
+            {"Stripe-Signature": sign_stripe(malformed_stripe_body, secrets["stripe_webhook_secret"])},
+        ),
+        (
+            "/api/webhooks/stripe/payment_intent/succeeded",
+            malformed_stripe_body,
+            {"Stripe-Signature": sign_stripe(malformed_stripe_body, secrets["stripe_webhook_secret"])},
+        ),
+        (
+            "/api/webhooks/paypal/sale_completed",
+            malformed_paypal_body,
+            paypal_auth_headers(malformed_paypal_body, secrets["paypal_webhook_secret"]),
+        ),
+        (
+            "/api/webhooks/woocommerce/order_completed",
+            malformed_woo_body,
+            {"X-WC-Webhook-Signature": sign_woocommerce(malformed_woo_body, secrets["woocommerce_webhook_secret"])},
+        ),
+    ]
 
     transport = ASGITransport(app=app, raise_app_exceptions=False)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -349,15 +378,6 @@ async def test_b22_p4_ack_matrix_is_stable_for_success_duplicate_forged_malforme
             content=valid_body,
             headers={
                 "X-Shopify-Hmac-Sha256": "invalid",
-                "X-Skeldir-Tenant-Key": api_key,
-                "Content-Type": "application/json",
-            },
-        )
-        malformed = await client.post(
-            "/api/webhooks/stripe/payment_intent/succeeded",
-            content=malformed_signed_body,
-            headers={
-                "Stripe-Signature": malformed_signature,
                 "X-Skeldir-Tenant-Key": api_key,
                 "Content-Type": "application/json",
             },
@@ -398,6 +418,63 @@ async def test_b22_p4_ack_matrix_is_stable_for_success_duplicate_forged_malforme
                 "Content-Type": "application/json",
             },
         )
+        malformed_authenticated_responses = []
+        forged_malformed_responses = []
+        missing_tenant_malformed_responses = []
+        wrong_tenant_malformed_responses = []
+        for route, body, auth_headers in malformed_cases:
+            malformed_authenticated_responses.append(
+                await client.post(
+                    route,
+                    content=body,
+                    headers={
+                        **auth_headers,
+                        "X-Skeldir-Tenant-Key": api_key,
+                        "Content-Type": "application/json",
+                    },
+                )
+            )
+            forged_headers = dict(auth_headers)
+            if "X-Shopify-Hmac-Sha256" in forged_headers:
+                forged_headers["X-Shopify-Hmac-Sha256"] = "invalid"
+            elif "Stripe-Signature" in forged_headers:
+                forged_headers["Stripe-Signature"] = "t=0,v1=invalid"
+            elif "X-WC-Webhook-Signature" in forged_headers:
+                forged_headers["X-WC-Webhook-Signature"] = "invalid"
+            else:
+                forged_headers = paypal_auth_headers(body, "wrong_webhook_id")
+            forged_malformed_responses.append(
+                await client.post(
+                    route,
+                    content=body,
+                    headers={
+                        **forged_headers,
+                        "X-Skeldir-Tenant-Key": api_key,
+                        "Content-Type": "application/json",
+                    },
+                )
+            )
+            missing_tenant_malformed_responses.append(
+                await client.post(
+                    route,
+                    content=body,
+                    headers={
+                        **auth_headers,
+                        "Content-Type": "application/json",
+                    },
+                )
+            )
+            wrong_tenant_malformed_responses.append(
+                await client.post(
+                    route,
+                    content=body,
+                    headers={
+                        **auth_headers,
+                        "X-Skeldir-Tenant-Key": f"wrong_{uuid4()}",
+                        "Content-Type": "application/json",
+                    },
+                )
+            )
 
     assert success.status_code == 200, success.text
     assert success.json()["status"] == "success"
@@ -405,12 +482,19 @@ async def test_b22_p4_ack_matrix_is_stable_for_success_duplicate_forged_malforme
     assert duplicate.json()["status"] == "success"
     assert duplicate.json()["event_id"] == success.json()["event_id"]
     assert forged.status_code == 401, forged.text
-    assert malformed.status_code == 200, malformed.text
-    assert malformed.json()["status"] == "dlq_routed"
     assert oversized.status_code == 413, oversized.text
     assert missing_tenant.status_code == 401, missing_tenant.text
     assert wrong_tenant.status_code == 401, wrong_tenant.text
     assert unsupported.status_code == 404, unsupported.text
+    for response in malformed_authenticated_responses:
+        assert response.status_code == 200, response.text
+        assert response.json()["status"] == "dlq_routed"
+    for response in forged_malformed_responses:
+        assert response.status_code == 401, response.text
+    for response in missing_tenant_malformed_responses:
+        assert response.status_code == 401, response.text
+    for response in wrong_tenant_malformed_responses:
+        assert response.status_code == 401, response.text
     assert len(observed_calls) == 1
 
 
@@ -435,6 +519,7 @@ async def test_b22_p4_stripe_alias_and_canonical_routes_share_ack_semantics():
             "data": {"object": {"id": pi_id, "amount": 6100, "currency": "usd"}},
         }
     ).encode()
+    malformed_body = b"{not-json"
 
     transport = ASGITransport(app=app, raise_app_exceptions=False)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
@@ -474,6 +559,24 @@ async def test_b22_p4_stripe_alias_and_canonical_routes_share_ack_semantics():
                 "Content-Type": "application/json",
             },
         )
+        canonical_malformed = await client.post(
+            "/api/webhooks/stripe/payment_intent_succeeded",
+            content=malformed_body,
+            headers={
+                "Stripe-Signature": sign_stripe(malformed_body, secrets["stripe_webhook_secret"]),
+                "X-Skeldir-Tenant-Key": api_key,
+                "Content-Type": "application/json",
+            },
+        )
+        alias_malformed = await client.post(
+            "/api/webhooks/stripe/payment_intent/succeeded",
+            content=malformed_body,
+            headers={
+                "Stripe-Signature": sign_stripe(malformed_body, secrets["stripe_webhook_secret"]),
+                "X-Skeldir-Tenant-Key": api_key,
+                "Content-Type": "application/json",
+            },
+        )
 
     assert canonical_ok.status_code == 200, canonical_ok.text
     assert canonical_ok.json()["status"] == "success"
@@ -481,3 +584,7 @@ async def test_b22_p4_stripe_alias_and_canonical_routes_share_ack_semantics():
     assert alias_ok.json()["status"] == "success"
     assert canonical_forged.status_code == 401, canonical_forged.text
     assert alias_forged.status_code == 401, alias_forged.text
+    assert canonical_malformed.status_code == 200, canonical_malformed.text
+    assert canonical_malformed.json()["status"] == "dlq_routed"
+    assert alias_malformed.status_code == 200, alias_malformed.text
+    assert alias_malformed.json()["status"] == "dlq_routed"

--- a/contracts-internal/governance/b22_p4_idempotent_ack_orchestration.main.json
+++ b/contracts-internal/governance/b22_p4_idempotent_ack_orchestration.main.json
@@ -1,6 +1,6 @@
 {
   "contract_id": "b22.p4.idempotent_ack_orchestration.main",
-  "contract_version": "1.0.0",
+  "contract_version": "1.1.0",
   "repository": "Synergyscape-V1/skeldir-2.0",
   "branch": "main",
   "phase": "B2.2-P4",
@@ -34,7 +34,14 @@
     },
     "malformed_authenticated_payload": {
       "http_status": 200,
-      "response_status": "dlq_routed"
+      "response_status": "dlq_routed",
+      "route_scope": [
+        "/api/webhooks/shopify/order_create",
+        "/api/webhooks/stripe/payment_intent_succeeded",
+        "/api/webhooks/stripe/payment_intent/succeeded",
+        "/api/webhooks/paypal/sale_completed",
+        "/api/webhooks/woocommerce/order_completed"
+      ]
     },
     "oversized_payload": {
       "http_status": 413

--- a/docs/forensics/B2.2-P4 Remediation Evidence Pack .md
+++ b/docs/forensics/B2.2-P4 Remediation Evidence Pack .md
@@ -1,0 +1,7 @@
+# B2.2-P4 Remediation Evidence Pack
+
+This evidence pack is maintained in:
+
+- `docs/forensics/Phase B2.2-P4 Remediation Evidence Pack.md`
+
+Use that file as the authoritative corrective-action iteration record for Phase B2.2-P4.

--- a/docs/forensics/Phase B2.2-P4 Remediation Evidence Pack.md
+++ b/docs/forensics/Phase B2.2-P4 Remediation Evidence Pack.md
@@ -1,62 +1,96 @@
 # Phase B2.2-P4 Remediation Evidence Pack
 
 Date: 2026-04-21  
-Branch basis: `main` (local working state)  
+Branch basis: `main` (corrective-action iteration after rejected closeout)  
 Directive: Idempotent ACK semantics + webhook-orchestration side-effect isolation
 
-## 1) Initial forensic findings on `main`
+## 1) Corrective blocker identified
 
-- Duplicate side-effect suppression was already functionally present for webhook success paths: downstream scheduling was gated by `result["is_duplicate"]`.
-- The duplicate signal was still carried through private ORM-instance mutation (`_ingestion_duplicate`) in `event_service`, which is architecturally brittle and phase-opaque.
-- ACK protocol behavior was already consistent with prior inventory: auth/tenant failures returned `401`, malformed authenticated payloads were DLQ-routed with `200` + `status: dlq_routed`, and duplicates returned idempotent `200` success.
-- Stripe canonical and alias routes both existed, but P4 merge-protected adjudication for orchestration idempotency + ACK matrix was not yet wired as a dedicated gate.
+- Prior P4 landing correctly fixed duplicate suppression and side-effect isolation, but ACK protocol stability was incomplete.
+- Root blocker: malformed authenticated payload handling was route-dependent:
+  - `stripe` alias route (`/api/webhooks/stripe/payment_intent/succeeded`) already used route-owned raw parsing and returned `200` + `status: dlq_routed`.
+  - `shopify`, `stripe` canonical (`/api/webhooks/stripe/payment_intent_succeeded`), `paypal`, and `woocommerce` still used FastAPI typed `Body(...)` signature binding, allowing framework pre-handler validation behavior and potential `422` leakage.
+- This violated the P4 protocol law requiring route-stable malformed authenticated ACK semantics across supported mounted providers and aliases.
 
-## 2) Remediations implemented
+## 2) Forensic hypotheses adjudicated
 
-- Replaced hidden duplicate signaling in `backend/app/ingestion/event_service.py`:
-  - Added explicit typed contract surface `IngestionResultState` (`inserted`, `duplicate`) and `IngestionDecision`.
-  - Added `ingest_event_with_decision(...)` to return event + explicit state.
-  - Kept `ingest_event(...)` as backward-compatible wrapper returning the event only.
-  - Updated `ingest_with_transaction(...)` to consume typed decision and return explicit `is_duplicate` plus `ingestion_state`.
-  - Removed private `_ingestion_duplicate` marker usage from authoritative ingestion path.
-- Added P4 governance + merge-blocking adjudication surface:
-  - `contracts-internal/governance/b22_p4_idempotent_ack_orchestration.main.json`
-  - `scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py`
-  - `backend/tests/test_b22_p4_idempotent_ack_orchestration_enforcer.py`
-  - CI wiring in `.github/workflows/ci.yml`.
-- Added runtime P4 proof suite:
-  - `backend/tests/test_b22_p4_idempotent_ack_orchestration.py`
-  - Proves duplicate replay emits one durable row and one downstream schedule only.
-  - Proves ACK matrix outcomes for success, duplicate, forged, malformed authenticated payload, oversized payload, missing/wrong tenant key, and unsupported family.
-  - Proves stripe canonical and alias route ACK parity for success + forged outcomes.
+- H01/H02 (framework-prevalidation leak and narrow proof surface): **Validated**.
+- H03 (global handler shortcut risk): **Rejected as implementation path**; no global `RequestValidationError` special-casing was used to implement the fix.
+- H04 (duplicate seam still dict-consumed): **Still bounded hardening debt**, but not the blocker for this corrective action.
+- H05/H06 (auth-precedence and non-regression risk): **Addressed in runtime tests** by explicit forged/missing/wrong-tenant malformed assertions and duplicate-substrate preservation checks.
 
-## 3) Falsifiable proof outcomes (local run)
+## 3) Remediations implemented
+
+- `backend/app/api/webhooks.py`
+  - Removed typed `Body(...)` request binding from supported webhook handlers:
+    - `shopify_order_create`
+    - `stripe_payment_intent_succeeded` (canonical)
+    - `paypal_sale_completed`
+    - `woocommerce_order_completed`
+  - Added route-local post-auth parsing surface:
+    - `_parse_json_object(...)`
+    - `_malformed_idempotency_key(...)`
+    - `_route_authenticated_malformed_payload(...)`
+  - Enforced malformed authenticated behavior at webhook boundary (after auth success):
+    - invalid JSON or invalid required shape now routes to DLQ and returns `200` + `status: dlq_routed` consistently.
+  - Preserved auth precedence:
+    - forged/missing-tenant/wrong-tenant requests continue to terminate in `401` auth class before malformed-DLQ handling.
+  - Preserved duplicate substrate and scheduling isolation:
+    - no change to duplicate suppression gate (`result.get("is_duplicate")`) and no change to scheduling failure containment behavior.
+
+- `backend/tests/test_b22_p4_idempotent_ack_orchestration.py`
+  - Expanded ACK matrix runtime proof to include malformed authenticated route coverage for:
+    - Shopify
+    - Stripe canonical
+    - Stripe alias
+    - PayPal
+    - WooCommerce
+  - Added auth-precedence assertions per malformed route:
+    - forged malformed -> `401`
+    - missing-tenant malformed -> `401`
+    - wrong-tenant malformed -> `401`
+  - Extended stripe canonical vs alias parity proof to include malformed ACK parity (`200` + `dlq_routed` on both).
+
+- `contracts-internal/governance/b22_p4_idempotent_ack_orchestration.main.json`
+  - Bumped contract version to `1.1.0`.
+  - Added explicit `route_scope` for `malformed_authenticated_payload` ACK contract covering all supported mounted routes/alias.
+
+- `scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py`
+  - Added governance check for malformed route scope completeness.
+  - Added webhook-surface invariant checks forbidding typed `Body(...)` binding on supported webhook routes.
+  - Kept duplicate-substrate and CI wiring assertions intact.
+
+- `backend/tests/test_b12_p8_error_contract_normalization.py`
+  - Updated authenticated malformed webhook expectation from `422` problem-details path to route-owned `200` + `dlq_routed`.
+  - Added DLQ stub in this test to keep it deterministic and independent of tenant-table fixture persistence.
+
+## 4) Local falsifiable proof outcomes
 
 - `python scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py` -> **PASS**
 - `pytest backend/tests/test_b22_p4_idempotent_ack_orchestration_enforcer.py -q` -> **5 passed**
-- `pytest backend/tests/test_b22_p4_idempotent_ack_orchestration.py -q` -> **4 skipped** (authoritative local DB lacks migrated `webhook_ingress_identities`; suite is configured to skip locally unless `SKELDIR_B22_P4_REQUIRE_DB_PROOFS=1`)
+- `pytest backend/tests/test_b22_p4_idempotent_ack_orchestration.py -q` -> **4 skipped** locally (authoritative DB proof gate unchanged; requires migrated DB and `SKELDIR_B22_P4_REQUIRE_DB_PROOFS=1`)
+- `pytest backend/tests/test_b12_p8_error_contract_normalization.py -q` -> **14 passed**
 
-## 4) Exit gate adjudication snapshot
+## 5) Exit gate adjudication (corrective iteration)
 
-- Exit Gate 1 (Duplicate-Suppression Mechanism): **Addressed** with explicit typed decision contract replacing hidden private marker propagation.
-- Exit Gate 2 (B0.4 Non-Regression): **Guarded** by backward-compatible `ingest_event(...)` wrapper + unchanged B0.4 call surface.
-- Exit Gate 3 (ACK Protocol): **Guarded** by dedicated ACK matrix runtime proofs and CI enforcer.
-- Exit Gate 4 (Merge-Blocking Adjudication): **Wired** via dedicated P4 enforcer + tests in CI workflow.
+- Exit Gate 1 (Duplicate-Suppression Integrity): **Maintained**.
+- Exit Gate 2 (ACK Protocol Physics, primary blocker): **Addressed in implementation + expanded route matrix proofs**.
+- Exit Gate 3 (Auth-Precedence): **Explicitly proven in malformed-route auth-precedence checks**.
+- Exit Gate 4 (B0.4 + Scheduling Non-Regression): **Maintained** (duplicate and scheduling logic unchanged; compatibility surfaces preserved).
+- Exit Gate 5 (Merge-Blocking P4 Adjudication): **Pending protected-branch merge + post-merge `main` CI success evidence capture**.
 
-## 5) Protected-branch landing status
+## 6) Protected-branch landing evidence (this corrective iteration)
 
-- Protected workflow PR: `https://github.com/Synergyscape-V1/skeldir-2.0/pull/367`
-- PR state: **MERGED** at `2026-04-21T18:00:23Z`
-- Merge commit on `main`: `7a84738adc38de30a8b1c54e7c9204ec7a33aee0`
-- Required-check adjudication for PR head passed prior to merge (authoritative `gh pr checks 367 --required` evidence captured).
-- Post-merge `main` CI run: `https://github.com/Synergyscape-V1/skeldir-2.0/actions/runs/24738191332`
-- Post-merge `main` CI status: **completed / success** for merge commit `7a84738adc38de30a8b1c54e7c9204ec7a33aee0`.
+- Feature branch: `b22-p4-ack-route-stability-corrective`
+- PR: _pending_
+- Merge commit on `main`: _pending_
+- Post-merge `main` CI run URL: _pending_
+- Post-merge `main` CI status: _pending_
 
-## 6) Completion verdict
+## 7) Completion verdict (current state)
 
-- Phase B2.2-P4 directive closure status: **COMPLETE**
-- Falsifiable closure basis:
-  - explicit duplicate-state orchestration contract replaces hidden private marker coupling,
-  - merge-blocking P4 enforcement and runtime proofs are wired in CI,
-  - protected-branch PR merge to `main` is complete,
-  - and full `main` CI run for the merge commit completed green.
+- Corrective implementation state: **READY FOR PROTECTED-BRANCH MERGE**
+- Final directive closure status: **PENDING** until:
+  - PR is merged into `main` through branch protection,
+  - required checks are green,
+  - and post-merge `main` CI is confirmed green for the landed corrective commit.

--- a/scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py
+++ b/scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py
@@ -31,6 +31,13 @@ EXPECTED_OUTCOMES = {
     "wrong_tenant_key",
     "unsupported_event_family",
 }
+EXPECTED_MALFORMED_ROUTE_SCOPE = {
+    "/api/webhooks/shopify/order_create",
+    "/api/webhooks/stripe/payment_intent_succeeded",
+    "/api/webhooks/stripe/payment_intent/succeeded",
+    "/api/webhooks/paypal/sale_completed",
+    "/api/webhooks/woocommerce/order_completed",
+}
 
 
 def _resolve(repo_root: Path, raw: str) -> Path:
@@ -77,6 +84,12 @@ def _validate_contract(contract: dict[str, Any], violations: list[str]) -> None:
     outcomes = {str(key).strip() for key in ack_matrix.keys()}
     if outcomes != EXPECTED_OUTCOMES:
         violations.append("contract_ack_outcome_set_mismatch:" + "|".join(sorted(outcomes)))
+    malformed_scope = {
+        str(item).strip()
+        for item in (ack_matrix.get("malformed_authenticated_payload") or {}).get("route_scope", [])
+    }
+    if malformed_scope != EXPECTED_MALFORMED_ROUTE_SCOPE:
+        violations.append("contract_malformed_route_scope_mismatch:" + "|".join(sorted(malformed_scope)))
 
 
 def _validate_event_service(path: Path, violations: list[str]) -> None:
@@ -107,12 +120,23 @@ def _validate_webhooks(path: Path, violations: list[str]) -> None:
         "not bool(result.get(\"is_duplicate\"))",
         "\"status\": \"dlq_routed\"",
         "status.HTTP_413_REQUEST_ENTITY_TOO_LARGE",
+        "_route_authenticated_malformed_payload(",
+        "_parse_json_object(",
         "/webhooks/stripe/payment_intent_succeeded",
         "/webhooks/stripe/payment_intent/succeeded",
     )
     for token in required_tokens:
         if token not in text:
             violations.append(f"webhooks_missing_token:{token}")
+    forbidden_tokens = (
+        "payload: ShopifyOrderCreateRequest = Body(...)",
+        "payload: StripePaymentIntentSucceededRequest = Body(...)",
+        "payload: PayPalSaleCompletedRequest = Body(...)",
+        "payload: WooCommerceOrderCompletedRequest = Body(...)",
+    )
+    for token in forbidden_tokens:
+        if token in text:
+            violations.append(f"webhooks_forbidden_token_present:{token}")
 
 
 def _validate_ci(path: Path, violations: list[str]) -> None:
@@ -135,6 +159,7 @@ def _validate_test_surfaces(*, p4_test: Path, p4_enforcer_test: Path, violations
         "test_b22_p4_duplicate_replay_preserves_single_durable_event_row",
         "test_b22_p4_ack_matrix_is_stable_for_success_duplicate_forged_malformed_oversized_tenant_and_unsupported_outcomes",
         "test_b22_p4_stripe_alias_and_canonical_routes_share_ack_semantics",
+        "malformed_cases = [",
     )
     for token in p4_required_tests:
         if token not in p4_text:


### PR DESCRIPTION
## Summary
- Move supported webhook routes (Shopify, Stripe canonical, PayPal, WooCommerce) from FastAPI typed body binding to post-auth raw-body/manual parse so malformed authenticated payloads are handler-owned and route-stable.
- Preserve protocol auth precedence: forged/missing-tenant/wrong-tenant malformed requests remain `401`, while authenticated malformed requests route to DLQ with `200` + `status: dlq_routed`.
- Expand P4 governance and runtime evidence to enforce full malformed route scope and update the Phase B2.2-P4 evidence pack for this corrective iteration.

## Test plan
- [x] `python scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py`
- [x] `pytest backend/tests/test_b22_p4_idempotent_ack_orchestration_enforcer.py -q`
- [x] `pytest backend/tests/test_b22_p4_idempotent_ack_orchestration.py -q` (local DB-gated skip behavior preserved)
- [x] `pytest backend/tests/test_b12_p8_error_contract_normalization.py -q`