### PR TITLE
B2.3-P0: fix governed deploy env scope for CI deploy role

### DIFF
--- a/.github/workflows/schema-deploy-production.yml
+++ b/.github/workflows/schema-deploy-production.yml
@@ -27,7 +27,8 @@ jobs:
       contents: read
     env:
       AWS_REGION: us-east-2
-      SKELDIR_ENV: prod
+      # B11 control-plane governance: skeldir-ci-deploy role is scoped to /skeldir/ci/*.
+      SKELDIR_ENV: ci
       GH_NEON_API_KEY: ${{ secrets.NEON_API_KEY }} # b23_p0_governed_secret_source
       GH_NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
     steps:


### PR DESCRIPTION
## Summary
- align schema-deploy-production SKELDIR env scope with B11 OIDC deploy-role policy
- use SKELDIR_ENV=ci so governed secret retrieval resolves against authorized /skeldir/ci/* namespace
- preserve fail-closed behavior and all B2.3-P0 runtime verification gates

## Why
The deploy role (skeldir-ci-deploy) is scoped to CI/shared paths; using prod namespace made AWS retrieval impossible and forced an invalid fallback credential path, blocking governed runtime proof.

## Validation
- python scripts/ci/enforce_b23_p0_semantic_authority_freeze.py
- python scripts/ci/enforce_b15_p7_ci_adjudication_closure.py
- pytest backend/tests/test_b23_p0_semantic_authority_freeze_enforcer.py -q
- pytest backend/tests/test_b11_p4_static_scans.py -q