### PR TITLE
B2.3-P0: sanctioned governed Neon API key source for deploy closure

### DIFF
--- a/.github/workflows/schema-deploy-production.yml
+++ b/.github/workflows/schema-deploy-production.yml
@@ -28,6 +28,8 @@ jobs:
     env:
       AWS_REGION: us-east-2
       SKELDIR_ENV: prod
+      GH_NEON_API_KEY: ${{ secrets.NEON_API_KEY }} # b23_p0_governed_secret_source
+      GH_NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -172,6 +174,12 @@ jobs:
           fi
           if [ -z "${NEON_DATABASE_URL}" ]; then
             NEON_DATABASE_URL=$(resolve_ssm_by_fragments neon database url || true)
+          fi
+          if [ -z "${NEON_API_KEY}" ] && [ -n "${GH_NEON_API_KEY:-}" ]; then
+            NEON_API_KEY="${GH_NEON_API_KEY}"
+          fi
+          if [ -z "${NEON_PROJECT_ID}" ] && [ -n "${GH_NEON_PROJECT_ID:-}" ]; then
+            NEON_PROJECT_ID="${GH_NEON_PROJECT_ID}"
           fi
 
           if [ -z "${NEON_DATABASE_URL}" ] && { [ -z "${NEON_API_KEY}" ] || [ -z "${NEON_PROJECT_ID}" ]; }; then

--- a/backend/tests/test_b11_p4_static_scans.py
+++ b/backend/tests/test_b11_p4_static_scans.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import subprocess
 import sys
 from pathlib import Path
@@ -7,6 +8,48 @@ from pathlib import Path
 
 def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
+
+
+def _load_static_scan_module():
+    root = _repo_root()
+    script_path = root / "scripts" / "security" / "b11_p4_generate_static_scans.py"
+    spec = importlib.util.spec_from_file_location("b11_p4_static_scan_module", script_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_b11_p4_static_scan_allowlisted_governed_neon_source(tmp_path: Path) -> None:
+    module = _load_static_scan_module()
+    repo_root = tmp_path / "repo"
+    workflow_path = repo_root / ".github" / "workflows" / "schema-deploy-production.yml"
+    workflow_path.parent.mkdir(parents=True, exist_ok=True)
+    workflow_path.write_text(
+        "env:\n  GH_NEON_API_KEY: ${{ secrets.NEON_API_KEY }} # b23_p0_governed_secret_source\n",
+        encoding="utf-8",
+    )
+
+    module.REPO_ROOT = repo_root
+    violations = module._scan_workflows([workflow_path])
+    assert not violations
+
+
+def test_b11_p4_static_scan_rejects_neon_secret_without_marker_even_on_governed_path(
+    tmp_path: Path,
+) -> None:
+    module = _load_static_scan_module()
+    repo_root = tmp_path / "repo"
+    workflow_path = repo_root / ".github" / "workflows" / "schema-deploy-production.yml"
+    workflow_path.parent.mkdir(parents=True, exist_ok=True)
+    workflow_path.write_text(
+        "env:\n  GH_NEON_API_KEY: ${{ secrets.NEON_API_KEY }}\n",
+        encoding="utf-8",
+    )
+
+    module.REPO_ROOT = repo_root
+    violations = module._scan_workflows([workflow_path])
+    assert any("prohibited GitHub secret source for high-risk credential" in item for item in violations)
 
 
 def test_b11_p4_static_scan_negative_control(tmp_path: Path):

--- a/contracts-internal/governance/b15_p7_ci_adjudication_closure.main.json
+++ b/contracts-internal/governance/b15_p7_ci_adjudication_closure.main.json
@@ -45,6 +45,8 @@
       "--mode technical",
       "--status-file docs/forensics/evidence/b15_p7/mental_model_study/status.json",
       "Guard Neon control-plane secrets (fail closed when missing)",
+      "GH_NEON_API_KEY: ${{ secrets.NEON_API_KEY }} # b23_p0_governed_secret_source",
+      "GH_NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}",
       "/skeldir/${SKELDIR_ENV}/secret/database/migration-url",
       "/skeldir/${SKELDIR_ENV}/secret/database/runtime-url",
       "Missing required Neon control-plane values for governed production deploy.",

--- a/scripts/ci/enforce_b23_p0_semantic_authority_freeze.py
+++ b/scripts/ci/enforce_b23_p0_semantic_authority_freeze.py
@@ -628,6 +628,8 @@ def _validate_deploy_workflow(path: Path, violations: list[str]) -> None:
         "python scripts/ci/b15_p7_phase_closure_gate.py",
         "--mode technical",
         "Guard Neon control-plane secrets (fail closed when missing)",
+        "GH_NEON_API_KEY: ${{ secrets.NEON_API_KEY }} # b23_p0_governed_secret_source",
+        "GH_NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}",
         "/skeldir/${SKELDIR_ENV}/secret/database/migration-url",
         "/skeldir/${SKELDIR_ENV}/secret/database/runtime-url",
         "Missing required Neon control-plane values for governed production deploy.",

--- a/scripts/security/b11_p4_generate_static_scans.py
+++ b/scripts/security/b11_p4_generate_static_scans.py
@@ -33,6 +33,7 @@ ALLOWED_PATHS = {
     "backend/app/core/managed_settings_contract.py",
     "alembic/env.py",
 }
+_GOVERNED_SECRET_MARKER = "b23_p0_governed_secret_source"
 
 
 def _repo_rel(path: Path) -> str:
@@ -102,7 +103,9 @@ def _scan_python_file(path: Path) -> tuple[list[str], list[str]]:
 def _scan_workflows(workflow_paths: list[Path]) -> list[str]:
     violations: list[str] = []
     workflows = workflow_paths
-    risky_github_secret = re.compile(r"\$\{\{\s*secrets\.(NEON_API_KEY|NEON_PROJECT_ID|DATABASE_URL|MIGRATION_DATABASE_URL)\s*}}")
+    risky_github_secret = re.compile(
+        r"\$\{\{\s*secrets\.(NEON_API_KEY|NEON_PROJECT_ID|DATABASE_URL|MIGRATION_DATABASE_URL)\s*}}"
+    )
     dsn_pattern = re.compile(r"postgresql(?:\+asyncpg)?://[^\s\"']+")
     allowed_hosts = ("localhost", "127.0.0.1", "postgres")
 
@@ -110,7 +113,16 @@ def _scan_workflows(workflow_paths: list[Path]) -> list[str]:
         rel = _repo_rel(path)
         text = path.read_text(encoding="utf-8")
         for idx, line in enumerate(text.splitlines(), start=1):
-            if risky_github_secret.search(line):
+            secret_match = risky_github_secret.search(line)
+            if secret_match:
+                secret_name = secret_match.group(1)
+                governed_allowlist_ok = (
+                    rel == ".github/workflows/schema-deploy-production.yml"
+                    and secret_name == "NEON_API_KEY"
+                    and _GOVERNED_SECRET_MARKER in line
+                )
+                if governed_allowlist_ok:
+                    continue
                 violations.append(f"{rel}:{idx}: prohibited GitHub secret source for high-risk credential")
             for match in dsn_pattern.finditer(line):
                 dsn = match.group(0)


### PR DESCRIPTION
## Summary
- permit a narrowly scoped governed secrets.NEON_API_KEY source only in schema-deploy-production.yml via explicit marker 23_p0_governed_secret_source
- preserve fail-closed B11 scanning everywhere else (including same secret on non-governed paths)
- wire deploy workflow fallback to consume governed GitHub API key + project ID when AWS control-plane values are unavailable
- keep canonical AWS DB secret path resolution in place
- enforce this path through B2.3 and B1.5 governance contracts/enforcers

## Validation
- python scripts/security/b11_p4_generate_static_scans.py --out-dir docs/forensics/evidence/b11_p4
- pytest backend/tests/test_b11_p4_static_scans.py -q
- python scripts/ci/enforce_b23_p0_semantic_authority_freeze.py
- python scripts/ci/enforce_b15_p7_ci_adjudication_closure.py
- pytest backend/tests/test_b23_p0_semantic_authority_freeze_enforcer.py -q
- pytest backend/tests/test_b15_p7_ci_adjudication_closure_enforcer.py -q
