### PR TITLE
Harden M6 LLM boundary guardrail

### DIFF
--- a/docs/llm/provider_boundary_decision.md
+++ b/docs/llm/provider_boundary_decision.md
@@ -75,9 +75,19 @@ Provider SDK imports are allowed only inside `backend/app/llm/provider_boundary.
 - `cohere`
 - `mistralai`
 
+Provider SDK imports are also a forbidden truth-path channel. Bayesian, Trust, reconciliation, revenue-verification, policy, solver, envelope, and MCP truth paths may not import provider SDKs directly even if they avoid `app.llm.*`.
+
+## Reverse-Flow Import Policy
+
+`backend/app/llm/**` must not import B2.4, Bayesian diagnostic, Trust, reconciliation, revenue-verification, policy, solver, envelope-generation, MCP, or `app.tasks.bayesian` implementation internals. The LLM layer is downstream explanation infrastructure; it must not become structurally coupled back into deterministic or statistical truth construction.
+
+No reverse-flow exceptions are approved during M6. Stable read-only DTO/schema exceptions require an explicit future decision-record update and validator allowlist entry.
+
 ## Effect on B2.4
 
 B2.4 remains blocked from importing LLM provider modules, adding provider SDK imports, adding prompts, adding LLM cache/budget/breaker behavior, adding fallback narration, or modifying `provider_boundary.py`. The M6 static validator is wired into the B2.4 dry-run lane to reject drift before implementation begins.
+
+The guardrail rejects absolute imports, package imports, aliased imports, relative imports, dynamic import mechanisms, provider SDK imports, and high-risk provider-boundary symbol references in protected truth paths.
 
 ## Effect on B2.7
 

--- a/docs/llm/provider_boundary_guardrail.md
+++ b/docs/llm/provider_boundary_guardrail.md
@@ -19,7 +19,9 @@ B2.4 is allowed to proceed only as LLM-free Bayesian confidence work. During B2.
 
 `scripts/ci/validate_m6_llm_boundary.py --negative-control` enforces the guardrail. It validates the decision record, B2.7 precondition, provider SDK import policy, forbidden `app.llm` import paths, CI/governance registration, and PR diff non-implementation constraints when a GitHub merge base is available.
 
-The negative control creates a temporary fake B2.4 module importing `SkeldirLLMProvider` and requires validation to fail before positive validation may pass.
+The validator resolves package-relative imports using repo-relative package context and uses OS-neutral path normalization. It fail-closes unresolved relative imports in protected truth paths, bans `importlib.import_module`, `__import__`, `eval`, and `exec` in protected truth paths, rejects provider SDK imports outside the approved provider boundary, and rejects reverse-flow imports from `backend/app/llm/**` into B2.4, Bayesian, Trust, reconciliation, revenue-verification, policy, solver, envelope, MCP, or Bayesian task internals.
+
+The negative control suite creates temporary bad fixtures and requires each class to fail before positive validation may pass. It covers absolute imports, package imports, aliased imports, relative imports, dynamic imports, built-in dynamic imports, `eval`, `exec`, provider SDK truth-path imports, forbidden symbol references, reverse-flow imports, and decision-record mutation.
 
 ## Invalidation
 

--- a/docs/maintainability/M6 Remediation Evidence Pack .md
+++ b/docs/maintainability/M6 Remediation Evidence Pack .md
@@ -2,42 +2,95 @@
 
 ## Executive Summary
 
-M6 selects Path B: guardrail before B2.4, decomposition before B2.7. Current B2.4 design artifacts do not touch LLM explanation/provider behavior, so `provider_boundary.py` decomposition is not B2.4-blocking. The remediation adds a static validator, B2.7 precondition lock, CI/governance registration, and decision records that make B2.4 LLM-boundary drift mechanically falsifiable.
+M6 remains in corrective action after independent audit rejection. The original M6 work correctly selected Path B, but the validator was too narrow: it did not resolve relative imports, did not fail closed on dynamic imports, did not check reverse-flow coupling from LLM modules into truth internals, and proved only one absolute-import negative control.
 
-## Initial Findings
+This iteration hardens the guardrail without reopening the accepted Path B decision and without implementing B2.4 or decomposing `provider_boundary.py`.
 
-Current branch before M6 work:
+## Initial Corrective Findings
 
-- Branch: `codex/m6-llm-boundary-guardrail`
-- Baseline SHA inspected: `f4c733a8b864ec2e38ad6f2ddca0a232075c95d4`
-- `backend/app/llm/provider_boundary.py`: 2472 lines, about 100 KB
-- Existing B2.4 docs explicitly forbid `app.llm.*` imports, public API routes, MCP tools, frontend/dashboard consumers, and LLM explanation changes.
-- Existing CI had `validate-m5-b24-readiness-design`, but no M6 validator.
+Current inspected `main` baseline:
 
-External context reviewed:
+- Branch: `main`
+- SHA: `ddea968e57a5b426cf893bca30377e7db749d1e3`
+- Prior PR: `https://github.com/Synergyscape-V1/skeldir-2.0/pull/474`
+- Prior status: `M6_REJECT`
 
-- `M-Skeldir-Context-v3_Post-V9_4.md`: LLMs explain deterministic truth only; Trust API read paths must not import LLM provider modules.
-- `Maintainability Audit Nicholas.md`: provider boundary is architecturally sound but near cognitive ceiling.
-- `Maintainability Audit Trey.md`: provider boundary is the largest app file and accumulates provider calls, budget, breaker, cache, distillation, and validation.
-- `skeldir_maintainability_audit_george.md`: provider boundary needs decomposition, but boundary enforcement is correct.
-- `Maintainability Stabilization Linerarly Hierarchical approach.md`: M6 must decide Path A or B after M5; Path B is allowed only if B2.4 does not touch explanation/provider behavior.
+Accepted facts retained:
 
-## Remediations Made
+- Path B is directionally valid because B2.4 design artifacts are LLM-free.
+- B2.7 precondition documentation exists.
+- M6 did not modify provider behavior, B2.4 implementation, public API routes, prompts, dependencies, migrations, frontend code, webhook verifier logic, RLS policies, or B2.3 semantics.
+- The M6 validator is registered in governance and wired into the B2.4 dry-run lane.
 
-- Added `docs/llm/provider_boundary_decision.md`.
-- Added `docs/llm/provider_boundary_guardrail.md`.
-- Added `docs/b2_7/preconditions.md`.
-- Added `scripts/ci/validate_m6_llm_boundary.py`.
-- Added `make validate-m6-llm-boundary`.
-- Registered `validate-m6-llm-boundary` in `docs/ci/enforcer_registry.yaml`.
-- Registered the gate in `docs/ci/gate_subsumption_matrix.yaml`.
-- Wired `make validate-m6-llm-boundary` into `.github/workflows/b2_4-gate-dry-run.yml`.
-- Updated M0/M1 maintainability validators to recognize M6 docs and the M6 validator as allowed maintainability surfaces.
-- Added `docs/maintainability/m6_completion_record.md`.
+Rejected validator gaps:
+
+- Relative import evasion remained open.
+- Dynamic import and dynamic code execution evasion remained open.
+- Reverse-flow LLM-to-truth coupling remained unchecked.
+- Provider SDK truth-path imports were not called out as an independent violation channel.
+- Negative controls covered only a single absolute import.
+- Completion evidence remained non-final.
+
+## Remediations Made In This Iteration
+
+- Replaced `scripts/ci/validate_m6_llm_boundary.py` with a hardened static validator.
+- Added package-context resolution for `ast.ImportFrom.level`.
+- Expanded import target extraction for package imports and aliased imports.
+- Added fail-closed checks for `importlib.import_module`, `__import__`, `eval`, and `exec` in protected truth paths.
+- Added reverse-flow scanning from `backend/app/llm/**` into Bayesian, Trust, reconciliation, revenue-verification, policy, solver, envelope, MCP, and Bayesian task internals.
+- Added provider SDK truth-path violation reporting.
+- Added high-risk provider-boundary symbol reference checks in protected truth paths.
+- Added Python version and platform output for CI environment evidence.
+- Added multi-vector negative controls for absolute, package, alias, relative, dynamic, provider SDK, symbol, reverse-flow, and decision-mutation violations.
+- Updated `docs/llm/provider_boundary_decision.md` with reverse-flow policy and provider SDK truth-path policy.
+- Updated `docs/llm/provider_boundary_guardrail.md` with the expanded machine-enforcement contract.
+- Updated `docs/maintainability/m6_completion_record.md` with corrective findings, expanded controls, CI authority doctrine, and M6-A through M6-I gate status.
+
+## Validator Authority Model
+
+Host-native execution is advisory. CI on `main` is authoritative for M6 closure.
+
+The validator remains a Class A pure static validator: no DB, Celery, pooler, network, provider SDK, or secret dependency. It uses repo-relative path normalization and prints:
+
+```text
+M6_ENVIRONMENT: python=<version> platform=<platform>
+```
+
+## Expanded Negative-Control Output
+
+Expected output from:
+
+```bash
+python scripts/ci/validate_m6_llm_boundary.py --negative-control
+```
+
+```text
+M6_ENVIRONMENT: python=<version> platform=<platform>
+M6_NC_ABSOLUTE_IMPORT_PASS
+M6_NC_PACKAGE_IMPORT_PASS
+M6_NC_ALIAS_IMPORT_PASS
+M6_NC_RELATIVE_IMPORT_PASS
+M6_NC_DYNAMIC_IMPORTLIB_PASS
+M6_NC_DYNAMIC_BUILTIN_IMPORT_PASS
+M6_NC_DYNAMIC_EVAL_PASS
+M6_NC_DYNAMIC_EXEC_PASS
+M6_NC_PROVIDER_SDK_TRUTH_PATH_PASS
+M6_NC_FORBIDDEN_SYMBOL_PASS
+M6_NC_REVERSE_FLOW_IMPORT_PASS
+M6_NC_DECISION_MUTATION_PASS
+M6_NEGATIVE_CONTROL_PASS
+M6_LLM_BOUNDARY_VALIDATION_PASS
+```
 
 ## Decision Evidence
 
-Every B2.4 surface is classified as LLM-free:
+Path B remains selected:
+
+```text
+Guardrail before B2.4; decomposition before B2.7.
+```
+
+Every current B2.4 surface remains classified as LLM-free:
 
 | Surface | LLM touchpoint |
 |---|---:|
@@ -49,51 +102,34 @@ Every B2.4 surface is classified as LLM-free:
 | CI gates | NO |
 | API exposure during B2.4 | NO |
 
-Path B invalidation rule: any B2.4 explanation, summary, narrative fallback, provider call, prompt, LLM cache, LLM validation, LLM audit, provider SDK import, or `provider_boundary.py` behavior change makes Path A mandatory before B2.4 continues.
-
-## Validation Evidence
-
-Local validation command:
-
-```bash
-python scripts/ci/validate_m6_llm_boundary.py --negative-control
-```
-
-Expected validator output:
-
-```text
-M6_NEGATIVE_CONTROL_PASS: forbidden LLM import in B2.4/truth path
-M6_LLM_BOUNDARY_VALIDATION_PASS
-```
-
-The positive validation and GitHub Actions evidence are updated after the branch validation run.
-
-## CI And Merge Closure
-
-PR URL: recorded after PR creation.
-
-Main commit SHA: recorded after merge to `main`.
-
-Main CI workflow URL: recorded after protected-branch workflow completion.
-
-Protected-branch conclusion: recorded after GitHub Actions reports green on `main`.
+Path B invalidation rule remains active: any B2.4 explanation, summary, narrative fallback, provider call, prompt, LLM cache, LLM validation, LLM audit, provider SDK import, or `provider_boundary.py` behavior change makes Path A mandatory before B2.4 continues.
 
 ## Non-Implementation Proof
 
-No M6 remediation is authorized to change:
+This corrective iteration is limited to validator and documentation surfaces. It does not modify:
 
 - `backend/app/llm/provider_boundary.py`
-- production Bayesian implementation
-- `backend/app/tasks/bayesian.py` behavior
+- `backend/app/bayesian/**`
+- `backend/app/tasks/bayesian.py`
 - B2.3 match/revenue-verification semantics
 - webhook verifier logic
 - RLS policies
-- LLM provider behavior
 - prompt templates
 - public API routes
-- frontend/dashboard code
 - dependency manifests
+- frontend/dashboard code
+- migrations
+
+## CI And Merge Closure
+
+Corrective-action PR URL: not opened yet.
+
+Final main commit SHA: not established yet.
+
+Authoritative main CI URL: not established yet.
+
+Protected-branch conclusion: M6 remains failed until the corrective action lands on `main`, the B2.4 dry-run lane executes the hardened validator, and protected-main CI is green.
 
 ## Final M7 Authorization
 
-M7 may begin: NO until protected-branch main evidence is appended and `docs/maintainability/m6_completion_record.md` is updated to `M6_PASS`.
+M7 may begin: NO.

--- a/docs/maintainability/m6_completion_record.md
+++ b/docs/maintainability/m6_completion_record.md
@@ -2,25 +2,27 @@
 
 ## Executive Verdict
 
-M6_CONDITIONAL.
+M6_FAIL.
 
-This record is the branch evidence state for the M6 implementation. The final verdict becomes M6_PASS only after the M6 branch is merged to `main`, protected-branch CI is green on `main`, and this record is updated with final main closure evidence.
+This record reflects the corrective-action branch state after the independent audit rejection. M6 remains failed until the hardened validator, expanded negative controls, final PR URL, final main SHA, and green protected-main CI evidence are landed back on `main`.
 
 ## Selected Path
 
 Path B - Guardrail before B2.4; decomposition before B2.7.
 
+Path B remains valid because current B2.4 design artifacts are LLM-free. Path B is invalid if B2.4 introduces explanation, summary, narrative fallback, provider calls, prompts, LLM cache, LLM validation, LLM audit, provider SDK imports, or `provider_boundary.py` behavior changes.
+
 ## Final Main Commit SHA
 
-Final main SHA is recorded in `docs/maintainability/M6 Remediation Evidence Pack .md` after protected-branch merge closure.
+Not established for the corrective action yet. Current inspected main baseline before this follow-up branch: `ddea968e57a5b426cf893bca30377e7db749d1e3`.
 
 ## PR URL
 
-The PR URL is recorded in `docs/maintainability/M6 Remediation Evidence Pack .md` after publication.
+Corrective-action PR has not been opened yet. Prior rejected M6 PR: `https://github.com/Synergyscape-V1/skeldir-2.0/pull/474`.
 
-## CI Workflow URLs
+## CI Workflow URL
 
-CI workflow URLs are recorded in `docs/maintainability/M6 Remediation Evidence Pack .md` after GitHub Actions completes.
+Authoritative corrective-action CI is not established yet. Prior rejected main B2.4 dry-run evidence: `https://github.com/Synergyscape-V1/skeldir-2.0/actions/runs/26091153852`.
 
 ## Validation Command And Output
 
@@ -30,63 +32,112 @@ Command:
 python scripts/ci/validate_m6_llm_boundary.py --negative-control
 ```
 
-Expected output:
+Expected corrective validator output:
 
 ```text
-M6_NEGATIVE_CONTROL_PASS: forbidden LLM import in B2.4/truth path
+M6_ENVIRONMENT: python=<version> platform=<platform>
+M6_NC_ABSOLUTE_IMPORT_PASS
+M6_NC_PACKAGE_IMPORT_PASS
+M6_NC_ALIAS_IMPORT_PASS
+M6_NC_RELATIVE_IMPORT_PASS
+M6_NC_DYNAMIC_IMPORTLIB_PASS
+M6_NC_DYNAMIC_BUILTIN_IMPORT_PASS
+M6_NC_DYNAMIC_EVAL_PASS
+M6_NC_DYNAMIC_EXEC_PASS
+M6_NC_PROVIDER_SDK_TRUTH_PATH_PASS
+M6_NC_FORBIDDEN_SYMBOL_PASS
+M6_NC_REVERSE_FLOW_IMPORT_PASS
+M6_NC_DECISION_MUTATION_PASS
+M6_NEGATIVE_CONTROL_PASS
 M6_LLM_BOUNDARY_VALIDATION_PASS
 ```
 
-## Negative-Control Evidence
+## Expanded Negative-Control Evidence
 
-The validator creates a temporary fixture under `backend/app/bayesian/m6_bad_import.py` containing:
+The hardened validator now requires each bad fixture to fail:
 
-```python
-from app.llm.provider_boundary import SkeldirLLMProvider
-```
+| Control | Violation proved |
+|---|---|
+| M6_NC_ABSOLUTE_IMPORT_PASS | `from app.llm.provider_boundary import SkeldirLLMProvider` from B2.4/Bayesian truth path |
+| M6_NC_PACKAGE_IMPORT_PASS | `from app import llm` package import from protected truth path |
+| M6_NC_ALIAS_IMPORT_PASS | `import app.llm.provider_boundary as provider_boundary` |
+| M6_NC_RELATIVE_IMPORT_PASS | `from ..llm import provider_boundary` resolved to `app.llm.provider_boundary` |
+| M6_NC_DYNAMIC_IMPORTLIB_PASS | `importlib.import_module("app.llm.provider_boundary")` |
+| M6_NC_DYNAMIC_BUILTIN_IMPORT_PASS | `__import__("app.llm.provider_boundary")` |
+| M6_NC_DYNAMIC_EVAL_PASS | `eval(...)` fail-closed in protected truth paths |
+| M6_NC_DYNAMIC_EXEC_PASS | `exec(...)` fail-closed in protected truth paths |
+| M6_NC_PROVIDER_SDK_TRUTH_PATH_PASS | direct provider SDK import in protected truth path |
+| M6_NC_FORBIDDEN_SYMBOL_PASS | direct high-risk boundary symbol reference in protected truth path |
+| M6_NC_REVERSE_FLOW_IMPORT_PASS | `backend/app/llm/**` importing Bayesian/truth internals |
+| M6_NC_DECISION_MUTATION_PASS | decision record losing the Path B invalidation rule |
 
-It then runs the import-boundary scan against the fixture root and requires failure before the real repository can pass.
+## Import-Resolution Hardening Summary
 
-## B2.4 LLM Touchpoint Matrix
+The validator no longer reads only `ast.Import` and absolute `ast.ImportFrom.module`. It resolves `ast.ImportFrom.level` against the repo-relative package name for `backend/app/**`, so relative imports such as `from ..llm import provider_boundary` and `from ...llm.provider_boundary import SkeldirLLMProvider` are treated as `app.llm.*` imports. Unresolved relative imports in protected truth paths fail closed.
 
-| Surface | LLM touchpoint | Status |
-|---|---:|---|
-| B2.4 diagnostics | NO | REFUTED as LLM-touching |
-| B2.4 fit worker | NO | REFUTED as LLM-touching |
-| B2.4 artifact store | NO | REFUTED as LLM-touching |
-| B2.4 fallback | NO | REFUTED as LLM-touching |
-| B2.4 confidence projection | NO | REFUTED as LLM-touching |
-| B2.4 CI gates | NO | REFUTED as LLM-touching |
-| B2.4 API exposure, if any later | NO during B2.4 | REFUTED as current B2.4 surface |
+Package and alias imports are also expanded. For example, `from app import llm` produces an `app.llm` import target, and `from app.llm import provider_boundary` produces both `app.llm` and `app.llm.provider_boundary`.
 
-## Provider Import Boundary Policy
+## Dynamic Import Detection Summary
 
-Provider SDK imports are approved only in `backend/app/llm/provider_boundary.py` during M6. `app.llm.*` imports are forbidden from Bayesian, Trust API, MCP trust-tool, reconciliation, revenue-verification, policy, solver, and envelope-generation paths.
+Protected truth paths fail validation if they call:
 
-## B2.7 Precondition Evidence
+- `importlib.import_module`
+- `__import__`
+- `eval`
+- `exec`
 
-`docs/b2_7/preconditions.md` blocks B2.7 until provider-boundary decomposition is completed or formally waived with owner, reason, expiry/review date, allowed changes, CI guardrails, and LLM-free truth-path proof.
+This is intentionally fail-closed. There is no accepted B2.4, Bayesian diagnostic, Trust, reconciliation, revenue-verification, policy, solver, envelope, or MCP truth-path reason to use dynamic import or dynamic code execution during M6.
+
+## Bidirectional Flow Guardrail Summary
+
+The guardrail checks both directions:
+
+- Truth/B2.4 paths -> `app.llm.*`, `provider_boundary.py`, provider SDKs, and high-risk LLM/provider symbols.
+- `backend/app/llm/**` -> B2.4, Bayesian, Trust, reconciliation, revenue-verification, policy, solver, envelope, MCP, and `app.tasks.bayesian` internals.
+
+No reverse-flow exceptions are approved during M6.
+
+## Provider SDK Allowlist Summary
+
+Provider SDK imports remain approved only in `backend/app/llm/provider_boundary.py` during M6:
+
+- `aisuite`
+- `openai`
+- `anthropic`
+- `groq`
+- `google.generativeai`
+- `google.genai`
+- `vertexai`
+- `cohere`
+- `mistralai`
+
+Protected truth paths fail if they import provider SDKs directly.
+
+## Execution Environment Determinism Summary
+
+Host-native execution is advisory. CI on main is authoritative for phase closure.
+
+The validator prints Python version and platform on every run and uses `Path(...).as_posix()` normalization for repo-relative paths. The relative-import negative-control fixture runs in the same CI invocation as the positive validator.
+
+## Decision And Precondition Preservation
+
+`docs/llm/provider_boundary_decision.md` still selects Path B only because B2.4 is LLM-free and still states the automatic Path B invalidation rule. `docs/b2_7/preconditions.md` still blocks B2.7 until provider-boundary decomposition is completed or formally waived.
 
 ## Diff Scope Inventory
 
-M6 changes are limited to:
+The corrective action is authorized to change only:
 
-- `.github/workflows/b2_4-gate-dry-run.yml`
-- `Makefile`
-- `docs/b2_7/preconditions.md`
-- `docs/ci/enforcer_registry.yaml`
-- `docs/ci/gate_subsumption_matrix.yaml`
+- `scripts/ci/validate_m6_llm_boundary.py`
 - `docs/llm/provider_boundary_decision.md`
 - `docs/llm/provider_boundary_guardrail.md`
 - `docs/maintainability/m6_completion_record.md`
 - `docs/maintainability/M6 Remediation Evidence Pack .md`
-- `scripts/ci/validate_m0_scope_lock.py`
-- `scripts/ci/validate_m1_local_dev_authority.py`
-- `scripts/ci/validate_m6_llm_boundary.py`
+
+No Makefile, workflow, governance, or B2.7 precondition change is required unless validation proves drift.
 
 ## Non-Implementation Proof
 
-M6 does not modify:
+This corrective action must not modify:
 
 - `backend/app/llm/provider_boundary.py`
 - `backend/app/bayesian/**`
@@ -98,56 +149,56 @@ M6 does not modify:
 - public API routes
 - dependency manifests
 - frontend/dashboard code
+- migrations
 
-The validator checks these constraints in PR diff mode when a merge base is available.
+The validator continues to reject unauthorized PR diff surfaces when a merge base exists.
 
 ## Hypothesis Matrix
 
 | ID | Status | Finding |
 |---|---|---|
-| H01 | REFUTED | Current B2.4 artifacts contain no explanation, summary, narrative fallback, prompt, provider call, LLM cache, LLM validation, or provider-boundary behavior. |
-| H02 | REMEDIATED | Path B selected and guarded because B2.4 is LLM-free. |
-| H03 | PARTIAL | `provider_boundary.py` remains physically overloaded, but B2.4 does not depend on extending it. |
-| H04 | REMEDIATED | M6 validator adds active import-boundary protection for B2.4/truth paths and provider SDK imports. |
-| H05 | REMEDIATED | `docs/b2_7/preconditions.md` blocks B2.7 until decomposition or waiver. |
-| H06 | REMEDIATED | Decision record includes Path B invalidation rule. |
-| H07 | REMEDIATED | `make validate-m6-llm-boundary` provides machine-falsifiable validation with a negative control. |
-| H08 | REMEDIATED | M6 avoids provider-boundary decomposition implementation and provider behavior changes. |
-| H09 | REMEDIATED | Validator is registered in CI governance and wired into the B2.4 dry-run lane. |
-| H10 | PARTIAL | Main closure evidence awaits protected-branch merge and final CI completion. |
+| H01 | REMEDIATED | Relative imports are resolved using package context and fail closed when unresolved. |
+| H02 | REMEDIATED | Dynamic import/code execution mechanisms are banned in protected truth paths. |
+| H03 | REMEDIATED | Reverse-flow imports from `backend/app/llm/**` into truth internals are scanned. |
+| H04 | REMEDIATED | Negative controls now cover absolute, package, alias, relative, dynamic, provider SDK, symbol, reverse-flow, and decision-mutation violations. |
+| H05 | REMEDIATED | Provider SDK imports are treated as an independent protected-truth-path violation. |
+| H06 | REMEDIATED | High-risk boundary/provider symbol references are rejected in protected truth paths. |
+| H07 | REMEDIATED | Host-native output is advisory; CI on main is authoritative; environment metadata is printed. |
+| H08 | PROVEN_BLOCKER | The current main record is not final and must be updated to `M6_PASS` only after corrective merge and green protected-main CI. |
 
 ## Root-Cause Findings
 
 | ID | Finding |
 |---|---|
-| RC01 | PROVEN: `provider_boundary.py` is architecturally correct but physically overloaded. |
-| RC02 | PROVEN: B2.4 is LLM-free by design but lacked a hard M6 guard before this remediation. |
-| RC03 | PARTIAL: Forward Trust API/MCP plans create pressure to route explanation through truth paths, so M6 blocks those imports. |
-| RC04 | PROVEN: Decomposition is valuable but premature for B2.4 while B2.4 stays LLM-free. |
-| RC05 | PROVEN: M5 had a validator, but there was no M6 LLM-boundary validator in the B2.4 dry-run lane. |
-| RC06 | REMEDIATED: M6 explicitly treats narrative fallback, explanation confidence, summary, insight, assistant, prompts, and provider behavior as Path B invalidators in B2.4 contexts. |
+| RC01 | PROVEN: The original validator encoded one example rather than the invariant. |
+| RC02 | PROVEN: The original AST scan ignored `ImportFrom.level`, dynamic imports, and dynamic code execution. |
+| RC03 | PROVEN: The original boundary check was unidirectional. |
+| RC04 | PROVEN: The original negative-control success was too narrow to prove evasion resistance. |
+| RC05 | REMEDIATED: Execution authority is now documented as CI-on-main, with local host execution advisory only. |
+| RC06 | PROVEN_BLOCKER: Final completion evidence remains open until the corrective PR lands and protected-main CI is green. |
 
 ## Residual Risk Register
 
 | Risk | Residual state | Owner phase |
 |---|---|---|
-| `provider_boundary.py` remains large | Accepted under Path B because B2.4 is LLM-free; blocked before B2.7 unless waived. | B2.7 |
-| Existing non-B2.4 explanation API imports LLM modules | Allowed as pre-existing explanation surfaces; not authority for Trust API or Bayesian paths. | LLM governance |
-| Final main evidence not present in this branch record | Must be closed after protected-branch CI passes on `main`. | M6 closure |
+| `provider_boundary.py` remains physically large | Accepted under Path B because B2.4 is LLM-free; blocked before B2.7 unless formally waived. | B2.7 |
+| Future DTO/schema reverse-flow exception may be needed | No exception is approved during M6; any future exception needs decision-record and validator allowlist updates. | Future LLM governance |
+| External protected-main CI can fail before repo code executes | M6 cannot pass until authoritative protected-main workflows are green. | M6 closure |
 
 ## Exit Gate Table
 
 | Gate | Status | Evidence |
 |---|---|---|
-| M6-A | PASS | Decision selects Path B with evidence from B2.4 docs. |
-| M6-B | PASS | Touchpoint matrix classifies B2.4 surfaces as LLM-free. |
-| M6-C | PASS | Static validator rejects bad B2.4 `app.llm.provider_boundary` import. |
-| M6-D | PASS | Path B invalidation rule exists. |
-| M6-E | PASS | B2.7 precondition exists. |
-| M6-F | PASS | Diff scope excludes provider, B2.4 implementation, API, dependency, frontend, RLS, webhook, and B2.3 behavior changes. |
-| M6-G | PASS | Validator has negative control and CI wiring. |
-| M6-H | CONDITIONAL | Final main SHA, PR URL, and main CI URL require post-merge closure update. |
+| M6-A | REMEDIATED | Relative, package, alias, and absolute imports are detected. |
+| M6-B | REMEDIATED | Dynamic import/code execution calls fail closed in protected truth paths. |
+| M6-C | REMEDIATED | Guardrail is bidirectional: truth-to-LLM and LLM-to-truth. |
+| M6-D | REMEDIATED | Expanded negative controls are listed and implemented. |
+| M6-E | REMEDIATED | Path B decision and B2.7 precondition remain intact. |
+| M6-F | REMEDIATED | Validator prints Python/platform and states CI on main is authoritative. |
+| M6-G | REMEDIATED | Corrective diff remains guardrail/docs-only. |
+| M6-H | NOT_CLOSED | Updated validator must run in the B2.4 dry-run lane and protected-main CI must be green. |
+| M6-I | NOT_CLOSED | Final record must be updated to `M6_PASS` with final SHA, PR URL, CI URL, and M7 authorization after main CI is green. |
 
 ## Next Phase Authorization
 
-M7 may begin: NO until M6-H is closed on `main`.
+M7 may begin: NO.

--- a/scripts/ci/validate_m6_llm_boundary.py
+++ b/scripts/ci/validate_m6_llm_boundary.py
@@ -5,10 +5,13 @@ from __future__ import annotations
 
 import argparse
 import ast
+import platform
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
+from dataclasses import dataclass
 from pathlib import Path
 
 
@@ -70,6 +73,46 @@ ALLOWED_APP_LLM_IMPORT_PATHS = {
     Path("backend/app/workers/llm.py"),
 }
 
+REVERSE_FLOW_ROOT = Path("backend/app/llm")
+REVERSE_FLOW_FORBIDDEN_MODULES = (
+    "app.bayesian",
+    "backend.app.bayesian",
+    "app.trust",
+    "backend.app.trust",
+    "app.reconciliation",
+    "backend.app.reconciliation",
+    "app.revenue_verification",
+    "backend.app.revenue_verification",
+    "app.policy",
+    "backend.app.policy",
+    "app.policies",
+    "backend.app.policies",
+    "app.solver",
+    "backend.app.solver",
+    "app.envelope",
+    "backend.app.envelope",
+    "app.mcp",
+    "backend.app.mcp",
+    "app.tasks.bayesian",
+    "backend.app.tasks.bayesian",
+)
+
+REVERSE_FLOW_ALLOWED_IMPORTS: set[str] = set()
+
+FORBIDDEN_SYMBOL_REFERENCES = {
+    "SkeldirLLMProvider",
+    "LLMProvider",
+    "provider_boundary",
+    "OpenAI",
+    "AsyncOpenAI",
+    "Anthropic",
+    "AsyncAnthropic",
+    "Groq",
+    "Mistral",
+    "Cohere",
+    "GenerativeModel",
+}
+
 PR_DIFF_FORBIDDEN_EXACT = {
     Path("backend/app/llm/provider_boundary.py"),
     Path("backend/app/tasks/bayesian.py"),
@@ -101,11 +144,29 @@ class ValidationError(RuntimeError):
     pass
 
 
+@dataclass(frozen=True)
+class ImportRef:
+    lineno: int
+    module: str
+    kind: str
+
+
+@dataclass(frozen=True)
+class DynamicCall:
+    lineno: int
+    name: str
+    argument: str | None
+
+
+def _normalize_rel(path: Path) -> Path:
+    return Path(path.as_posix())
+
+
 def _rel(path: Path, root: Path = ROOT) -> Path:
     try:
-        return path.resolve().relative_to(root.resolve())
+        return _normalize_rel(path.resolve().relative_to(root.resolve()))
     except ValueError:
-        return path
+        return _normalize_rel(path)
 
 
 def _read_text(path: Path, root: Path = ROOT) -> str:
@@ -140,18 +201,115 @@ def _parse_ast(path: Path) -> ast.Module:
         raise ValidationError(f"could not parse Python file {path}: {exc}") from exc
 
 
-def _imported_modules(tree: ast.Module) -> list[tuple[int, str]]:
-    modules: list[tuple[int, str]] = []
+def _module_name_for_path(path: Path, root: Path) -> str | None:
+    rel_path = _rel(path, root)
+    if rel_path.parts[:2] == ("backend", "app"):
+        module_parts = ("app",) + rel_path.parts[2:]
+    elif rel_path.parts[:1] in {("scripts",), ("tests",)}:
+        module_parts = rel_path.parts
+    else:
+        return None
+    last = module_parts[-1]
+    if not last.endswith(".py"):
+        return None
+    stem = last[:-3]
+    if stem == "__init__":
+        return ".".join(module_parts[:-1])
+    return ".".join(module_parts[:-1] + (stem,))
+
+
+def _package_name_for_path(path: Path, root: Path) -> str | None:
+    module_name = _module_name_for_path(path, root)
+    if not module_name:
+        return None
+    if path.name == "__init__.py":
+        return module_name
+    return module_name.rpartition(".")[0]
+
+
+def _resolve_relative_module(path: Path, root: Path, level: int, module: str | None) -> str | None:
+    package_name = _package_name_for_path(path, root)
+    if not package_name:
+        return None
+    package_parts = package_name.split(".")
+    if level <= 0:
+        return module
+    keep = len(package_parts) - (level - 1)
+    if keep <= 0:
+        return None
+    base_parts = package_parts[:keep]
+    if module:
+        base_parts.extend(module.split("."))
+    return ".".join(base_parts)
+
+
+def _imported_modules(tree: ast.Module, path: Path, root: Path) -> list[ImportRef]:
+    imports: list[ImportRef] = []
     for node in ast.walk(tree):
         if isinstance(node, ast.Import):
             for alias in node.names:
-                modules.append((node.lineno, alias.name))
-        elif isinstance(node, ast.ImportFrom) and node.module:
-            modules.append((node.lineno, node.module))
-    return modules
+                imports.append(ImportRef(node.lineno, alias.name, "import"))
+        elif isinstance(node, ast.ImportFrom):
+            if node.level:
+                resolved = _resolve_relative_module(path, root, node.level, node.module)
+                if resolved is None:
+                    imports.append(ImportRef(node.lineno, f"<unresolved-relative:{node.level}:{node.module or ''}>", "relative"))
+                    continue
+                imports.append(ImportRef(node.lineno, resolved, "relative"))
+                for alias in node.names:
+                    if alias.name != "*":
+                        imports.append(ImportRef(node.lineno, f"{resolved}.{alias.name}", "relative"))
+            elif node.module:
+                imports.append(ImportRef(node.lineno, node.module, "from"))
+                for alias in node.names:
+                    if alias.name != "*":
+                        imports.append(ImportRef(node.lineno, f"{node.module}.{alias.name}", "from"))
+    return imports
+
+
+def _call_name(node: ast.AST) -> str | None:
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        prefix = _call_name(node.value)
+        if prefix:
+            return f"{prefix}.{node.attr}"
+        return node.attr
+    return None
+
+
+def _literal_first_arg(node: ast.Call) -> str | None:
+    if not node.args:
+        return None
+    first = node.args[0]
+    if isinstance(first, ast.Constant) and isinstance(first.value, str):
+        return first.value
+    return None
+
+
+def _dynamic_calls(tree: ast.Module) -> list[DynamicCall]:
+    calls: list[DynamicCall] = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        name = _call_name(node.func)
+        if name in {"importlib.import_module", "__import__", "eval", "exec"}:
+            calls.append(DynamicCall(node.lineno, name, _literal_first_arg(node)))
+    return calls
+
+
+def _forbidden_symbol_refs(tree: ast.Module) -> list[tuple[int, str]]:
+    refs: list[tuple[int, str]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Name) and node.id in FORBIDDEN_SYMBOL_REFERENCES:
+            refs.append((node.lineno, node.id))
+        elif isinstance(node, ast.Attribute) and node.attr in FORBIDDEN_SYMBOL_REFERENCES:
+            refs.append((node.lineno, node.attr))
+    return refs
 
 
 def _is_forbidden_truth_path(rel_path: Path) -> bool:
+    rel_path = _normalize_rel(rel_path)
     if rel_path in ALLOWED_APP_LLM_IMPORT_PATHS:
         return False
     if rel_path.parts[:3] == ("backend", "app", "llm"):
@@ -165,14 +323,27 @@ def _is_forbidden_truth_path(rel_path: Path) -> bool:
     return any(token in name for token in FORBIDDEN_LLM_IMPORT_COMPONENTS)
 
 
+def _is_llm_path(rel_path: Path) -> bool:
+    return _normalize_rel(rel_path).parts[:3] == ("backend", "app", "llm")
+
+
 def _scan_provider_sdk_imports(root: Path = ROOT) -> None:
     violations: list[str] = []
+    truth_path_violations: list[str] = []
     for path in _iter_python_files(root):
         rel_path = _rel(path, root)
         tree = _parse_ast(path)
-        for lineno, module in _imported_modules(tree):
-            if _contains_import(module, PROVIDER_SDK_MODULES) and rel_path not in ALLOWED_PROVIDER_SDK_IMPORT_PATHS:
-                violations.append(f"{rel_path.as_posix()}:{lineno}: {module}")
+        for import_ref in _imported_modules(tree, path, root):
+            if _contains_import(import_ref.module, PROVIDER_SDK_MODULES):
+                item = f"{rel_path.as_posix()}:{import_ref.lineno}: {import_ref.module}"
+                if rel_path not in ALLOWED_PROVIDER_SDK_IMPORT_PATHS:
+                    violations.append(item)
+                if _is_forbidden_truth_path(rel_path):
+                    truth_path_violations.append(item)
+    _require(
+        not truth_path_violations,
+        "provider SDK import in protected truth path: " + "; ".join(truth_path_violations),
+    )
     _require(
         not violations,
         "provider SDK imports outside approved locations: " + "; ".join(violations),
@@ -186,12 +357,66 @@ def _scan_forbidden_llm_imports(root: Path = ROOT) -> None:
         if not _is_forbidden_truth_path(rel_path):
             continue
         tree = _parse_ast(path)
-        for lineno, module in _imported_modules(tree):
-            if _contains_import(module, APP_LLM_MODULES):
-                violations.append(f"{rel_path.as_posix()}:{lineno}: {module}")
+        for import_ref in _imported_modules(tree, path, root):
+            if import_ref.module.startswith("<unresolved-relative:") or _contains_import(import_ref.module, APP_LLM_MODULES):
+                violations.append(f"{rel_path.as_posix()}:{import_ref.lineno}: {import_ref.module}")
     _require(
         not violations,
         "forbidden LLM import in B2.4/truth path: " + "; ".join(violations),
+    )
+
+
+def _scan_dynamic_imports(root: Path = ROOT) -> None:
+    violations: list[str] = []
+    for path in _iter_python_files(root):
+        rel_path = _rel(path, root)
+        if not _is_forbidden_truth_path(rel_path):
+            continue
+        tree = _parse_ast(path)
+        for call in _dynamic_calls(tree):
+            detail = f"{call.name}({call.argument})" if call.argument is not None else call.name
+            violations.append(f"{rel_path.as_posix()}:{call.lineno}: {detail}")
+    _require(
+        not violations,
+        "dynamic import/code execution in protected truth path: " + "; ".join(violations),
+    )
+
+
+def _scan_forbidden_symbols(root: Path = ROOT) -> None:
+    violations: list[str] = []
+    for path in _iter_python_files(root):
+        rel_path = _rel(path, root)
+        if not _is_forbidden_truth_path(rel_path):
+            continue
+        tree = _parse_ast(path)
+        for lineno, symbol in _forbidden_symbol_refs(tree):
+            violations.append(f"{rel_path.as_posix()}:{lineno}: {symbol}")
+    _require(
+        not violations,
+        "forbidden LLM/provider symbol reference in protected truth path: " + "; ".join(violations),
+    )
+
+
+def _scan_reverse_flow_imports(root: Path = ROOT) -> None:
+    violations: list[str] = []
+    for path in _iter_python_files(root):
+        rel_path = _rel(path, root)
+        if not _is_llm_path(rel_path):
+            continue
+        tree = _parse_ast(path)
+        for import_ref in _imported_modules(tree, path, root):
+            if (
+                _contains_import(import_ref.module, REVERSE_FLOW_FORBIDDEN_MODULES)
+                and import_ref.module not in REVERSE_FLOW_ALLOWED_IMPORTS
+            ):
+                violations.append(f"{rel_path.as_posix()}:{import_ref.lineno}: {import_ref.module}")
+        for call in _dynamic_calls(tree):
+            if call.name in {"importlib.import_module", "__import__"} and call.argument:
+                if _contains_import(call.argument, REVERSE_FLOW_FORBIDDEN_MODULES):
+                    violations.append(f"{rel_path.as_posix()}:{call.lineno}: {call.name}({call.argument})")
+    _require(
+        not violations,
+        "forbidden reverse-flow import from LLM into truth internals: " + "; ".join(violations),
     )
 
 
@@ -219,6 +444,7 @@ def _validate_decision_docs(root: Path = ROOT) -> None:
         "Allowed LLM Import Locations",
         "Forbidden Import Locations",
         "Provider SDK Import Policy",
+        "Reverse-Flow Import Policy",
         "Effect on B2.4",
         "Effect on B2.7",
         "Effect on Trust API and MCP Paths",
@@ -235,6 +461,7 @@ def _validate_decision_docs(root: Path = ROOT) -> None:
     )
     for module in PROVIDER_SDK_MODULES:
         _require(module in decision, f"decision record missing provider SDK policy token: {module}")
+    _require("No reverse-flow exceptions are approved during M6" in decision, "decision record must list reverse-flow exceptions")
 
     if "Selected path: Path A" in decision:
         plan = root / "docs/llm/provider_boundary_decomposition_plan.md"
@@ -247,6 +474,9 @@ def _validate_decision_docs(root: Path = ROOT) -> None:
         "Path B Guardrail",
         "Machine Enforcement",
         "negative control",
+        "relative imports",
+        "dynamic imports",
+        "reverse-flow",
         "Path B is invalid",
     ):
         _require(token in guardrail, f"{GUARDRAIL_PATH.as_posix()} missing token: {token}")
@@ -261,6 +491,16 @@ def _validate_decision_docs(root: Path = ROOT) -> None:
         "If B2.4 introduces explanation/provider behavior",
     ):
         _require(token in preconditions, f"{B27_PRECONDITION_PATH.as_posix()} missing token: {token}")
+
+    for token in (
+        "Host-native execution is advisory",
+        "CI on main is authoritative",
+        "M6_NC_RELATIVE_IMPORT_PASS",
+        "M6_NC_DYNAMIC_IMPORTLIB_PASS",
+        "M6_NC_REVERSE_FLOW_IMPORT_PASS",
+        "M6_NC_DECISION_MUTATION_PASS",
+    ):
+        _require(token in completion, f"{COMPLETION_RECORD_PATH.as_posix()} missing token: {token}")
 
     for path, text in (
         (COMPLETION_RECORD_PATH, completion),
@@ -318,7 +558,7 @@ def _validate_pr_diff_scope() -> None:
 
     violations: list[str] = []
     for path in changed:
-        normalized = Path(path.as_posix())
+        normalized = _normalize_rel(path)
         if normalized in PR_DIFF_FORBIDDEN_EXACT or normalized in PR_DIFF_FORBIDDEN_DEPENDENCIES:
             violations.append(normalized.as_posix())
             continue
@@ -333,21 +573,135 @@ def _validate_pr_diff_scope() -> None:
     )
 
 
-def _run_negative_control() -> None:
-    with tempfile.TemporaryDirectory(prefix="m6_bad_import_") as tmp:
+def _write_fixture(root: Path, rel_path: str, content: str) -> Path:
+    path = root / rel_path
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def _expect_failure(label: str, func, expected: str) -> None:
+    try:
+        func()
+    except ValidationError as exc:
+        message = str(exc)
+        _require(expected in message, f"{label} failed for unexpected reason: {message}")
+        print(f"{label}: {message}")
+        return
+    raise ValidationError(f"{label} did not fail")
+
+
+def _negative_control_scan(label: str, rel_path: str, content: str, scan_func, expected: str) -> None:
+    with tempfile.TemporaryDirectory(prefix="m6_negative_control_") as tmp:
         tmp_root = Path(tmp)
-        bad_file = tmp_root / "backend/app/bayesian/m6_bad_import.py"
-        bad_file.parent.mkdir(parents=True, exist_ok=True)
-        bad_file.write_text(
-            "from app.llm.provider_boundary import SkeldirLLMProvider\n",
-            encoding="utf-8",
+        _write_fixture(tmp_root, rel_path, content)
+        _expect_failure(label, lambda: scan_func(tmp_root), expected)
+
+
+def _negative_control_decision_mutation() -> None:
+    with tempfile.TemporaryDirectory(prefix="m6_decision_mutation_") as tmp:
+        tmp_root = Path(tmp)
+        for path in (
+            DECISION_PATH,
+            GUARDRAIL_PATH,
+            B27_PRECONDITION_PATH,
+            COMPLETION_RECORD_PATH,
+            EVIDENCE_PACK_PATH,
+        ):
+            destination = tmp_root / path
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(ROOT / path, destination)
+        decision_path = tmp_root / DECISION_PATH
+        decision = decision_path.read_text(encoding="utf-8")
+        decision = decision.replace("Path B is invalid", "Path B drift is handled later")
+        decision_path.write_text(decision, encoding="utf-8")
+        _expect_failure(
+            "M6_NC_DECISION_MUTATION_PASS",
+            lambda: _validate_decision_docs(tmp_root),
+            "missing token: Path B is invalid",
         )
-        try:
-            _scan_forbidden_llm_imports(tmp_root)
-        except ValidationError as exc:
-            print(f"M6_NEGATIVE_CONTROL_PASS: {exc}")
-            return
-        raise ValidationError("negative control failed to detect forbidden B2.4 LLM import")
+
+
+def _run_negative_controls() -> None:
+    _negative_control_scan(
+        "M6_NC_ABSOLUTE_IMPORT_PASS",
+        "backend/app/bayesian/m6_bad_absolute.py",
+        "from app.llm.provider_boundary import SkeldirLLMProvider\n",
+        _scan_forbidden_llm_imports,
+        "forbidden LLM import",
+    )
+    _negative_control_scan(
+        "M6_NC_PACKAGE_IMPORT_PASS",
+        "backend/app/bayesian/m6_bad_package.py",
+        "from app import llm\n",
+        _scan_forbidden_llm_imports,
+        "forbidden LLM import",
+    )
+    _negative_control_scan(
+        "M6_NC_ALIAS_IMPORT_PASS",
+        "backend/app/bayesian/m6_bad_alias.py",
+        "import app.llm.provider_boundary as provider_boundary\n",
+        _scan_forbidden_llm_imports,
+        "forbidden LLM import",
+    )
+    _negative_control_scan(
+        "M6_NC_RELATIVE_IMPORT_PASS",
+        "backend/app/bayesian/m6_bad_relative.py",
+        "from ..llm import provider_boundary\n",
+        _scan_forbidden_llm_imports,
+        "forbidden LLM import",
+    )
+    _negative_control_scan(
+        "M6_NC_DYNAMIC_IMPORTLIB_PASS",
+        "backend/app/bayesian/m6_bad_importlib.py",
+        "import importlib\nprovider = importlib.import_module('app.llm.provider_boundary')\n",
+        _scan_dynamic_imports,
+        "dynamic import/code execution",
+    )
+    _negative_control_scan(
+        "M6_NC_DYNAMIC_BUILTIN_IMPORT_PASS",
+        "backend/app/bayesian/m6_bad_builtin_import.py",
+        "provider = __import__('app.llm.provider_boundary')\n",
+        _scan_dynamic_imports,
+        "dynamic import/code execution",
+    )
+    _negative_control_scan(
+        "M6_NC_DYNAMIC_EVAL_PASS",
+        "backend/app/bayesian/m6_bad_eval.py",
+        "value = eval('1 + 1')\n",
+        _scan_dynamic_imports,
+        "dynamic import/code execution",
+    )
+    _negative_control_scan(
+        "M6_NC_DYNAMIC_EXEC_PASS",
+        "backend/app/bayesian/m6_bad_exec.py",
+        "exec('value = 1')\n",
+        _scan_dynamic_imports,
+        "dynamic import/code execution",
+    )
+    _negative_control_scan(
+        "M6_NC_PROVIDER_SDK_TRUTH_PATH_PASS",
+        "backend/app/bayesian/m6_bad_provider_sdk.py",
+        "from openai import OpenAI\n",
+        _scan_provider_sdk_imports,
+        "provider SDK import in protected truth path",
+    )
+    _negative_control_scan(
+        "M6_NC_FORBIDDEN_SYMBOL_PASS",
+        "backend/app/bayesian/m6_bad_symbol.py",
+        "def build():\n    return SkeldirLLMProvider\n",
+        _scan_forbidden_symbols,
+        "forbidden LLM/provider symbol reference",
+    )
+    _negative_control_scan(
+        "M6_NC_REVERSE_FLOW_IMPORT_PASS",
+        "backend/app/llm/m6_bad_reverse_flow.py",
+        "from app.bayesian import diagnostics\n",
+        _scan_reverse_flow_imports,
+        "forbidden reverse-flow import",
+    )
+    _negative_control_decision_mutation()
+    print("M6_NEGATIVE_CONTROL_PASS")
 
 
 def validate_all(args: argparse.Namespace) -> None:
@@ -355,9 +709,12 @@ def validate_all(args: argparse.Namespace) -> None:
     _validate_governance()
     _scan_provider_sdk_imports()
     _scan_forbidden_llm_imports()
+    _scan_dynamic_imports()
+    _scan_forbidden_symbols()
+    _scan_reverse_flow_imports()
     _validate_pr_diff_scope()
     if args.negative_control:
-        _run_negative_control()
+        _run_negative_controls()
 
 
 def main() -> int:
@@ -365,9 +722,10 @@ def main() -> int:
     parser.add_argument(
         "--negative-control",
         action="store_true",
-        help="Run a bad B2.4 import fixture proving the validator fails.",
+        help="Run bad fixtures proving the validator fails across static, dynamic, reverse-flow, and doc-drift cases.",
     )
     args = parser.parse_args()
+    print(f"M6_ENVIRONMENT: python={platform.python_version()} platform={platform.platform()}")
     try:
         validate_all(args)
     except ValidationError as exc:


### PR DESCRIPTION
## Summary
- harden `validate_m6_llm_boundary.py` for relative imports, package/alias imports, dynamic imports, provider SDK truth-path imports, forbidden symbols, and LLM-to-truth reverse-flow imports
- expand M6 negative controls to cover absolute, package, alias, relative, importlib, `__import__`, `eval`, `exec`, provider SDK, forbidden symbol, reverse-flow, and decision-mutation failures
- update M6 decision, guardrail, completion record, and evidence pack with CI authority and corrective findings

## Validation
- `python scripts/ci/validate_m6_llm_boundary.py --negative-control`
- `python -m py_compile scripts/ci/validate_m6_llm_boundary.py`
- `python scripts/ci/validate_m5_b24_readiness_design.py --negative-control`
- `python scripts/ci/validate_m3_ci_governance.py --b24-dry-run`
- `python scripts/ci/run_ci_governance_cohort.py --cohort b2-4-dry-run --dry-run --summary-path artifacts/b24_gate_dry_run_summary.json`
- `python scripts/ci/validate_m0_scope_lock.py --baseline-sha f4c733a8b864ec2e38ad6f2ddca0a232075c95d4`
- `python scripts/ci/validate_m1_local_dev_authority.py --baseline-sha f4c733a8b864ec2e38ad6f2ddca0a232075c95d4`

Local note: `make validate-m6-llm-boundary` was not available on the Windows host because `make` is not installed; CI exercises the Make target in the B2.4 dry-run workflow.