### PR TITLE
ci(m0): fail stale clean-state evidence

### DIFF
--- a/scripts/ci/validate_m0_scope_lock.py
+++ b/scripts/ci/validate_m0_scope_lock.py
@@ -259,14 +259,16 @@ def check_baseline_fields(result: ValidationResult) -> None:
         result.add(f"Baseline field: {field}", field in content)
 
     stale_markers = [
-        "final clean-state confirmation\n\n**status:** pending",
-        "final clean-state confirmation\r\n\r\n**status:** pending",
         "**status:** pending",
         "pending admin action",
     ]
+    stale_clean_state = re.search(
+        r"final clean-state confirmation\s*:?\s*(?:\*\*status:\*\*\s*)?pending",
+        content,
+    )
     result.add(
         "Baseline has no stale pending/admin language",
-        not any(marker in content for marker in stale_markers),
+        stale_clean_state is None and not any(marker in content for marker in stale_markers),
     )
     result.add(
         "Baseline references canonical validation artifact",


### PR DESCRIPTION
## Summary
- tighten the M0 validator so any Final Clean-State Confirmation: PENDING baseline text fails, including inline stale language

## Validation
- python -m py_compile scripts/ci/validate_m0_scope_lock.py
- python scripts/ci/validate_m0_scope_lock.py --baseline-sha 0f0b3dd0c333ca84cb9ef8a725f4b268f909276a
- negative controls: missing canonical artifact exit=1; stale PENDING baseline exit=1; missing required-status evidence exit=1
- git diff --check