### PR TITLE
b23-p0: harden governed Neon credential resolution

### DIFF
--- a/.github/workflows/schema-deploy-production.yml
+++ b/.github/workflows/schema-deploy-production.yml
@@ -200,7 +200,32 @@ jobs:
                   fi
                   ;;
                 neon_database_url)
-                  normalized=$(echo "${payload}" | jq -r '(.RUNTIME_DATABASE_URL // .runtime_database_url // .DATABASE_URL // .database_url // .connection_uri // .uri // .runtime_url // .url // .MIGRATION_DATABASE_URL // .migration_database_url // .migration_url // empty)')
+                  normalized=$(echo "${payload}" | jq -r '
+                    def dsn_candidates:
+                      [
+                        .RUNTIME_DATABASE_URL,
+                        .runtime_database_url,
+                        .DATABASE_URL,
+                        .database_url,
+                        .connection_uri,
+                        .uri,
+                        .runtime_url,
+                        .url,
+                        .MIGRATION_DATABASE_URL,
+                        .migration_database_url,
+                        .migration_url,
+                        (.. | strings | select(test("^postgres(ql)?(\\+[A-Za-z0-9_]+)?://"))),
+                        (.. | strings | select(test("(^|[[:space:]])host=")))
+                      ]
+                      | map(select(type == "string" and length > 0))
+                      | map(gsub("^\\s+|\\s+$"; ""));
+                    def is_local:
+                      test("://([^/@]+@)?(localhost|127\\.0\\.0\\.1|\\[::1\\]|::1)(:|/|$)")
+                      or test("(^|[[:space:]])host=(localhost|127\\.0\\.0\\.1|::1|\\[::1\\])([[:space:]]|$)");
+                    (dsn_candidates | map(select((is_local | not))) | .[0])
+                    // (dsn_candidates | .[0])
+                    // empty
+                  ')
                   ;;
                 *)
                   normalized="${payload}"
@@ -242,6 +267,23 @@ jobs:
             NEON_API_KEY=$(normalize_secret_payload "${NEON_API_KEY:-}" neon_api_key)
             if [ -n "${NEON_API_KEY}" ]; then
               NEON_API_SOURCE="aws_secrets_manager_fragment"
+            fi
+          fi
+          if [ -z "${NEON_API_KEY}" ]; then
+            NEON_API_KEY=$(resolve_ssm_value \
+              "/skeldir/${SKELDIR_ENV}/config/ci/neon-api-key" \
+              "/skeldir/${SKELDIR_ENV}/config/neon-api-key" \
+              "/skeldir/${SKELDIR_ENV}/config/control-plane/neon-api-key" || true)
+            NEON_API_KEY=$(normalize_secret_payload "${NEON_API_KEY:-}" neon_api_key)
+            if [ -n "${NEON_API_KEY}" ]; then
+              NEON_API_SOURCE="aws_ssm_explicit"
+            fi
+          fi
+          if [ -z "${NEON_API_KEY}" ]; then
+            NEON_API_KEY=$(resolve_ssm_by_fragments neon api key || true)
+            NEON_API_KEY=$(normalize_secret_payload "${NEON_API_KEY:-}" neon_api_key)
+            if [ -n "${NEON_API_KEY}" ]; then
+              NEON_API_SOURCE="aws_ssm_fragment"
             fi
           fi
 


### PR DESCRIPTION
## Summary
- prefer non-local Postgres DSNs when managed secret payloads include multiple URI forms
- extend governed Neon API key discovery to AWS SSM (explicit + fragment paths) before GitHub allowlisted fallback
- keep fail-closed behavior when no governed credential path yields a valid runtime connection

## Validation
- python scripts/ci/enforce_b23_p0_semantic_authority_freeze.py --skip-baseline-git-check
- pytest backend/tests/test_b23_p0_semantic_authority_freeze_enforcer.py -q

## Why
Mainline deploy run 24927517453 failed at Get Neon connection string with pi=github_secret_allowlisted and Neon auth diagnostic, despite AWS-managed secret sources being present for DB URLs. This patch broadens governed resolution while preserving existing freeze invariants.