### PR TITLE
fix(marketing): force favicon cache rollover after remediation merge

### DIFF
--- a/marketing/src/app/layout.tsx
+++ b/marketing/src/app/layout.tsx
@@ -16,7 +16,7 @@ const playfairDisplay = Playfair_Display({
   style: ["normal", "italic"],
 });
 
-const FAVICON_VERSION = "20260415a";
+const FAVICON_VERSION = "20260430a";
 
 export const metadata: Metadata = {
   metadataBase: new URL("https://skeldir.com"),


### PR DESCRIPTION
## Summary
- bump marketing favicon cache version from `20260415a` to `20260430a`
- force clean icon/manifest URL rollover to prevent stale favicon artifacts after production merge

## Validation
- `marketing` build passes locally (`npm run build`)
- no lint diagnostics in updated layout metadata
- change scope is one-line metadata version bump only