### PR TITLE
Enable production hero typewriter

### DIFF
--- a/marketing/src/components/layout/HeroSection.tsx
+++ b/marketing/src/components/layout/HeroSection.tsx
@@ -1,29 +1,244 @@
 "use client";
 
 import Link from "next/link";
+import type { CSSProperties, ReactNode } from "react";
+import { useEffect, useRef, useState } from "react";
 import { Button } from "@/components/ui/button";
+
+/** Full phrase — measure + slice use identical string for stable layout physics */
+const HERO_HEADLINE_LEAD = "Every ad dollar traced, verified to the source—";
+const HERO_TYPEWRITER_PREFIX = "So your AI Agents and teams ";
+const HERO_TYPEWRITER_SUFFIX_INITIAL = "never act on a guess.";
+const HERO_TYPEWRITER_SUFFIX_FINAL = "execute from confirmed truth.";
+const HERO_TYPEWRITER_PHRASE_INITIAL =
+  HERO_TYPEWRITER_PREFIX + HERO_TYPEWRITER_SUFFIX_INITIAL;
+const HERO_TYPEWRITER_PHRASE_FINAL =
+  HERO_TYPEWRITER_PREFIX + HERO_TYPEWRITER_SUFFIX_FINAL;
+/** Longest suffix sets invisible reserve width during suffix swap */
+const HERO_TYPEWRITER_LAYOUT_SUFFIX =
+  HERO_TYPEWRITER_SUFFIX_FINAL.length >= HERO_TYPEWRITER_SUFFIX_INITIAL.length
+    ? HERO_TYPEWRITER_SUFFIX_FINAL
+    : HERO_TYPEWRITER_SUFFIX_INITIAL;
+const HERO_HEADLINE_ARIA_LABEL = `${HERO_HEADLINE_LEAD} ${HERO_TYPEWRITER_PHRASE_FINAL}`;
+
+/** Subheadline — one string per line; order + spacing are layout-stable */
+const HERO_SUBHEADLINE_LINES = [
+  "Every major ad platform grades its own homework.",
+  "Skeldir cross-checks & reconciles ad platform data against Stripe and Shopify revenue in real time, and gives you and your tools data you can actually trust.",
+  "Live in 48 hours, not months.",
+] as const;
+const HERO_TYPEWRITER_MS_PER_CHAR = 58;
+const HERO_TYPEWRITER_BACKSPACE_MS_PER_CHAR = 42;
+const HERO_TYPEWRITER_START_DELAY_MS = 520;
+const HERO_HOLD_AFTER_INITIAL_MS = 2400;
+/** Caret geometry + blink — tied to type scale (em), not arbitrary px */
+const HERO_CARET_WIDTH_EM = 0.065;
+const HERO_CARET_MIN_WIDTH_PX = 2;
+const HERO_CARET_HEIGHT_EM = 1.06;
+const HERO_CARET_BLINK_DURATION_S = 1.55;
+
+/** Highlight term — indices are stable across initial/final (shared prefix) */
+const HERO_AI_AGENTS_TERM = "AI Agents";
+const HERO_AI_AGENTS_TERM_START = HERO_TYPEWRITER_PHRASE_INITIAL.indexOf(HERO_AI_AGENTS_TERM);
+const HERO_AI_AGENTS_TERM_END =
+  HERO_AI_AGENTS_TERM_START + HERO_AI_AGENTS_TERM.length;
+/** Ink (typewriter body) ↔ signal (CTA / intelligence accent) — discrete flip, not a gradient bleed */
+const HERO_AI_AGENTS_COLOR_INK = "#111827";
+const HERO_AI_AGENTS_COLOR_SIGNAL = "#2563EB";
+const HERO_AI_AGENTS_FLIP_DURATION_S = 1.9;
+
+/** Desktop — lift text column from grid vertical center (tablet/mobile unchanged) */
+const HERO_DESKTOP_TEXT_OFFSET_PX = 28;
+
+/** Single stack for h1 lead + typewriter — must match .hero-headline in scoped CSS */
+const HERO_HEADLINE_FONT_FAMILY =
+  "var(--font-hero-display), var(--font-dm-sans), ui-sans-serif, system-ui, sans-serif";
+
+const heroTypewriterTextStyle: CSSProperties = {
+  color: "#111827",
+  fontFamily: HERO_HEADLINE_FONT_FAMILY,
+  fontWeight: 700,
+  lineHeight: 1.2,
+  letterSpacing: "-0.02em",
+};
+
+type HeroTypewriterPhase =
+  | "type-initial"
+  | "hold"
+  | "backspace"
+  | "type-final"
+  | "done";
+
+function heroTypewriterInvisibleReserve(displayText: string): string {
+  const prefixLen = HERO_TYPEWRITER_PREFIX.length;
+  if (displayText.length < prefixLen) {
+    return (
+      HERO_TYPEWRITER_PREFIX.slice(displayText.length) + HERO_TYPEWRITER_LAYOUT_SUFFIX
+    );
+  }
+  const suffixVisible = displayText.slice(prefixLen);
+  return HERO_TYPEWRITER_LAYOUT_SUFFIX.slice(suffixVisible.length);
+}
+
+function renderTypewriterWithAiAgentsHighlight(
+  displayText: string,
+  aiAgentsFlipActive: boolean,
+): ReactNode {
+  const aiAgentsFullyTyped =
+    HERO_AI_AGENTS_TERM_START >= 0 && displayText.length >= HERO_AI_AGENTS_TERM_END;
+
+  if (!aiAgentsFullyTyped || HERO_AI_AGENTS_TERM_START < 0) {
+    return displayText;
+  }
+
+  return (
+    <>
+      {displayText.slice(0, HERO_AI_AGENTS_TERM_START)}
+      <span
+        className={
+          aiAgentsFlipActive ? "hero-ai-agents-flip" : "hero-ai-agents-term"
+        }
+      >
+        {HERO_AI_AGENTS_TERM}
+      </span>
+      {displayText.slice(HERO_AI_AGENTS_TERM_END)}
+    </>
+  );
+}
+
+function HeroTypewriterKnowPhrase() {
+  const [displayText, setDisplayText] = useState("");
+  const [phase, setPhase] = useState<HeroTypewriterPhase>("type-initial");
+  const [aiAgentsFlipActive, setAiAgentsFlipActive] = useState(false);
+  const intervalRef = useRef<number | null>(null);
+  const timeoutRef = useRef<number | null>(null);
+  const aiAgentsFlipFiredRef = useRef(false);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+
+    const clearTimers = () => {
+      if (timeoutRef.current) {
+        window.clearTimeout(timeoutRef.current);
+        timeoutRef.current = null;
+      }
+      if (intervalRef.current) {
+        window.clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) {
+      setDisplayText(HERO_TYPEWRITER_PHRASE_FINAL);
+      setPhase("done");
+      return clearTimers;
+    }
+
+    const runTypeForward = (
+      target: string,
+      startIndex: number,
+      onComplete: () => void,
+    ) => {
+      let index = startIndex;
+      intervalRef.current = window.setInterval(() => {
+        index += 1;
+        setDisplayText(target.slice(0, index));
+        if (index >= target.length) {
+          clearTimers();
+          onComplete();
+        }
+      }, HERO_TYPEWRITER_MS_PER_CHAR);
+    };
+
+    const runBackspace = (fromLength: number, stopLength: number, onComplete: () => void) => {
+      let index = fromLength;
+      intervalRef.current = window.setInterval(() => {
+        index -= 1;
+        setDisplayText(HERO_TYPEWRITER_PHRASE_INITIAL.slice(0, index));
+        if (index <= stopLength) {
+          setDisplayText(HERO_TYPEWRITER_PREFIX);
+          clearTimers();
+          onComplete();
+        }
+      }, HERO_TYPEWRITER_BACKSPACE_MS_PER_CHAR);
+    };
+
+    const startSequence = () => {
+      setPhase("type-initial");
+      runTypeForward(HERO_TYPEWRITER_PHRASE_INITIAL, 0, () => {
+        setPhase("hold");
+        timeoutRef.current = window.setTimeout(() => {
+          setPhase("backspace");
+          runBackspace(
+            HERO_TYPEWRITER_PHRASE_INITIAL.length,
+            HERO_TYPEWRITER_PREFIX.length,
+            () => {
+              setPhase("type-final");
+              runTypeForward(
+                HERO_TYPEWRITER_PHRASE_FINAL,
+                HERO_TYPEWRITER_PREFIX.length,
+                () => {
+                  setPhase("done");
+                },
+              );
+            },
+          );
+        }, HERO_HOLD_AFTER_INITIAL_MS);
+      });
+    };
+
+    timeoutRef.current = window.setTimeout(startSequence, HERO_TYPEWRITER_START_DELAY_MS);
+
+    return clearTimers;
+  }, []);
+
+  useEffect(() => {
+    if (aiAgentsFlipFiredRef.current) return;
+    if (HERO_AI_AGENTS_TERM_START < 0) return;
+    if (displayText.length < HERO_AI_AGENTS_TERM_END) return;
+    if (typeof window === "undefined") return;
+    if (window.matchMedia("(prefers-reduced-motion: reduce)").matches) return;
+
+    aiAgentsFlipFiredRef.current = true;
+    setAiAgentsFlipActive(true);
+  }, [displayText]);
+
+  const invisibleReserve = heroTypewriterInvisibleReserve(displayText);
+  const showCaret = phase !== "done";
+
+  return (
+    <span className="hero-typewriter-wrap" style={heroTypewriterTextStyle} aria-hidden="true">
+      <span className="hero-typewriter-typed">
+        {renderTypewriterWithAiAgentsHighlight(displayText, aiAgentsFlipActive)}
+        {showCaret ? <span className="hero-typewriter-caret" aria-hidden /> : null}
+      </span>
+      <span className="hero-typewriter-remainder">{invisibleReserve}</span>
+    </span>
+  );
+}
 
 export function HeroSection() {
   return (
     <div className="pt-24 pb-16 lg:pt-32 lg:pb-24">
       <div className="container mx-auto px-4 md:px-6">
-        <div className="grid gap-12 lg:grid-cols-2 lg:gap-12 items-center">
-          {/* Left: Text Content */}
-          <div className="flex flex-col justify-center space-y-8 text-left lg:pr-8 hero-text-column">
-            <h1 className="text-4xl font-bold tracking-tight text-white sm:text-5xl md:text-6xl leading-tight hero-headline" style={{ color: 'white' }}>
-              <span>Stop guessing where</span> <span>your ad budget works—</span><span style={{ 
-                color: '#111827', 
-                fontFamily: "'Inter', ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif",
-                fontWeight: 700,
-                lineHeight: 1.2,
-                letterSpacing: '-0.025em'
-              }}>know with statistical confidence</span>
+        <div className="grid gap-12 lg:grid-cols-2 lg:gap-12 items-center min-w-0 hero-home-grid">
+          {/* Left: Text Content — above product visual (3D transform creates stacking) */}
+          <div className="flex flex-col justify-center space-y-8 text-left lg:pr-8 hero-text-column relative z-[30] min-w-0 max-w-full">
+            <h1
+              className="font-bold text-white hero-headline max-w-full"
+              style={{ color: "white" }}
+              aria-label={HERO_HEADLINE_ARIA_LABEL}
+            >
+              <span className="hero-headline-lead">{HERO_HEADLINE_LEAD}</span>{" "}
+              <HeroTypewriterKnowPhrase />
             </h1>
 
-            <p className="max-w-[600px] text-white mx-auto lg:mx-0 hero-subheadline" style={{ fontSize: '16px', lineHeight: 1.5 }}>
-              Skeldir compares Facebook/Google/TikTok claims against your actual Stripe/Shopify revenue<br />
-              <span style={{ display: 'inline-block', marginTop: '2px' }}>See platform over-reporting—then act on statistical confidence ranges, not black-box numbers.</span><br />
-              <span style={{ display: 'inline-block', marginTop: '2px' }}>Live in 48 hours, not months.</span>
+            <p className="max-w-[600px] text-white mx-auto lg:mx-0 hero-subheadline">
+              {HERO_SUBHEADLINE_LINES.map((line) => (
+                <span key={line} className="hero-subheadline-line">
+                  {line}
+                </span>
+              ))}
             </p>
 
             <div className="flex flex-col items-center lg:items-start gap-4 hero-cta-container">
@@ -97,32 +312,108 @@ export function HeroSection() {
           </div>
 
           {/* Right: Product Visual — 3D perspective hero dashboard */}
-          <div className="relative mx-auto w-full max-w-[950px] lg:max-w-none lg:ml-[20%] hero-image-container home-product-hero">
+          <div className="relative z-0 mx-auto w-full min-w-0 max-w-[950px] lg:max-w-none lg:ml-[20%] hero-image-container home-product-hero">
             <div className="hero-image-float-wrapper">
-              <div 
-                className="relative rounded-2xl overflow-visible hero-image-glass"
-                style={{
-                  background: 'rgba(255, 255, 255, 0.7)',
-                  backdropFilter: 'blur(20px) saturate(180%)',
-                  WebkitBackdropFilter: 'blur(20px) saturate(180%)',
-                  border: '1px solid rgba(255, 255, 255, 0.3)',
-                }}
-              >
-                <div className="overflow-hidden rounded-2xl">
-                  <img
-                    src="/homepage-demo-2.png"
-                    alt="Skeldir command center — unified attribution and ROAS control panel"
-                    className="w-full h-auto object-contain hero-dashboard-image"
-                    loading="eager"
-                    decoding="async"
-                    fetchPriority="high"
-                  />
-                </div>
+              <div className="relative overflow-visible hero-image-glass">
+                <img
+                  src="/homepage-demo-2.png"
+                  alt="Skeldir command center — unified attribution and ROAS control panel"
+                  className="w-full h-auto object-contain hero-dashboard-image block"
+                  loading="eager"
+                  decoding="async"
+                  fetchPriority="high"
+                />
               </div>
             </div>
           </div>
           
           <style>{`
+            @keyframes hero-caret-blink {
+              0%, 45% { opacity: 1; }
+              50%, 95% { opacity: 0; }
+              100% { opacity: 1; }
+            }
+            /* One burst per page load: ink ↔ signal, stepped (no continuous loop) */
+            @keyframes hero-ai-agents-color-flip {
+              0%, 100% { color: ${HERO_AI_AGENTS_COLOR_INK}; }
+              16.67% { color: ${HERO_AI_AGENTS_COLOR_SIGNAL}; }
+              33.33% { color: ${HERO_AI_AGENTS_COLOR_INK}; }
+              50% { color: ${HERO_AI_AGENTS_COLOR_SIGNAL}; }
+              66.67% { color: ${HERO_AI_AGENTS_COLOR_INK}; }
+              83.33% { color: ${HERO_AI_AGENTS_COLOR_SIGNAL}; }
+            }
+            .hero-ai-agents-term {
+              color: ${HERO_AI_AGENTS_COLOR_INK};
+            }
+            .hero-ai-agents-flip {
+              animation: hero-ai-agents-color-flip ${HERO_AI_AGENTS_FLIP_DURATION_S}s step-end 1 forwards;
+            }
+            /* Column-sized type scale — same cqi basis as measure + slice reserve below */
+            .hero-text-column {
+              container-type: inline-size;
+              container-name: hero-text;
+            }
+            .hero-headline {
+              font-family: ${HERO_HEADLINE_FONT_FAMILY};
+              font-size: clamp(1.875rem, 0.6rem + 5.2cqi, 2.75rem);
+              line-height: 1.2;
+              letter-spacing: -0.02em;
+              font-weight: 700;
+            }
+            .hero-headline-lead {
+              display: inline;
+              white-space: normal;
+            }
+            .hero-subheadline {
+              font-size: 16px;
+              line-height: 1.5;
+            }
+            .hero-subheadline-line {
+              display: block;
+            }
+            .hero-subheadline-line + .hero-subheadline-line {
+              margin-top: 2px;
+            }
+            /* In-flow reserve: invisible suffix keeps width = full phrase; caret sits before remainder from first paint */
+            .hero-typewriter-wrap {
+              display: inline;
+              max-width: 100%;
+              white-space: normal;
+            }
+            .hero-typewriter-remainder {
+              visibility: hidden !important;
+              user-select: none;
+              pointer-events: none;
+              white-space: normal;
+            }
+            .hero-typewriter-typed {
+              display: inline;
+            }
+            .hero-typewriter-caret {
+              display: inline-block;
+              width: ${HERO_CARET_WIDTH_EM}em;
+              min-width: ${HERO_CARET_MIN_WIDTH_PX}px;
+              height: ${HERO_CARET_HEIGHT_EM}em;
+              margin-left: 0;
+              margin-right: 0.05em;
+              vertical-align: -0.1em;
+              background: #111827;
+              animation: hero-caret-blink ${HERO_CARET_BLINK_DURATION_S}s step-end infinite;
+            }
+            @media (prefers-reduced-motion: reduce) {
+              .hero-typewriter-caret {
+                animation: none;
+                opacity: 1;
+              }
+              .hero-ai-agents-flip {
+                animation: none;
+                color: ${HERO_AI_AGENTS_COLOR_INK} !important;
+              }
+            }
+            .hero-home-grid {
+              min-width: 0;
+            }
+
             /* ─── 3D Perspective Stage ─── */
             .hero-image-container {
               perspective: 1200px;
@@ -162,35 +453,12 @@ export function HeroSection() {
               pointer-events: none;
             }
 
-            /* 3D Glass Panel */
+            /* 3D panel — no glass frame (avoids white matting / border around asset) */
             .hero-image-glass {
               position: relative;
               transform-style: preserve-3d;
               transform: translateX(4%) scale(1.25) rotateY(-8deg) rotateX(4deg);
               transform-origin: 65% center;
-              box-shadow:
-                0 1px 2px rgba(0, 0, 0, 0.06),
-                4px 6px 16px rgba(0, 0, 0, 0.07),
-                8px 16px 40px rgba(31, 38, 135, 0.10),
-                16px 32px 80px -10px rgba(0, 0, 0, 0.18),
-                inset 0 1px 0 rgba(255, 255, 255, 0.25);
-            }
-
-            /* Light-catch gradient — simulates surface reflecting ambient light */
-            .hero-image-glass::before {
-              content: '';
-              position: absolute;
-              inset: 0;
-              border-radius: inherit;
-              background: linear-gradient(
-                110deg,
-                rgba(255, 255, 255, 0.14) 0%,
-                rgba(255, 255, 255, 0.05) 35%,
-                transparent 55%,
-                rgba(0, 0, 0, 0.03) 100%
-              );
-              z-index: 10;
-              pointer-events: none;
             }
 
             /* ─── Responsive ─── */
@@ -200,16 +468,16 @@ export function HeroSection() {
                 align-items: flex-start !important;
               }
               .hero-headline {
-                font-size: 32px !important;
-                line-height: 1.25 !important;
-                letter-spacing: -0.03em !important;
-                font-weight: 800 !important;
+                font-size: clamp(1.75rem, 0.5rem + 5.5cqi, 2.25rem) !important;
+                line-height: 1.22 !important;
+                letter-spacing: -0.02em !important;
+                font-weight: 700 !important;
                 margin-bottom: 20px !important;
                 text-align: left !important;
               }
-              .hero-headline span {
+              .hero-headline-lead,
+              .hero-typewriter-wrap {
                 white-space: normal !important;
-                display: inline !important;
               }
               .hero-subheadline {
                 font-size: 14px !important;
@@ -329,8 +597,8 @@ export function HeroSection() {
 
             @media (min-width: 768px) and (max-width: 1023px) {
               .hero-headline {
-                font-size: 36px !important;
-                line-height: 1.25 !important;
+                font-size: clamp(1.875rem, 0.55rem + 4.8cqi, 2.5rem) !important;
+                line-height: 1.22 !important;
               }
               .hero-subheadline {
                 font-size: 18px !important;
@@ -342,6 +610,13 @@ export function HeroSection() {
             }
 
             @media (min-width: 1024px) {
+              .hero-text-column {
+                transform: translateY(-${HERO_DESKTOP_TEXT_OFFSET_PX}px);
+              }
+              .hero-headline {
+                font-size: clamp(2rem, 0.65rem + 5cqi, 3rem) !important;
+                line-height: 1.18 !important;
+              }
               .hero-image-container {
                 max-width: 1100px !important;
                 margin-left: 0 !important;


### PR DESCRIPTION
Minimal production-source fix for Skeldir.com. Scope: one marketing file, marketing/src/components/layout/HeroSection.tsx. Adds the hero typewriter markup/animation directly to the Netlify-watched main branch source while keeping the existing production hero image asset path. No backend, infra, Netlify config, package files, favicon/icon/manifest, or public asset changes.