### PR TITLE
B2.3-P0: remove privileged pg_cron create from governed deploy

### DIFF
--- a/.github/workflows/schema-deploy-production.yml
+++ b/.github/workflows/schema-deploy-production.yml
@@ -1007,7 +1007,17 @@ jobs:
           psql "${CONTROL_DATABASE_URL}" -v ON_ERROR_STOP=1 \
             -v target_db="${TARGET_DATABASE_NAME}" \
             -v target_user="${TARGET_DATABASE_USER}" <<'SQL' | tee -a audit_logs/deployment.log
-          CREATE EXTENSION IF NOT EXISTS pg_cron;
+          DO $$
+          BEGIN
+            IF NOT EXISTS (
+              SELECT 1
+              FROM pg_extension
+              WHERE extname = 'pg_cron'
+            ) THEN
+              RAISE EXCEPTION 'missing_extension:pg_cron';
+            END IF;
+          END
+          $$;
 
           SELECT cron.unschedule(jobid)
           FROM cron.job


### PR DESCRIPTION
## Summary
- remove privileged `CREATE EXTENSION pg_cron` call from governed deploy control-db registration step
- preserve fail-closed behavior by explicitly asserting `pg_cron` extension existence before scheduling
- keep downstream cron job registration + lifecycle verification path intact

## Why
- governed deploy on `main` run 25074083392 reached runtime registration and failed with:
  - `permission denied to create extension pg_cron`
- this role cannot create extensions in control DB, so deployment must rely on pre-provisioned extension while still failing closed if absent.

## Validation
- python scripts/ci/enforce_b23_p0_semantic_authority_freeze.py --skip-baseline-git-check