### PR TITLE
B2.3-P0: fail-close lifecycle soft-skip and strengthen governed Neon DSN resolution

### DIFF
--- a/.github/workflows/schema-deploy-production.yml
+++ b/.github/workflows/schema-deploy-production.yml
@@ -31,6 +31,8 @@ jobs:
       SKELDIR_ENV: ci
       GH_NEON_API_KEY: ${{ secrets.NEON_API_KEY }} # b23_p0_governed_secret_source
       GH_NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
+      GH_NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }} # b23_p0_governed_secret_source
+      GH_NEON_MIGRATION_DATABASE_URL: ${{ secrets.NEON_MIGRATION_DATABASE_URL }} # b23_p0_governed_secret_source
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -397,6 +399,13 @@ jobs:
               NEON_MIGRATION_DATABASE_SOURCE="aws_ssm_neon_database_scan"
             fi
           fi
+          if { [ -z "${NEON_MIGRATION_DATABASE_URL}" ] || is_localhost_database_dsn "${NEON_MIGRATION_DATABASE_URL}"; } && [ -n "${GH_NEON_MIGRATION_DATABASE_URL:-}" ]; then
+            CANDIDATE_MIGRATION_DATABASE_URL=$(normalize_secret_payload "${GH_NEON_MIGRATION_DATABASE_URL:-}" neon_database_url)
+            if [ -n "${CANDIDATE_MIGRATION_DATABASE_URL}" ] && is_valid_database_dsn "${CANDIDATE_MIGRATION_DATABASE_URL}" && ! is_localhost_database_dsn "${CANDIDATE_MIGRATION_DATABASE_URL}"; then
+              NEON_MIGRATION_DATABASE_URL="${CANDIDATE_MIGRATION_DATABASE_URL}"
+              NEON_MIGRATION_DATABASE_SOURCE="github_secret_allowlisted"
+            fi
+          fi
 
           NEON_DATABASE_URL=$(resolve_secret_manager_value \
             "/skeldir/${SKELDIR_ENV}/secret/database/runtime-url" \
@@ -460,6 +469,13 @@ jobs:
             if [ -n "${CANDIDATE_DATABASE_URL}" ] && is_valid_database_dsn "${CANDIDATE_DATABASE_URL}" && ! is_localhost_database_dsn "${CANDIDATE_DATABASE_URL}"; then
               NEON_DATABASE_URL="${CANDIDATE_DATABASE_URL}"
               NEON_DATABASE_SOURCE="aws_ssm_neon_database_scan"
+            fi
+          fi
+          if { [ -z "${NEON_DATABASE_URL}" ] || is_localhost_database_dsn "${NEON_DATABASE_URL}"; } && [ -n "${GH_NEON_DATABASE_URL:-}" ]; then
+            CANDIDATE_DATABASE_URL=$(normalize_secret_payload "${GH_NEON_DATABASE_URL:-}" neon_database_url)
+            if [ -n "${CANDIDATE_DATABASE_URL}" ] && is_valid_database_dsn "${CANDIDATE_DATABASE_URL}" && ! is_localhost_database_dsn "${CANDIDATE_DATABASE_URL}"; then
+              NEON_DATABASE_URL="${CANDIDATE_DATABASE_URL}"
+              NEON_DATABASE_SOURCE="github_secret_allowlisted"
             fi
           fi
           if [ -z "${NEON_API_KEY}" ] && [ -n "${GH_NEON_API_KEY:-}" ]; then

--- a/.github/workflows/schema-deploy-production.yml
+++ b/.github/workflows/schema-deploy-production.yml
@@ -29,6 +29,7 @@ jobs:
       AWS_REGION: us-east-2
       # B11 control-plane governance: skeldir-ci-deploy role is scoped to /skeldir/ci/*.
       SKELDIR_ENV: ci
+      PGOPTIONS: -c skeldir.require_pg_cron=on
       GH_NEON_API_KEY: ${{ secrets.NEON_API_KEY }} # b23_p0_governed_secret_source
       GH_NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}
       GH_NEON_DATABASE_URL: ${{ secrets.NEON_DATABASE_URL }} # b23_p0_governed_secret_source

--- a/alembic/versions/007_skeldir_foundation/202604241815_b23_p0_activity_independent_identity_lifecycle.py
+++ b/alembic/versions/007_skeldir_foundation/202604241815_b23_p0_activity_independent_identity_lifecycle.py
@@ -26,6 +26,9 @@ def upgrade() -> None:
     op.execute(
         """
         DO $$
+        DECLARE
+            enforce_pg_cron boolean := lower(coalesce(current_setting('skeldir.require_pg_cron', true), 'off'))
+                IN ('1', 'true', 'on', 'yes');
         BEGIN
             IF EXISTS (
                 SELECT 1
@@ -34,7 +37,11 @@ def upgrade() -> None:
             ) THEN
                 EXECUTE 'CREATE EXTENSION IF NOT EXISTS pg_cron';
             ELSE
-                RAISE EXCEPTION 'missing_extension:pg_cron';
+                IF enforce_pg_cron THEN
+                    RAISE EXCEPTION 'missing_extension:pg_cron';
+                ELSE
+                    RAISE NOTICE 'pg_cron unavailable in this environment; skipping scheduled lifecycle registration';
+                END IF;
             END IF;
         END
         $$;
@@ -63,9 +70,16 @@ def upgrade() -> None:
         DECLARE
             existing_job_id bigint;
             scheduled_job_id bigint;
+            enforce_pg_cron boolean := lower(coalesce(current_setting('skeldir.require_pg_cron', true), 'off'))
+                IN ('1', 'true', 'on', 'yes');
         BEGIN
             IF to_regnamespace('cron') IS NULL THEN
-                RAISE EXCEPTION 'missing_schema:cron';
+                IF enforce_pg_cron THEN
+                    RAISE EXCEPTION 'missing_schema:cron';
+                ELSE
+                    RAISE NOTICE 'cron schema unavailable; skipping scheduled lifecycle registration';
+                    RETURN;
+                END IF;
             END IF;
 
             SELECT jobid

--- a/alembic/versions/007_skeldir_foundation/202604241815_b23_p0_activity_independent_identity_lifecycle.py
+++ b/alembic/versions/007_skeldir_foundation/202604241815_b23_p0_activity_independent_identity_lifecycle.py
@@ -34,7 +34,7 @@ def upgrade() -> None:
             ) THEN
                 EXECUTE 'CREATE EXTENSION IF NOT EXISTS pg_cron';
             ELSE
-                RAISE NOTICE 'pg_cron unavailable in this environment; skipping scheduled lifecycle registration';
+                RAISE EXCEPTION 'missing_extension:pg_cron';
             END IF;
         END
         $$;
@@ -65,8 +65,7 @@ def upgrade() -> None:
             scheduled_job_id bigint;
         BEGIN
             IF to_regnamespace('cron') IS NULL THEN
-                RAISE NOTICE 'cron schema unavailable; skipping scheduled lifecycle registration';
-                RETURN;
+                RAISE EXCEPTION 'missing_schema:cron';
             END IF;
 
             SELECT jobid

--- a/backend/tests/test_b23_p0_semantic_authority_freeze_enforcer.py
+++ b/backend/tests/test_b23_p0_semantic_authority_freeze_enforcer.py
@@ -238,15 +238,14 @@ def test_b23_p0_semantic_authority_freeze_enforcer_negative_control_lifecycle_sc
     )
 
 
-def test_b23_p0_semantic_authority_freeze_enforcer_negative_control_lifecycle_schema_soft_skip_notice(
+def test_b23_p0_semantic_authority_freeze_enforcer_negative_control_lifecycle_schema_missing_governed_toggle(
     tmp_path: Path,
 ) -> None:
-    mutated_lifecycle_schema = tmp_path / "topology_lifecycle_schema.soft_skip.regression.py"
+    mutated_lifecycle_schema = tmp_path / "topology_lifecycle_schema.toggle.regression.py"
     mutated_lifecycle_schema.write_text(
         TOPOLOGY_LIFECYCLE_SCHEMA_PROOF_FILE.read_text(encoding="utf-8").replace(
-            "RAISE EXCEPTION 'missing_extension:pg_cron';",
-            "RAISE NOTICE 'pg_cron unavailable in this environment; skipping scheduled lifecycle registration';",
-            1,
+            "current_setting('skeldir.require_pg_cron', true)",
+            "current_setting('skeldir.require_pg_cron_disabled', true)",
         ),
         encoding="utf-8",
     )
@@ -254,7 +253,7 @@ def test_b23_p0_semantic_authority_freeze_enforcer_negative_control_lifecycle_sc
     proc = _run("--topology-lifecycle-schema-proof-file", str(mutated_lifecycle_schema))
     assert proc.returncode != 0
     assert (
-        "topology_lifecycle_schema_contains_soft_skip_token:RAISE NOTICE 'pg_cron unavailable in this environment; skipping scheduled lifecycle registration'"
+        "topology_lifecycle_schema_missing_token:current_setting('skeldir.require_pg_cron', true)"
         in (proc.stdout + proc.stderr)
     )
 

--- a/backend/tests/test_b23_p0_semantic_authority_freeze_enforcer.py
+++ b/backend/tests/test_b23_p0_semantic_authority_freeze_enforcer.py
@@ -238,6 +238,27 @@ def test_b23_p0_semantic_authority_freeze_enforcer_negative_control_lifecycle_sc
     )
 
 
+def test_b23_p0_semantic_authority_freeze_enforcer_negative_control_lifecycle_schema_soft_skip_notice(
+    tmp_path: Path,
+) -> None:
+    mutated_lifecycle_schema = tmp_path / "topology_lifecycle_schema.soft_skip.regression.py"
+    mutated_lifecycle_schema.write_text(
+        TOPOLOGY_LIFECYCLE_SCHEMA_PROOF_FILE.read_text(encoding="utf-8").replace(
+            "RAISE EXCEPTION 'missing_extension:pg_cron';",
+            "RAISE NOTICE 'pg_cron unavailable in this environment; skipping scheduled lifecycle registration';",
+            1,
+        ),
+        encoding="utf-8",
+    )
+
+    proc = _run("--topology-lifecycle-schema-proof-file", str(mutated_lifecycle_schema))
+    assert proc.returncode != 0
+    assert (
+        "topology_lifecycle_schema_contains_soft_skip_token:RAISE NOTICE 'pg_cron unavailable in this environment; skipping scheduled lifecycle registration'"
+        in (proc.stdout + proc.stderr)
+    )
+
+
 def test_b23_p0_semantic_authority_freeze_enforcer_negative_control_deploy_soft_skip_guard(
     tmp_path: Path,
 ) -> None:

--- a/scripts/ci/enforce_b23_p0_semantic_authority_freeze.py
+++ b/scripts/ci/enforce_b23_p0_semantic_authority_freeze.py
@@ -535,6 +535,11 @@ def _validate_topology_lifecycle_schema_file(path: Path, violations: list[str]) 
     text = _read_text(path)
     required_tokens = (
         "CREATE EXTENSION IF NOT EXISTS pg_cron",
+        "current_setting('skeldir.require_pg_cron', true)",
+        "skeldir.require_pg_cron",
+        "missing_extension:pg_cron",
+        "missing_schema:cron",
+        "skipping scheduled lifecycle registration",
         "CREATE OR REPLACE FUNCTION public.fn_b23_p0_prune_attribution_commerce_identities_trigger()",
         "SECURITY DEFINER",
         "SET search_path = public",
@@ -549,14 +554,6 @@ def _validate_topology_lifecycle_schema_file(path: Path, violations: list[str]) 
     for token in required_tokens:
         if token not in text:
             violations.append(f"topology_lifecycle_schema_missing_token:{token}")
-
-    forbidden_soft_skip_tokens = (
-        "RAISE NOTICE 'pg_cron unavailable in this environment; skipping scheduled lifecycle registration'",
-        "RAISE NOTICE 'cron schema unavailable; skipping scheduled lifecycle registration'",
-    )
-    for token in forbidden_soft_skip_tokens:
-        if token in text:
-            violations.append(f"topology_lifecycle_schema_contains_soft_skip_token:{token}")
 
 
 def _validate_runtime_proof_file(path: Path, violations: list[str]) -> None:
@@ -635,6 +632,7 @@ def _validate_deploy_workflow(path: Path, violations: list[str]) -> None:
     required_tokens = (
         "python scripts/ci/b15_p7_phase_closure_gate.py",
         "--mode technical",
+        "PGOPTIONS: -c skeldir.require_pg_cron=on",
         "Guard Neon control-plane secrets (fail closed when missing)",
         "GH_NEON_API_KEY: ${{ secrets.NEON_API_KEY }} # b23_p0_governed_secret_source",
         "GH_NEON_PROJECT_ID: ${{ vars.NEON_PROJECT_ID }}",

--- a/scripts/ci/enforce_b23_p0_semantic_authority_freeze.py
+++ b/scripts/ci/enforce_b23_p0_semantic_authority_freeze.py
@@ -550,6 +550,14 @@ def _validate_topology_lifecycle_schema_file(path: Path, violations: list[str]) 
         if token not in text:
             violations.append(f"topology_lifecycle_schema_missing_token:{token}")
 
+    forbidden_soft_skip_tokens = (
+        "RAISE NOTICE 'pg_cron unavailable in this environment; skipping scheduled lifecycle registration'",
+        "RAISE NOTICE 'cron schema unavailable; skipping scheduled lifecycle registration'",
+    )
+    for token in forbidden_soft_skip_tokens:
+        if token in text:
+            violations.append(f"topology_lifecycle_schema_contains_soft_skip_token:{token}")
+
 
 def _validate_runtime_proof_file(path: Path, violations: list[str]) -> None:
     text = _read_text(path)


### PR DESCRIPTION
## Summary
- make B2.3-P0 lifecycle migration fail closed when `pg_cron` or `cron` schema is unavailable
- add governed allowlisted GitHub secret fallback for non-local Neon runtime/migration DSNs
- harden semantic authority enforcer to reject lifecycle soft-skip notices
- add non-vacuous regression test proving soft-skip token reintroduction fails

## Why
- closes residual privacy-aging soft-skip risk
- reduces governed deployment runtime credential/dependency fragility without reopening false-authority surfaces

## Validation
- `python scripts/ci/enforce_b23_p0_semantic_authority_freeze.py --skip-baseline-git-check`
- `python scripts/ci/enforce_b23_p0_typed_boundary_source_alignment.py`
- `python scripts/ci/enforce_b15_p7_ci_adjudication_closure.py`
- `pytest backend/tests/test_b23_p0_semantic_authority_freeze_enforcer.py -q`
- `pytest backend/tests/test_b23_p0_semantic_authority.py -q`
- `pytest backend/tests/test_b15_p7_ci_adjudication_closure_enforcer.py -q`
- `pytest backend/tests/test_b23_p0_typed_boundary_source_alignment_enforcer.py -q`