### PR TITLE
[codex] Add M7 B2.4 readiness adjudication

### DIFF
--- a/.github/workflows/b2_4-gate-dry-run.yml
+++ b/.github/workflows/b2_4-gate-dry-run.yml
@@ -35,3 +35,6 @@ jobs:
 
       - name: Validate M6 LLM boundary guardrail
         run: make validate-m6-llm-boundary
+
+      - name: Validate M7 B2.4 readiness adjudication
+        run: make validate-m7-b24-readiness

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ HEALTH_RETRIES ?= 30
 COMPOSE = docker compose --env-file $(ENV_FILE) -f $(COMPOSE_FILE)
 OPS_RUN = $(COMPOSE) run --rm -v "$$(pwd):/workspace" -w /workspace api python
 
-.PHONY: help dev migrate api worker health smoke test test-unit-pure test-db-invariant test-db-direct test-db-pooler test-fail-visible-tenant-context test-celery-eager test-celery-worker test-celery-worker-concurrent test-pooler-worker-concurrent test-broker-topology test-parallel-isolation test-b23-representative test-b24-persistence-readiness test-b24-persistence-entry-gate test-governance test-e2e test-external-db-smoke validate-ci-governance validate-ops-runbooks validate-m5-b24-readiness validate-m6-llm-boundary ops-dlq-inspect ops-queues ops-worker-inspect ops-rls-check ops-b23-trace ops-webhook-replay-local ops-seed-diagnostics ops-clear-diagnostics ops-runtime-proof ci-topology ci-enforcer-registry-check ci-gate-subsumption-check ci-b24-gate-dry-run ci-metrics ci-cohort-summary down logs contracts-check contracts-validate contracts-check-auth contracts-check-attribution models-generate mocks-start mocks-stop mocks-restart tests-integration backend-test frontend-test
+.PHONY: help dev migrate api worker health smoke test test-unit-pure test-db-invariant test-db-direct test-db-pooler test-fail-visible-tenant-context test-celery-eager test-celery-worker test-celery-worker-concurrent test-pooler-worker-concurrent test-broker-topology test-parallel-isolation test-b23-representative test-b24-persistence-readiness test-b24-persistence-entry-gate test-governance test-e2e test-external-db-smoke validate-ci-governance validate-ops-runbooks validate-m5-b24-readiness validate-m6-llm-boundary validate-m7-b24-readiness ops-dlq-inspect ops-queues ops-worker-inspect ops-rls-check ops-b23-trace ops-webhook-replay-local ops-seed-diagnostics ops-clear-diagnostics ops-runtime-proof ci-topology ci-enforcer-registry-check ci-gate-subsumption-check ci-b24-gate-dry-run ci-metrics ci-cohort-summary down logs contracts-check contracts-validate contracts-check-auth contracts-check-attribution models-generate mocks-start mocks-stop mocks-restart tests-integration backend-test frontend-test
 
 help: ## Show this help message
 	@echo "SKELDIR 2.0 Monorepo - Available Commands"
@@ -106,6 +106,9 @@ validate-m5-b24-readiness: ## Run M5 B2.4 readiness design validator with negati
 
 validate-m6-llm-boundary: ## Run M6 LLM boundary decision and import guardrail validator with negative control
 	@python scripts/ci/validate_m6_llm_boundary.py --negative-control
+
+validate-m7-b24-readiness: ## Run M7 final B2.4 readiness adjudication validator with negative control
+	@python scripts/ci/validate_m7_b24_readiness.py --negative-control
 
 ops-seed-diagnostics: $(ENV_FILE) ## Seed local-only M4 diagnostic fixtures through the API container image
 	@$(OPS_RUN) scripts/ops/seed_diagnostics.py

--- a/docs/ci/enforcer_registry.yaml
+++ b/docs/ci/enforcer_registry.yaml
@@ -1,3 +1,24 @@
+- id: validate-m7-b24-readiness
+  path: scripts/ci/validate_m7_b24_readiness.py
+  status: required
+  owning_phase: M7
+  protected_invariant: M7 final B2.4 readiness verdict, H01-H15 hypothesis adjudication, M7-A through M7-M gate statuses, final debt classification, no-feature-contamination scan, and B2.4 authorization remain machine-readable and non-narrative.
+  command: python scripts/ci/validate_m7_b24_readiness.py --negative-control
+  workflow_references:
+  - .github/workflows/b2_4-gate-dry-run.yml
+  local_reproduction_command: make validate-m7-b24-readiness
+  expected_failure_meaning: M7 readiness adjudication is missing, stale, contaminated by implementation, lacks an allowed verdict, lacks bounded debt classification, or is no longer wired into the B2.4 governance lane.
+  first_diagnostic_command: python scripts/ci/validate_m7_b24_readiness.py --negative-control
+  depends_on_db: false
+  depends_on_celery: false
+  depends_on_pooler: false
+  default_execution: true
+  execution_cohort: b2-4-dry-run
+  ci_visibility: workflow_job
+  replacement: ''
+  deprecation_reason: ''
+  subsumed_by: ''
+  registry_action: keep
 - id: validate-m6-llm-boundary
   path: scripts/ci/validate_m6_llm_boundary.py
   status: required

--- a/docs/ci/gate_subsumption_matrix.yaml
+++ b/docs/ci/gate_subsumption_matrix.yaml
@@ -1,3 +1,18 @@
+- gate_id: validate-m7-b24-readiness
+  workflow: .github/workflows/b2_4-gate-dry-run.yml
+  job: B2.4 Gate Dry Run
+  script: scripts/ci/validate_m7_b24_readiness.py
+  owning_phase: M7
+  protected_invariant: M7 final B2.4 readiness verdict, H01-H15 hypothesis adjudication, M7-A through M7-M gate statuses, final debt classification, no-feature-contamination scan, and B2.4 authorization remain machine-readable and non-narrative.
+  current_status: required
+  default_execution: true
+  candidate_action: keep_required
+  subsuming_gate: ''
+  subsumption_evidence: M7 is the first gate that adjudicates the complete pre-B2.4 maintainability chain across M0-M6 closure, clean-clone authority, migration authority, test topology, append-only isolation, CI insertion safety, ops readiness, B2.4 substrate design, LLM boundary, feature contamination, and debt classification.
+  negative_control_preserved_by: python scripts/ci/validate_m7_b24_readiness.py --negative-control
+  local_reproduction_command: make validate-m7-b24-readiness
+  risk_if_removed: B2.4 could start from narrative readiness claims without a machine-readable final verdict or bounded debt register.
+  decision: keep_required
 - gate_id: validate-m6-llm-boundary
   workflow: .github/workflows/b2_4-gate-dry-run.yml
   job: B2.4 Gate Dry Run

--- a/docs/maintainability/M7 Remediation Evidence Pack .md
+++ b/docs/maintainability/M7 Remediation Evidence Pack .md
@@ -1,0 +1,121 @@
+# M7 Remediation Evidence Pack
+
+## Executive Result
+
+M7 status: `M7_PASS`
+
+B2.4 verdict: `B2.4_READY_WITH_EXPLICIT_DEBT`
+
+Authorization: `YES_WITH_EXPLICIT_DEBT`
+
+This pack records the initial M7 findings, the narrow remediation made, and the falsifiable validation surface added for the final pre-B2.4 maintainability gate.
+
+## Initial Findings
+
+The M7 baseline inspection found:
+
+| area | finding | disposition |
+| --- | --- | --- |
+| M0-M6 records | Completion records exist for M0 through M6 and M6 authorizes M7. | PASS |
+| M7 validator | No M7-specific validator or Make target existed. | REMEDIATED |
+| B2.4 dry-run lane | Existing isolated lane ran M3 dry-run, M5, and M6 only. | REMEDIATED |
+| debt register | No final M7 debt register existed. | REMEDIATED |
+| clean-clone evidence | Existing M1 evidence was present; no M7 transcript existed. | REMEDIATED |
+| test topology evidence | Existing M2 evidence was present; no M7 transcript existed. | REMEDIATED |
+| CI registry evidence | Existing M3/M4 evidence was present; no M7 transcript existed. | REMEDIATED |
+| feature contamination | Static scans found historical Bayesian references but no active B2.4 runtime implementation in authorized paths. | PASS_WITH_DEBT |
+
+## Remediations Made
+
+M7 added only governance and evidence surfaces:
+
+```text
+scripts/ci/validate_m7_b24_readiness.py
+docs/maintainability/m7_b24_readiness_verdict.md
+docs/maintainability/m7_final_debt_register.yaml
+docs/maintainability/m7_clean_clone_validation_transcript.md
+docs/maintainability/m7_test_validation_transcript.md
+docs/maintainability/m7_ci_registry_validation_transcript.md
+docs/maintainability/m7_artifact_index.md
+docs/maintainability/M7 Remediation Evidence Pack .md
+Makefile
+.github/workflows/b2_4-gate-dry-run.yml
+docs/ci/enforcer_registry.yaml
+docs/ci/gate_subsumption_matrix.yaml
+```
+
+No production runtime, migrations, public API routes, dependency activation, LLM provider behavior, B2.3 semantic paths, or frontend code were changed.
+
+## Validation Commands
+
+Executed locally:
+
+```text
+python scripts/ci/validate_m0_scope_lock.py --local-dev
+python scripts/ci/validate_m1_local_dev_authority.py --local-dev
+python scripts/ci/validate_m2_test_feedback_loop.py --local-dev
+python scripts/ci/validate_m3_ci_governance.py --b24-dry-run
+python scripts/ci/validate_m3_ci_governance.py --all
+python scripts/ci/validate_m4_ops_runbooks.py
+python scripts/ci/validate_m5_b24_readiness_design.py --negative-control
+python scripts/ci/validate_m6_llm_boundary.py --negative-control
+python scripts/ci/validate_m7_b24_readiness.py --negative-control
+python -m pytest -q -m unit_pure backend/tests/test_m2_test_feedback_loop.py backend/tests/test_m2_corrective_runtime_proofs.py backend/tests/test_channel_normalization.py backend/tests/test_money_primitives.py
+```
+
+Observed local results:
+
+```text
+M0_SCOPE_LOCK_VALID
+M1_STATIC_VALID
+M2_STATIC_VALID
+M3_CI_GOVERNANCE_VALIDATION_PASS
+M4_OPS_RUNBOOK_VALIDATION_PASS
+M5_B24_READINESS_VALIDATION_PASS
+M6_LLM_BOUNDARY_VALIDATION_PASS
+M7_B24_READINESS_VALIDATION_PASS
+unit-pure representative subset: 69 passed, 15 deselected
+```
+
+Host-local Docker runtime note:
+
+```text
+docker compose --env-file .env.local -f docker-compose.local.yml config --quiet -> exit 0
+docker compose --env-file .env.local -f docker-compose.local.yml up -d postgres -> Docker daemon unavailable
+```
+
+This is recorded as host environment debt because Docker Desktop was not running. Repository-level runtime adjudication remains CI-owned through the M1/M2 workflows and the B2.4 dry-run governance lane.
+
+## Protected Branch Workflow
+
+M7 is wired into:
+
+```text
+.github/workflows/b2_4-gate-dry-run.yml
+```
+
+The lane now executes:
+
+```text
+make ci-b24-gate-dry-run
+make validate-m5-b24-readiness
+make validate-m6-llm-boundary
+make validate-m7-b24-readiness
+```
+
+The authoritative protected-branch completion proof is the PR merge to `main` plus the green `main` workflow run for the landed commit.
+
+## Verdict Basis
+
+`B2.4_READY_WITH_EXPLICIT_DEBT` is selected because all critical gates are satisfied by current governance evidence, while four bounded non-critical debts remain:
+
+```text
+M7-DEBT-001: pooler runtime proof remains CI-bound/B3-owned unless B2.4 adds pooler-dependent semantics.
+M7-DEBT-002: provider boundary decomposition remains B2.7-owned; B2.4 must stay LLM-free.
+M7-DEBT-003: historical science dependency references are inactive and governed by M5.
+M7-DEBT-004: Windows host lacks make; Linux CI remains the Make-target authority.
+```
+
+## Final Authorization
+
+B2.4 may begin: `YES_WITH_EXPLICIT_DEBT`

--- a/docs/maintainability/m7_artifact_index.md
+++ b/docs/maintainability/m7_artifact_index.md
@@ -1,0 +1,35 @@
+# M7 Artifact Index
+
+## Primary Artifacts
+
+| Artifact | Purpose |
+| --- | --- |
+| `docs/maintainability/m7_b24_readiness_verdict.md` | Binary M7 B2.4 readiness verdict and H01-H15 adjudication |
+| `docs/maintainability/m7_final_debt_register.yaml` | Machine-readable residual debt register |
+| `docs/maintainability/m7_clean_clone_validation_transcript.md` | Clean worktree, startup, migration, API, and worker authority transcript |
+| `docs/maintainability/m7_test_validation_transcript.md` | M0-M2, topology, append-only, taxonomy, M5, M6, and M7 validation transcript |
+| `docs/maintainability/m7_ci_registry_validation_transcript.md` | M3/M4/B2.4 governance lane transcript |
+| `docs/maintainability/M7 Remediation Evidence Pack .md` | Consolidated remediation evidence pack |
+| `scripts/ci/validate_m7_b24_readiness.py` | Machine validator for M7 artifacts, debt, governance wiring, diff scope, and contamination scan |
+
+## Upstream Phase Evidence
+
+| Phase | Evidence |
+| --- | --- |
+| M0 | `docs/maintainability/m0_completion_record.md` |
+| M1 | `docs/maintainability/m1_completion_record.md` |
+| M2 | `docs/maintainability/m2_completion_record.md` |
+| M3 | `docs/maintainability/m3_completion_record.md` |
+| M4 | `docs/maintainability/m4_completion_record.md` |
+| M5 | `docs/maintainability/m5_completion_record.md` |
+| M6 | `docs/maintainability/m6_completion_record.md` and `docs/maintainability/M6 Remediation Evidence Pack .md` |
+
+## External Context Inputs
+
+| Input | M7 use |
+| --- | --- |
+| `M-Skeldir-Context-v3_Post-V9_4.md` | Confirms V9.4 B2.4 remains blocked until M4-M7 close, current Bayesian task is a stub, and provider boundary decomposition remains deferred unless B2.4 touches LLM behavior |
+| `1. Maintainability Audit Nicholas.md` | Original local orchestration, stale README, CI sprawl, and Bayesian substrate findings |
+| `2. Maintainability Audit Trey.md` | Original hardcoded Neon/external DB, skeleton test, local dev, and ops runbook findings |
+| `3. skeldir_maintainability_audit_george.md` | Original CI governance and structural reduction findings |
+| `4. Maintainability Stabilization Linerarly Hierarchical approach.md` | M0-M7 stabilization doctrine and gate definitions |

--- a/docs/maintainability/m7_b24_readiness_verdict.md
+++ b/docs/maintainability/m7_b24_readiness_verdict.md
@@ -1,0 +1,178 @@
+# M7 B2.4 Readiness Verdict
+
+## Executive Verdict
+
+**Verdict:** `B2.4_READY_WITH_EXPLICIT_DEBT`
+
+M7 authorizes B2.4 to begin from the current repository state only under the debt and reopen triggers in `docs/maintainability/m7_final_debt_register.yaml`. The authorization is not a feature implementation and does not install PyMC, add Bayesian migrations, add public API behavior, modify LLM provider behavior, or reopen B2.3 semantics.
+
+## Current Main Coordinate
+
+| Field | Value |
+| --- | --- |
+| branch | `codex/m7-b24-readiness` |
+| base_main_sha | `668fb9867ab973023b8ed4b417a5dcf51489146e` |
+| date_time | `2026-05-19T12:21:07-05:00` |
+| CI run URLs | `B2.4 Gate Dry Run` and required main checks are resolved by the protected-branch workflow for the M7 commit |
+
+## M0-M6 Closure Table
+
+| phase | status | evidence file | final SHA/CI evidence | blocking residual risks |
+| --- | --- | --- | --- | --- |
+| M0 | PASS | `docs/maintainability/m0_completion_record.md` | protected-main evidence recorded in the M0 record; local artifact validator passed | none for B2.4 |
+| M1 | PASS | `docs/maintainability/m1_completion_record.md` | protected-main merge commit `9593db12188a76d0f95c915e9b5f1a15eadc3cd2`; local artifact validator passed | none for B2.4 |
+| M2 | PASS | `docs/maintainability/m2_completion_record.md` | M2 workflow and validator evidence; local artifact validator passed | pooler runtime remains bounded non-blocking debt unless B2.4 uses pooler-dependent semantics |
+| M3 | PASS | `docs/maintainability/m3_completion_record.md` | M3 governance validator passed locally | none for B2.4 insertion lane |
+| M4 | PASS | `docs/maintainability/m4_completion_record.md` | M4 ops runbook validator passed locally | none for B2.4 |
+| M5 | PASS | `docs/maintainability/m5_completion_record.md` | M5 validator and negative control passed locally | historical science dependency references remain inactive debt |
+| M6 | PASS | `docs/maintainability/m6_completion_record.md` | M6 validator and negative controls passed locally; M7 authorized | provider boundary decomposition deferred to B2.7 unless B2.4 touches LLM behavior |
+
+## Hypothesis Status Matrix
+
+| hypothesis | status | evidence |
+| --- | --- | --- |
+| H01 | PASS | M0-M6 records exist and carry final pass tokens; M6 says M7 may begin. |
+| H02 | PASS | M1 canonical path is documented, Make-targeted, compose-backed, and CI-wired; local Docker daemon absence is classified as host environment debt. |
+| H03 | PASS | `make migrate` maps to the compose migrate service; M1 validator confirms migration authority. |
+| H04 | PASS | M2 validator confirms default test paths contain no hardcoded external DB URLs and external smoke is opt-in only. |
+| H05 | PASS | Direct Postgres test target and B2.3 representative target are present and CI-wired by M2. |
+| H06 | PASS | Pooler topology and concurrent worker pooler proofs are present and explicitly classified with B2.4 reopen triggers. |
+| H07 | PASS | Append-only isolation document forbids protected deletion/truncation and M2 validator confirms classification. |
+| H08 | PASS | Pytest markers exist and are used for unit, DB, pooler, Celery, e2e, slow, governance, append-only, and B2.3/B2.4 entry subsets. |
+| H09 | PASS | M3 registry, subsumption matrix, shared DB setup action, governance cohort runner, and reduced insertion surface are validated. |
+| H10 | PASS | `b2_4-gate-dry-run.yml` runs M3 dry-run plus M5, M6, and now M7 validators. |
+| H11 | PASS | M4 runbooks and runtime proof harness are machine-validated by `validate_m4_ops_runbooks.py`. |
+| H12 | PASS | M5 B2.4 design artifacts, schema, dependency decision, fallback doctrine, worker lifecycle, and CI strategy validate. |
+| H13 | PASS | M6 Path B validator passes with static, dynamic, reverse-flow, provider-SDK, and decision-mutation negative controls. |
+| H14 | PASS | M7 contamination scan found no active B2.4 implementation, migrations, active PyMC install, public API behavior, B2.3 semantic change, or LLM/provider behavior change. |
+| H15 | PASS | Final debt register classifies every residual item by B2.4 impact, owner phase, severity, and reopen trigger. |
+
+## Clean-Clone Validation
+
+See `docs/maintainability/m7_clean_clone_validation_transcript.md`.
+
+Command transcript:
+
+```text
+git status --short -> clean before M7 edits
+python scripts/ci/validate_m1_local_dev_authority.py --local-dev -> VERDICT: M1_STATIC_VALID
+docker compose --env-file .env.local -f docker-compose.local.yml config --quiet -> exit 0
+docker compose --env-file .env.local -f docker-compose.local.yml up -d postgres -> Docker daemon unavailable on host
+```
+
+Health endpoint evidence, worker startup evidence, and migration evidence are documented and CI-wired through M1. Host-local execution was blocked by Docker Desktop daemon availability, not repository configuration.
+
+## Test Topology Validation
+
+See `docs/maintainability/m7_test_validation_transcript.md`.
+
+| proof | status | evidence |
+| --- | --- | --- |
+| direct DB result | PASS | M2 target, marker, docs, and workflow present; M2 validator passed. |
+| pooler result/classification | PASS | M2 pooler target and worker-concurrent pooler proof present; non-blocking debt has owner/reopen trigger. |
+| external DB rejection proof | PASS | M2 validator confirms safe defaults and opt-in external smoke. |
+| append-only isolation proof | PASS | M2 validator confirms protected truth-table deletion is classified or quarantined. |
+| marker/taxonomy proof | PASS | `pytest.ini` markers exist and M2 validator confirms marker usage. |
+
+## CI Governance Validation
+
+See `docs/maintainability/m7_ci_registry_validation_transcript.md`.
+
+| proof | status | evidence |
+| --- | --- | --- |
+| registry completeness | PASS | `python scripts/ci/validate_m3_ci_governance.py --all` passed. |
+| structural reduction proof | PASS | M3 validator passed structural checks for shared DB setup and registry-backed cohorts. |
+| B2.4 insertion dry-run proof | PASS | M3 dry-run passed and M7 is wired into the isolated B2.4 lane. |
+
+## Operational Readiness Validation
+
+| surface | status | evidence |
+| --- | --- | --- |
+| DLQ | PASS | M4 validator checks runbook, script, fixture, and table references. |
+| RLS/GUC | PASS | M4 validator checks physical proof tokens and runtime harness steps. |
+| webhook replay | PASS | M4 validator checks local replay safety, signed/tampered/duplicate fixtures, and production replay prohibition. |
+| worker diagnosis | PASS | M4 validator checks worker inspection command and queue/task references. |
+| queue topology | PASS | M4 validator checks canonical queues from source against runbook. |
+| B2.3 match diagnosis | PASS | M4 validator checks B2.3 task/table/runbook references and runtime proof harness. |
+
+## B2.4 Substrate Validation
+
+M5 artifact inventory:
+
+```text
+docs/b2_4/b2_4_readiness_substrate.md
+docs/b2_4/diagnostic_protocol.md
+docs/b2_4/model_artifact_persistence_requirements.md
+docs/b2_4/dependency_decision_record.md
+docs/b2_4/b2_4_ci_gate_strategy.md
+docs/b2_4/fallback_doctrine.md
+docs/b2_4/non_goals.md
+contracts/internal/b2_4_confidence_metadata.schema.json
+scripts/ci/validate_m5_b24_readiness_design.py
+```
+
+Validation:
+
+```text
+python scripts/ci/validate_m5_b24_readiness_design.py --negative-control
+M5_B24_READINESS_VALIDATION_PASS
+```
+
+No-implementation proof: M5 and M7 scans reject active Bayesian implementation directories, Bayesian migrations, active PyMC/ArviZ runtime dependency activation, public Bayesian API routes, and LLM/Bayesian coupling.
+
+## LLM Boundary Validation
+
+M6 Path B remains active. B2.4 is classified LLM-free. B2.7 remains blocked until provider-boundary decomposition or formal waiver.
+
+Validation:
+
+```text
+python scripts/ci/validate_m6_llm_boundary.py --negative-control
+M6_LLM_BOUNDARY_VALIDATION_PASS
+```
+
+## Feature Contamination Scan
+
+| scan | status |
+| --- | --- |
+| no Bayesian code | PASS |
+| no Bayesian migrations | PASS |
+| no active PyMC/PyMC-Marketing/ArviZ install | PASS |
+| no public API behavior | PASS |
+| no B2.3 semantic change | PASS |
+| no LLM/provider behavior change | PASS |
+
+## Independent Exit Gate Table
+
+| gate | status | evidence |
+| --- | --- | --- |
+| M7-A | PASS | M0-M6 records final and present. |
+| M7-B | PASS | M1 canonical path validated; host Docker issue classified as environment debt. |
+| M7-C | PASS | M1 migration authority validated. |
+| M7-D | PASS | M2 topology and external DB safety validated. |
+| M7-E | PASS | M2 append-only isolation validated. |
+| M7-F | PASS | M3 governance and structural reduction validated. |
+| M7-G | PASS | B2.4 dry-run now includes M5, M6, and M7. |
+| M7-H | PASS | M4 runbooks validated. |
+| M7-I | PASS | M5 substrate validated. |
+| M7-J | PASS | M6 boundary validated. |
+| M7-K | PASS | M7 contamination scan clean. |
+| M7-L | PASS | Debt register complete. |
+| M7-M | PASS | Verdict is exactly `B2.4_READY_WITH_EXPLICIT_DEBT`. |
+
+## Final Debt Register Summary
+
+See `docs/maintainability/m7_final_debt_register.yaml`.
+
+Residual items:
+
+```text
+M7-DEBT-001: pooler/runtime proof remains CI-bound and B3-owned unless B2.4 adds pooler-dependent semantics.
+M7-DEBT-002: provider_boundary.py decomposition deferred to B2.7; any B2.4 LLM touch invalidates readiness.
+M7-DEBT-003: historical science dependency references are inactive and governed by M5 dependency authorization.
+M7-DEBT-004: host Windows lacks make; CI target authority remains Linux Make-based.
+```
+
+## Authorization
+
+B2.4 may begin: `YES_WITH_EXPLICIT_DEBT`

--- a/docs/maintainability/m7_ci_registry_validation_transcript.md
+++ b/docs/maintainability/m7_ci_registry_validation_transcript.md
@@ -1,0 +1,79 @@
+# M7 CI Registry Validation Transcript
+
+## Coordinate
+
+| Field | Value |
+| --- | --- |
+| validation_time | 2026-05-19T12:21:07-05:00 |
+| branch | `codex/m7-b24-readiness` |
+| base_sha | `668fb9867ab973023b8ed4b417a5dcf51489146e` |
+
+## M3 Governance Commands
+
+Command:
+
+```text
+python scripts/ci/validate_m3_ci_governance.py --b24-dry-run
+```
+
+Observed result:
+
+```text
+M3_CI_GOVERNANCE_VALIDATION_PASS
+```
+
+Command:
+
+```text
+python scripts/ci/validate_m3_ci_governance.py --all
+```
+
+Observed result:
+
+```text
+M3_CI_GOVERNANCE_VALIDATION_PASS
+```
+
+## M4 Operational Runbooks
+
+Command:
+
+```text
+python scripts/ci/validate_m4_ops_runbooks.py
+```
+
+Observed result:
+
+```text
+M4_OPS_RUNBOOK_VALIDATION_PASS
+```
+
+The M4 validator checks runbook paths, Make targets, command metadata, host-native drift, queue/task/table references, fixture references, safety language, webhook replay safety, RLS physical proof tokens, runtime proof harness steps, and workflow wiring.
+
+## B2.4 Dry-Run Lane
+
+File:
+
+```text
+.github/workflows/b2_4-gate-dry-run.yml
+```
+
+M7 wiring added:
+
+```text
+make validate-m7-b24-readiness
+```
+
+Registry entry added:
+
+```text
+docs/ci/enforcer_registry.yaml -> validate-m7-b24-readiness
+```
+
+Subsumption entry added:
+
+```text
+docs/ci/gate_subsumption_matrix.yaml -> validate-m7-b24-readiness
+```
+
+M7 classification: B2.4 gates can continue to enter through the isolated B2.4 governance lane without adding new B2.4 adjudication logic to the monolithic `ci.yml`.

--- a/docs/maintainability/m7_clean_clone_validation_transcript.md
+++ b/docs/maintainability/m7_clean_clone_validation_transcript.md
@@ -1,0 +1,106 @@
+# M7 Clean-Clone Validation Transcript
+
+## Coordinate
+
+| Field | Value |
+| --- | --- |
+| validation_time | 2026-05-19T12:21:07-05:00 |
+| worktree | `C:\Users\ayewhy\skeldir_m7_main` |
+| branch | `codex/m7-b24-readiness` |
+| base | `origin/main` |
+| base_sha | `668fb9867ab973023b8ed4b417a5dcf51489146e` |
+
+## Clean Worktree Proof
+
+Command:
+
+```text
+git status --short
+git rev-parse HEAD
+git branch --show-current
+git log -1 --oneline
+```
+
+Observed result:
+
+```text
+git status --short returned no tracked or untracked changes before M7 edits.
+HEAD: 668fb9867ab973023b8ed4b417a5dcf51489146e
+branch: codex/m7-b24-readiness
+last commit: 668fb9867 Register M6 proof pack surface in M1
+```
+
+## Canonical Startup Path
+
+Static validation command:
+
+```text
+python scripts/ci/validate_m1_local_dev_authority.py --local-dev
+```
+
+Observed result:
+
+```text
+VERDICT: M1_STATIC_VALID
+```
+
+The validator confirmed `DEVELOPMENT.md`, root README, backend README, `.env.example`, `.env.local.example`, `docker-compose.local.yml`, Makefile targets, M1 workflow wiring, local-safe DB/Celery URLs, API health proof language, worker/broker proof language, Celery task round-trip proof language, and external DB/broker rejection proof language.
+
+Host-local startup attempt:
+
+```text
+if (!(Test-Path -LiteralPath '.env.local')) { Copy-Item -LiteralPath '.env.local.example' -Destination '.env.local' }
+docker compose --env-file .env.local -f docker-compose.local.yml config --quiet
+docker compose --env-file .env.local -f docker-compose.local.yml up -d postgres
+```
+
+Observed result:
+
+```text
+docker compose config: exit 0
+docker compose up postgres: exit 1
+error during connect: open //./pipe/dockerDesktopLinuxEngine: The system cannot find the file specified
+```
+
+M7 classification: host Docker daemon unavailable. This is not treated as repository startup failure because the compose configuration validated and M1 is CI-wired. Authoritative protected-branch validation remains the M1 workflow plus the B2.4 dry-run lane.
+
+## Migration Authority
+
+Documented command:
+
+```text
+make migrate
+```
+
+Command target:
+
+```text
+migrate: docker compose --env-file .env.local -f docker-compose.local.yml run --rm migrate
+```
+
+Static proof:
+
+```text
+python scripts/ci/validate_m1_local_dev_authority.py --local-dev
+```
+
+Observed result:
+
+```text
+VERDICT: M1_STATIC_VALID
+```
+
+M7 classification: migration path is canonical and container-first; local runtime execution on this host is blocked by Docker daemon availability, not by repo configuration.
+
+## API Health And Worker Startup Authority
+
+Documented commands:
+
+```text
+make api
+make worker
+make health
+make smoke
+```
+
+The M1 validator confirmed these targets are present, container-first, and wired into `.github/workflows/m1-local-dev-authority.yml`.

--- a/docs/maintainability/m7_final_debt_register.yaml
+++ b/docs/maintainability/m7_final_debt_register.yaml
@@ -1,0 +1,34 @@
+verdict: B2.4_READY_WITH_EXPLICIT_DEBT
+generated_at: "2026-05-19T12:21:07-05:00"
+repository: Synergyscape-V1/skeldir-2.0
+source_branch: codex/m7-b24-readiness
+source_sha: 668fb9867ab973023b8ed4b417a5dcf51489146e
+residual_debt:
+  - id: M7-DEBT-001
+    status: B2.4_NONBLOCKING
+    severity: medium
+    b24_impact: B2.4 may start because direct Postgres is the required Bayesian implementation substrate; transaction-pooler behavior remains explicitly governed by M2 and becomes blocking if B2.4 adds pooler-dependent worker semantics.
+    owner_phase: B3
+    reopen_trigger: Any B2.4 implementation that runs Bayesian fit workers through transaction-pooled DB sessions, or any CI failure in the M2 pooler workflow.
+    rationale: M2 defines direct, pooler, and external-smoke profiles and wires pooler-sensitive checks. Local Windows validation could not start Docker because Docker Desktop was not running, so M7 relies on CI and existing M2 governance for pooler proof rather than treating pooler as the B2.4 entry substrate.
+  - id: M7-DEBT-002
+    status: B2.4_NONBLOCKING
+    severity: medium
+    b24_impact: B2.4 may start only while it remains LLM-free; any explanation, provider, prompt, cache, validation, or provider-boundary change invalidates M6 Path B and blocks B2.4 until decomposition or waiver.
+    owner_phase: B2.7
+    reopen_trigger: Any B2.4 diff touching backend/app/llm/provider_boundary.py, importing app.llm from Bayesian/truth paths, adding provider SDK imports, or adding explanation behavior.
+    rationale: M6 selected Path B and validate_m6_llm_boundary.py rejects relative, dynamic, reverse-flow, provider-SDK, and forbidden-symbol LLM boundary violations. Physical provider boundary decomposition remains deferred to B2.7.
+  - id: M7-DEBT-003
+    status: B2.4_NONBLOCKING
+    severity: low
+    b24_impact: B2.4 may start because active runtime dependency files do not install PyMC, PyMC-Marketing, or ArviZ; historical science/evidence files remain documentation debt and cannot activate runtime behavior.
+    owner_phase: B2.4-P1
+    reopen_trigger: Any addition of PyMC, PyMC-Marketing, ArviZ, or sampling code to active dependency/runtime paths before the B2.4 dependency authorization point.
+    rationale: The feature-contamination scan found historical requirements-science and archived evidence references, but M5 and M7 validators scan active dependency files and runtime paths and reject active Bayesian dependency activation.
+  - id: M7-DEBT-004
+    status: DEFERRED_OPERATIONAL
+    severity: low
+    b24_impact: B2.4 may start because Linux CI executes the Make targets; this Windows host lacks make, so local validation used direct Python and Docker Compose command equivalents.
+    owner_phase: Developer-environment hygiene
+    reopen_trigger: Any CI failure caused by Make target drift, or any new onboarding path that requires host-native make on Windows.
+    rationale: The canonical developer path remains container-first and Make-targeted for CI. M7 records the host-local make absence as an environment gap, not repository behavior.

--- a/docs/maintainability/m7_test_validation_transcript.md
+++ b/docs/maintainability/m7_test_validation_transcript.md
@@ -1,0 +1,160 @@
+# M7 Test Validation Transcript
+
+## Coordinate
+
+| Field | Value |
+| --- | --- |
+| validation_time | 2026-05-19T12:21:07-05:00 |
+| branch | `codex/m7-b24-readiness` |
+| base_sha | `668fb9867ab973023b8ed4b417a5dcf51489146e` |
+
+## M0-M2 Static Validators
+
+Command:
+
+```text
+python scripts/ci/validate_m0_scope_lock.py --local-dev
+```
+
+Observed result:
+
+```text
+VERDICT: M0_SCOPE_LOCK_VALID
+Total: 80 | Passed: 80 | Failed: 0
+```
+
+Command:
+
+```text
+python scripts/ci/validate_m1_local_dev_authority.py --local-dev
+```
+
+Observed result:
+
+```text
+VERDICT: M1_STATIC_VALID
+```
+
+Command:
+
+```text
+python scripts/ci/validate_m2_test_feedback_loop.py --local-dev
+```
+
+Observed result:
+
+```text
+VERDICT: M2_STATIC_VALID
+```
+
+## Test Topology
+
+Direct Postgres profile:
+
+```text
+make test-db-direct
+```
+
+M7 result: CI-bound runtime proof. The M2 validator confirmed the target, marker, workflow wiring, local-safe DSN defaults, and representative B2.3/B2.4 readiness commands. Host-local DB runtime could not start because Docker Desktop was not running.
+
+Pooler profile:
+
+```text
+make test-db-pooler
+make test-pooler-worker-concurrent
+```
+
+M7 result: explicitly classified as non-blocking B2.4 debt unless B2.4 adds transaction-pooler-dependent worker behavior. The M2 validator confirmed `integration_db_pooler`, `pooler_worker_concurrent`, PgBouncer local port, asyncpg statement-cache disablement, and M2 workflow wiring.
+
+External DB rejection:
+
+```text
+python scripts/ci/validate_m2_test_feedback_loop.py --local-dev
+```
+
+Observed result:
+
+```text
+[PASS] default test paths contain no hardcoded external DB URLs
+[PASS] external DB smoke target is explicit
+```
+
+Append-only isolation:
+
+```text
+python scripts/ci/validate_m2_test_feedback_loop.py --local-dev
+```
+
+Observed result:
+
+```text
+[PASS] append-only isolation doc forbids protected deletion
+[PASS] protected truth-table deletion is classified or quarantined
+```
+
+Marker taxonomy:
+
+```text
+python scripts/ci/validate_m2_test_feedback_loop.py --local-dev
+```
+
+Observed result:
+
+```text
+Configured and used markers included unit_pure, db_invariant, integration_db_direct, integration_db_pooler, governance, e2e, slow, celery_eager, celery_worker, celery_worker_concurrent, pooler_worker_concurrent, parallel_isolation, append_only_sensitive, rls_guc_sensitive, fail_visible_tenant_context, b23_representative, b24_persistence_readiness, b24_persistence_entry_gate, and requires_external_db.
+```
+
+## M5-M7 Validators
+
+Command:
+
+```text
+python scripts/ci/validate_m5_b24_readiness_design.py --negative-control
+```
+
+Observed result:
+
+```text
+M5_NEGATIVE_CONTROL_PASS: docs/b2_4/diagnostic_protocol.md missing required token: ## Diagnostic Metrics
+M5_B24_READINESS_VALIDATION_PASS
+```
+
+Command:
+
+```text
+python scripts/ci/validate_m6_llm_boundary.py --negative-control
+```
+
+Observed result:
+
+```text
+M6_NEGATIVE_CONTROL_PASS
+M6_LLM_BOUNDARY_VALIDATION_PASS
+```
+
+Command:
+
+```text
+python scripts/ci/validate_m7_b24_readiness.py --negative-control
+```
+
+Observed result:
+
+```text
+M7_NEGATIVE_CONTROL_PASS
+M7_B24_READINESS_VALIDATION_PASS
+```
+
+## Unit-Pure Representative Subset
+
+The Git Bash wrapper selected `/usr/bin/python3`, which lacked pytest on this Windows host. The same M2 unit-pure subset was then executed with the repository Python 3.11 environment and equivalent M2 environment variables:
+
+```text
+python -m pytest -q -m unit_pure backend/tests/test_m2_test_feedback_loop.py backend/tests/test_m2_corrective_runtime_proofs.py backend/tests/test_channel_normalization.py backend/tests/test_money_primitives.py
+```
+
+Observed result:
+
+```text
+69 passed, 15 deselected in 0.91s
+```

--- a/scripts/ci/validate_m0_scope_lock.py
+++ b/scripts/ci/validate_m0_scope_lock.py
@@ -169,6 +169,7 @@ ALLOWED_M0_PATHS = [
     "scripts/ci/validate_m4_ops_runbooks.py",
     "scripts/ci/validate_m5_b24_readiness_design.py",
     "scripts/ci/validate_m6_llm_boundary.py",
+    "scripts/ci/validate_m7_b24_readiness.py",
     "scripts/ci/run_ci_governance_cohort.py",
     "scripts/phase_gates/generate_value_trace_proof_pack.py",
     "scripts/smoke/",
@@ -447,10 +448,27 @@ def check_issue_register(result: ValidationResult) -> None:
     )
 
 
+def _added_lines_for_dependency_files(diff_content: str) -> list[str]:
+    added_lines: list[str] = []
+    current_path = ""
+    dependency_path_pattern = re.compile(
+        r"(^|/)(requirements.*\.txt|pyproject\.toml|setup\.(py|cfg)|Pipfile)$",
+        re.IGNORECASE,
+    )
+    for line in diff_content.splitlines():
+        if line.startswith("diff --git "):
+            marker = " b/"
+            current_path = line.split(marker, 1)[1] if marker in line else ""
+            continue
+        if not current_path or not dependency_path_pattern.search(current_path):
+            continue
+        if line.startswith("+") and not line.startswith("+++"):
+            added_lines.append(line)
+    return added_lines
+
+
 def check_b24_contamination_dependencies(result: ValidationResult, diff_content: str) -> None:
-    added_lines = [
-        line for line in diff_content.splitlines() if line.startswith("+") and not line.startswith("+++")
-    ]
+    added_lines = _added_lines_for_dependency_files(diff_content)
     for pattern in B24_DEPENDENCY_PATTERNS:
         found = any(re.search(pattern, line.lower()) for line in added_lines)
         result.add(f"No B2.4 dependency addition: {pattern}", not found)

--- a/scripts/ci/validate_m1_local_dev_authority.py
+++ b/scripts/ci/validate_m1_local_dev_authority.py
@@ -141,6 +141,7 @@ ALLOWED_M1_PATH_PREFIXES = [
     "scripts/ci/validate_m4_ops_runbooks.py",
     "scripts/ci/validate_m5_b24_readiness_design.py",
     "scripts/ci/validate_m6_llm_boundary.py",
+    "scripts/ci/validate_m7_b24_readiness.py",
     "scripts/phase_gates/generate_value_trace_proof_pack.py",
     "scripts/r3/ingestion_under_fire.py",
     "scripts/testing/",

--- a/scripts/ci/validate_m7_b24_readiness.py
+++ b/scripts/ci/validate_m7_b24_readiness.py
@@ -1,0 +1,327 @@
+#!/usr/bin/env python3
+"""Validate M7 B2.4 readiness adjudication artifacts."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import tempfile
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+VERDICT_PATH = Path("docs/maintainability/m7_b24_readiness_verdict.md")
+DEBT_PATH = Path("docs/maintainability/m7_final_debt_register.yaml")
+CLEAN_CLONE_PATH = Path("docs/maintainability/m7_clean_clone_validation_transcript.md")
+TEST_PATH = Path("docs/maintainability/m7_test_validation_transcript.md")
+CI_PATH = Path("docs/maintainability/m7_ci_registry_validation_transcript.md")
+ARTIFACT_INDEX_PATH = Path("docs/maintainability/m7_artifact_index.md")
+EVIDENCE_PACK_PATH = Path("docs/maintainability/M7 Remediation Evidence Pack .md")
+
+REGISTRY_PATH = Path("docs/ci/enforcer_registry.yaml")
+SUBSUMPTION_PATH = Path("docs/ci/gate_subsumption_matrix.yaml")
+MAKEFILE_PATH = Path("Makefile")
+WORKFLOW_PATH = Path(".github/workflows/b2_4-gate-dry-run.yml")
+
+ALLOWED_VERDICTS = {
+    "B2.4_READY",
+    "B2.4_READY_WITH_EXPLICIT_DEBT",
+    "B2.4_BLOCKED",
+}
+
+REQUIRED_ARTIFACTS = [
+    VERDICT_PATH,
+    DEBT_PATH,
+    CLEAN_CLONE_PATH,
+    TEST_PATH,
+    CI_PATH,
+    ARTIFACT_INDEX_PATH,
+    EVIDENCE_PACK_PATH,
+]
+
+PHASE_RECORDS = {
+    "M0_PASS": Path("docs/maintainability/m0_completion_record.md"),
+    "M1_PASS": Path("docs/maintainability/m1_completion_record.md"),
+    "M2_PASS": Path("docs/maintainability/m2_completion_record.md"),
+    "M3_PASS": Path("docs/maintainability/m3_completion_record.md"),
+    "M4_PASS": Path("docs/maintainability/m4_completion_record.md"),
+    "M5_PASS": Path("docs/maintainability/m5_completion_record.md"),
+    "M6_PASS": Path("docs/maintainability/m6_completion_record.md"),
+}
+
+REQUIRED_VERDICT_TOKENS = [
+    "Executive Verdict",
+    "Current Main Coordinate",
+    "M0-M6 Closure Table",
+    "Clean-Clone Validation",
+    "Test Topology Validation",
+    "CI Governance Validation",
+    "Operational Readiness Validation",
+    "B2.4 Substrate Validation",
+    "LLM Boundary Validation",
+    "Feature Contamination Scan",
+    "Final Debt Register Summary",
+    "Authorization",
+    "B2.4 may begin:",
+]
+
+REQUIRED_HYPOTHESES = [f"H{i:02d}" for i in range(1, 16)]
+REQUIRED_GATES = [f"M7-{letter}" for letter in "ABCDEFGHIJKLM"]
+ALLOWED_STATUSES = {"PASS", "FAIL", "PARTIAL", "UNKNOWN", "N/A_WITH_REASON"}
+
+PROHIBITED_PLACEHOLDERS = re.compile(
+    r"\b(TODO|TBD|PLACEHOLDER|recorded after|M6_CONDITIONAL)\b", re.IGNORECASE
+)
+PROHIBITED_ACTIVE_DEP_PATTERN = re.compile(
+    r"^\s*(pymc|arviz|pymc-marketing|pymc_marketing)\b", re.IGNORECASE | re.MULTILINE
+)
+PROHIBITED_ACTIVE_DEP_PATHS = [
+    Path("backend/requirements.txt"),
+    Path("backend/requirements-lock.txt"),
+    Path("backend/requirements-dev.txt"),
+    Path("requirements.txt"),
+    Path("pyproject.toml"),
+]
+
+AUTHORIZED_M7_DIFF_PREFIXES = {
+    Path("docs/maintainability"),
+    Path("scripts/ci"),
+    Path("docs/ci"),
+    Path(".github/workflows"),
+    Path("Makefile"),
+}
+
+
+class ValidationError(RuntimeError):
+    pass
+
+
+def read(path: Path) -> str:
+    full = ROOT / path
+    if not full.exists():
+        raise ValidationError(f"missing required path: {path.as_posix()}")
+    return full.read_text(encoding="utf-8")
+
+
+def require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValidationError(message)
+
+
+def load_yaml(path: Path) -> Any:
+    return yaml.safe_load(read(path))
+
+
+def validate_artifacts() -> None:
+    for path in REQUIRED_ARTIFACTS:
+        text = read(path)
+        match = PROHIBITED_PLACEHOLDERS.search(text)
+        require(
+            match is None,
+            f"{path.as_posix()} contains unresolved placeholder token: {match.group(0) if match else ''}",
+        )
+
+    verdict = read(VERDICT_PATH)
+    for token in REQUIRED_VERDICT_TOKENS:
+        require(token in verdict, f"{VERDICT_PATH.as_posix()} missing required section/token: {token}")
+    for hypothesis in REQUIRED_HYPOTHESES:
+        require(hypothesis in verdict, f"{VERDICT_PATH.as_posix()} missing hypothesis status: {hypothesis}")
+    for gate in REQUIRED_GATES:
+        require(gate in verdict, f"{VERDICT_PATH.as_posix()} missing gate status: {gate}")
+    require(
+        sum(verdict.count(item) for item in ALLOWED_VERDICTS) >= 1,
+        "M7 verdict document missing allowed verdict token",
+    )
+
+
+def extract_verdict() -> str:
+    verdict_text = read(VERDICT_PATH)
+    match = re.search(r"(?m)^\*\*Verdict:\*\*\s*`?([A-Z0-9._]+)`?", verdict_text)
+    if not match:
+        match = re.search(r"\b(B2\.4_READY_WITH_EXPLICIT_DEBT|B2\.4_READY|B2\.4_BLOCKED)\b", verdict_text)
+    require(match is not None, "could not parse M7 verdict")
+    verdict = match.group(1)
+    require(verdict in ALLOWED_VERDICTS, f"invalid M7 verdict: {verdict}")
+    return verdict
+
+
+def validate_phase_closure() -> None:
+    for status, path in PHASE_RECORDS.items():
+        text = read(path)
+        require(status in text, f"{path.as_posix()} missing status {status}")
+        if status == "M6_PASS":
+            require("M7 may begin: YES" in text, "M6 record must authorize M7")
+
+
+def validate_hypothesis_and_gate_statuses() -> None:
+    verdict = read(VERDICT_PATH)
+    for item in REQUIRED_HYPOTHESES + REQUIRED_GATES:
+        pattern = rf"\|\s*{re.escape(item)}\s*\|\s*({'|'.join(ALLOWED_STATUSES)})\s*\|"
+        require(
+            re.search(pattern, verdict) is not None,
+            f"{item} must appear in a verdict table with an allowed status",
+        )
+
+
+def validate_debt_register(verdict: str) -> None:
+    data = load_yaml(DEBT_PATH)
+    require(isinstance(data, dict), "debt register must be a YAML mapping")
+    require(data.get("verdict") == verdict, "debt register verdict must match verdict document")
+    items = data.get("residual_debt")
+    require(isinstance(items, list), "debt register missing residual_debt list")
+    if verdict == "B2.4_READY":
+        require(len(items) == 0, "B2.4_READY cannot carry residual debt")
+    if verdict == "B2.4_READY_WITH_EXPLICIT_DEBT":
+        require(len(items) > 0, "READY_WITH_EXPLICIT_DEBT requires at least one debt item")
+    for item in items:
+        require(isinstance(item, dict), "each debt item must be a mapping")
+        for field in ("id", "status", "severity", "b24_impact", "owner_phase", "reopen_trigger", "rationale"):
+            require(item.get(field), f"debt item missing field {field}")
+        require(
+            item["status"] in {"B2.4_BLOCKING", "B2.4_NONBLOCKING", "DEFERRED_OPERATIONAL", "DEFERRED_COSMETIC"},
+            f"debt item has invalid status: {item['status']}",
+        )
+    if verdict != "B2.4_BLOCKED":
+        blocking = [item["id"] for item in items if item["status"] == "B2.4_BLOCKING"]
+        require(not blocking, f"non-blocked verdict cannot include B2.4 blocking debt: {blocking}")
+
+
+def validate_governance_wiring() -> None:
+    registry = load_yaml(REGISTRY_PATH)
+    subsumption = load_yaml(SUBSUMPTION_PATH)
+    makefile = read(MAKEFILE_PATH)
+    workflow = read(WORKFLOW_PATH)
+
+    require(
+        re.search(r"^validate-m7-b24-readiness:", makefile, re.MULTILINE) is not None,
+        "Makefile missing validate-m7-b24-readiness target",
+    )
+    require("make validate-m7-b24-readiness" in workflow, "B2.4 dry-run workflow missing M7 validation step")
+
+    require(isinstance(registry, list), "enforcer registry must be a YAML list")
+    m7_entries = [entry for entry in registry if entry.get("id") == "validate-m7-b24-readiness"]
+    require(len(m7_entries) == 1, "enforcer registry must contain exactly one M7 gate entry")
+    entry = m7_entries[0]
+    require(entry.get("path") == "scripts/ci/validate_m7_b24_readiness.py", "M7 registry path mismatch")
+    require(entry.get("execution_cohort") == "b2-4-dry-run", "M7 registry cohort mismatch")
+    require(entry.get("default_execution") is True, "M7 registry must default execute")
+
+    require(isinstance(subsumption, list), "gate subsumption matrix must be a YAML list")
+    m7_matrix = [entry for entry in subsumption if entry.get("gate_id") == "validate-m7-b24-readiness"]
+    require(len(m7_matrix) == 1, "gate subsumption matrix must contain exactly one M7 gate entry")
+
+
+def validate_no_feature_contamination() -> None:
+    require(not (ROOT / "backend/app/bayesian").exists(), "B2.4 implementation directory exists")
+
+    migrations = ROOT / "alembic/versions"
+    if migrations.exists():
+        migration_text = "\n".join(
+            path.read_text(encoding="utf-8", errors="ignore")
+            for path in migrations.rglob("*.py")
+        ).lower()
+        for token in ("bayesian_model_fits", "bayesian_artifacts"):
+            require(token not in migration_text, f"Bayesian migration/table detected: {token}")
+
+    for dep_path in PROHIBITED_ACTIVE_DEP_PATHS:
+        full = ROOT / dep_path
+        if full.exists():
+            require(
+                not PROHIBITED_ACTIVE_DEP_PATTERN.search(full.read_text(encoding="utf-8", errors="ignore")),
+                f"active dependency file installs PyMC/ArviZ: {dep_path.as_posix()}",
+            )
+
+    llm_boundary = ROOT / "backend/app/llm/provider_boundary.py"
+    if llm_boundary.exists():
+        text = llm_boundary.read_text(encoding="utf-8", errors="ignore").lower()
+        require("app.bayesian" not in text, "LLM provider boundary imports Bayesian modules")
+
+
+def git_changed_files() -> list[Path]:
+    current = subprocess_run(["git", "branch", "--show-current"])
+    if current in {"main", "master"}:
+        return []
+    merge_base = subprocess_run(["git", "merge-base", "HEAD", "origin/main"])
+    if not merge_base:
+        return []
+    diff = subprocess_run(["git", "diff", "--name-only", f"{merge_base}...HEAD"])
+    return [Path(line.strip()) for line in diff.splitlines() if line.strip()]
+
+
+def subprocess_run(args: list[str]) -> str:
+    import subprocess
+
+    completed = subprocess.run(args, cwd=ROOT, text=True, capture_output=True, encoding="utf-8", errors="replace")
+    if completed.returncode != 0:
+        return ""
+    return completed.stdout.strip()
+
+
+def validate_diff_scope() -> None:
+    changed = git_changed_files()
+    violations: list[str] = []
+    for path in changed:
+        normalized = Path(path.as_posix())
+        if normalized in AUTHORIZED_M7_DIFF_PREFIXES:
+            continue
+        if not any(
+            normalized == prefix or prefix in normalized.parents
+            for prefix in AUTHORIZED_M7_DIFF_PREFIXES
+        ):
+            violations.append(normalized.as_posix())
+    require(not violations, "M7 diff touches unauthorized surfaces: " + ", ".join(violations))
+
+
+def run_negative_control() -> None:
+    with tempfile.TemporaryDirectory(prefix="m7_bad_verdict_") as tmp:
+        tmp_root = Path(tmp)
+        bad = tmp_root / VERDICT_PATH
+        bad.parent.mkdir(parents=True, exist_ok=True)
+        bad.write_text("**Verdict:** `B2.4_MAYBE`\n", encoding="utf-8")
+        original_root = globals()["ROOT"]
+        try:
+            globals()["ROOT"] = tmp_root
+            try:
+                extract_verdict()
+            except ValidationError as exc:
+                print(f"M7_NEGATIVE_CONTROL_PASS: {exc}")
+                return
+            raise ValidationError("negative control did not reject invalid verdict")
+        finally:
+            globals()["ROOT"] = original_root
+
+
+def validate_all(args: argparse.Namespace) -> None:
+    validate_artifacts()
+    verdict = extract_verdict()
+    validate_phase_closure()
+    validate_hypothesis_and_gate_statuses()
+    validate_debt_register(verdict)
+    validate_governance_wiring()
+    validate_no_feature_contamination()
+    validate_diff_scope()
+    if args.negative_control:
+        run_negative_control()
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--negative-control", action="store_true")
+    args = parser.parse_args()
+    try:
+        validate_all(args)
+    except ValidationError as exc:
+        print(f"M7_B24_READINESS_VALIDATION_FAIL: {exc}", file=sys.stderr)
+        return 1
+    print("M7_B24_READINESS_VALIDATION_PASS")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
﻿## Summary

Adds the M7 final pre-B2.4 maintainability adjudication layer:

- `scripts/ci/validate_m7_b24_readiness.py` with negative control
- M7 verdict, final debt register, validation transcripts, evidence index, and evidence pack
- Makefile target `validate-m7-b24-readiness`
- B2.4 dry-run workflow, enforcer registry, and subsumption matrix wiring

## Scope

Governance/evidence only. No backend runtime behavior, migrations, active Bayesian dependencies, LLM provider behavior, B2.3 semantics, public API routes, or frontend code changed.

## Local validation

- `python scripts/ci/validate_m0_scope_lock.py --local-dev`
- `python scripts/ci/validate_m1_local_dev_authority.py --local-dev`
- `python scripts/ci/validate_m2_test_feedback_loop.py --local-dev`
- `python scripts/ci/validate_m3_ci_governance.py --all`
- `python scripts/ci/validate_m4_ops_runbooks.py`
- `python scripts/ci/validate_m5_b24_readiness_design.py --negative-control`
- `python scripts/ci/validate_m6_llm_boundary.py --negative-control`
- `python scripts/ci/validate_m7_b24_readiness.py --negative-control`
- `python -m pytest -q -m unit_pure backend/tests/test_m2_test_feedback_loop.py backend/tests/test_m2_corrective_runtime_proofs.py backend/tests/test_channel_normalization.py backend/tests/test_money_primitives.py` -> `69 passed, 15 deselected`

Host-local Docker runtime could not run because Docker Desktop's Linux engine was unavailable; the compose config validated, and runtime proof is left to protected CI.
