### PR TITLE
b23-p0: prioritize runtime db secret in governed deploy

### DIFF
--- a/.github/workflows/schema-deploy-production.yml
+++ b/.github/workflows/schema-deploy-production.yml
@@ -217,8 +217,8 @@ jobs:
           fi
 
           NEON_DATABASE_URL=$(resolve_secret_manager_value \
-            "/skeldir/${SKELDIR_ENV}/secret/database/migration-url" \
             "/skeldir/${SKELDIR_ENV}/secret/database/runtime-url" \
+            "/skeldir/${SKELDIR_ENV}/secret/database/migration-url" \
             "/skeldir/${SKELDIR_ENV}/secret/control-plane/neon-database-url" \
             "/skeldir/${SKELDIR_ENV}/secret/ci/neon-database-url" \
             "/skeldir/${SKELDIR_ENV}/secret/neon-database-url" \


### PR DESCRIPTION
## Scope
- Resolve runtime secret precedence ambiguity in governed production schema deployment.
- Prefer `/secret/database/runtime-url` before `/secret/database/migration-url`.

## Why
Governed deploy was selecting migration DSN (localhost) before runtime DSN, forcing fallback paths and blocking Neon runtime proof.

## Validation
- `python scripts/ci/enforce_b23_p0_semantic_authority_freeze.py --skip-baseline-git-check`
- `python scripts/ci/enforce_b15_p7_ci_adjudication_closure.py`
- `pytest backend/tests/test_b23_p0_semantic_authority_freeze_enforcer.py -q`