### PR TITLE
ci(m0): allow main validator dispatch

### DIFF
--- a/.github/workflows/m0-maintainability-scope-lock.yml
+++ b/.github/workflows/m0-maintainability-scope-lock.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   push:
     branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary
- enable workflow_dispatch for the M0 maintainability scope-lock workflow so the merged main SHA can be re-run directly for final evidence

## Validation
- python scripts/ci/validate_m0_scope_lock.py --baseline-sha 9b9c0796faab9113f13bd9040a863b10213dfd7a
- git diff --check