### PR TITLE
Fix R2 reconciliation status bootstrap SQL

### DIFF
--- a/.github/workflows/r2-data-truth-hardening.yml
+++ b/.github/workflows/r2-data-truth-hardening.yml
@@ -271,6 +271,35 @@ jobs:
           if allocation_summary_view not in reordered:
               raise SystemExit("unable to locate mv_allocation_summary block in canonical schema")
           reordered = reordered.replace(allocation_summary_view, allocation_summary_view_bootstrap, 1)
+          reconciliation_status_view = textwrap.dedent("""\
+              CREATE MATERIALIZED VIEW mv_reconciliation_status AS
+               SELECT tenant_id,
+                  state,
+                  last_run_at,
+                  id AS reconciliation_run_id
+                 FROM (reconciliation_runs rr
+                   JOIN ( SELECT tenant_id,
+                          max(last_run_at) AS max_last_run_at
+                         FROM reconciliation_runs
+                        GROUP BY tenant_id) latest ON (((tenant_id = tenant_id) AND (last_run_at = max_last_run_at))))
+                WITH NO DATA;"""
+          ).strip()
+          reconciliation_status_view_bootstrap = textwrap.dedent("""\
+              CREATE MATERIALIZED VIEW mv_reconciliation_status AS
+               SELECT rr.tenant_id,
+                  rr.state,
+                  rr.last_run_at,
+                  rr.id AS reconciliation_run_id
+                 FROM (reconciliation_runs rr
+                   JOIN ( SELECT reconciliation_runs.tenant_id,
+                          max(reconciliation_runs.last_run_at) AS max_last_run_at
+                         FROM reconciliation_runs
+                        GROUP BY reconciliation_runs.tenant_id) latest ON (((rr.tenant_id = latest.tenant_id) AND (rr.last_run_at = latest.max_last_run_at))))
+                WITH NO DATA;"""
+          ).strip()
+          if reconciliation_status_view not in reordered:
+              raise SystemExit("unable to locate mv_reconciliation_status block in canonical schema")
+          reordered = reordered.replace(reconciliation_status_view, reconciliation_status_view_bootstrap, 1)
           target.write_text(reordered.rstrip() + "\n\n" + "\n".join(deferred_blocks), encoding="utf-8")
           PY
           podman exec -i skeldir-r2-postgres psql -v ON_ERROR_STOP=1 -U $POSTGRES_USER -d $POSTGRES_DB < /tmp/canonical_schema_r2_bootstrap.sql


### PR DESCRIPTION
## Summary
- qualify the R2 bootstrap copy of mv_reconciliation_status so raw canonical schema application avoids ambiguous tenant_id references
- keep canonical schema and migrations unchanged

## Validation
- local PyYAML parse of all workflow files
- local R2-style transformed canonical schema replay against PostgreSQL 18 temporary database succeeds
- git diff --check