### PR TITLE
B2.3-P0: support same-db pg_cron registration permissions

### DIFF
--- a/.github/workflows/schema-deploy-production.yml
+++ b/.github/workflows/schema-deploy-production.yml
@@ -1157,7 +1157,20 @@ jobs:
           FROM cron.job
           WHERE jobname = 'b23_p0_prune_attribution_commerce_identities_hourly'
             AND database = :'target_db';
+          SQL
 
+          if [ "${CRON_DATABASE_NAME}" = "${TARGET_DATABASE_NAME}" ]; then
+            psql "${CONTROL_DATABASE_URL}" -v ON_ERROR_STOP=1 <<'SQL' | tee -a audit_logs/deployment.log
+          SELECT cron.schedule(
+            'b23_p0_prune_attribution_commerce_identities_hourly',
+            '0 * * * *',
+            $$SELECT public.fn_b23_p0_prune_attribution_commerce_identities(1000);$$
+          );
+          SQL
+          else
+            psql "${CONTROL_DATABASE_URL}" -v ON_ERROR_STOP=1 \
+              -v target_db="${TARGET_DATABASE_NAME}" \
+              -v target_user="${TARGET_DATABASE_USER}" <<'SQL' | tee -a audit_logs/deployment.log
           SELECT cron.schedule_in_database(
             'b23_p0_prune_attribution_commerce_identities_hourly',
             '0 * * * *',
@@ -1167,6 +1180,7 @@ jobs:
             true
           );
           SQL
+          fi
 
       - name: Verify B2.3-P0 delayed-arrival lifecycle substrate in Neon production
         env:


### PR DESCRIPTION
## Summary\n- keep fail-closed pg_cron alignment logic from PR #411\n- fix governed runtime registration for Neon roles that cannot call cron.schedule_in_database\n- when cron.database_name == target_db, register via cron.schedule(...)\n- keep cross-db fallback via cron.schedule_in_database(...)\n\n## Why\nGoverned deploy run 25078254133 reached runtime registration and failed with permission denied for function schedule_in_database even after lifecycle alignment and extension installation.\n\n## Validation\n- runtime SQL repro confirmed role can call cron.schedule in same DB\n- workflow now picks permission-compatible path while preserving fail-closed behavior"