### PR TITLE
[codex] Fix M4 webhook proof negative control

### DIFF
--- a/docs/maintainability/M7 Remediation Evidence Pack .md
+++ b/docs/maintainability/M7 Remediation Evidence Pack .md
@@ -46,6 +46,29 @@ docs/ci/gate_subsumption_matrix.yaml
 
 No production runtime, migrations, public API routes, dependency activation, LLM provider behavior, B2.3 semantic paths, or frontend code were changed.
 
+The first protected-main run for landed commit
+`4ff1c19dbb0ec7297298841be4e679a8db0cd709` exposed one additional
+non-product defect in the M4 runtime proof harness:
+
+```text
+workflow: M4 Operational Runbooks
+run: https://github.com/Synergyscape-V1/skeldir-2.0/actions/runs/26115539633
+failed step: webhook_valid_tampered_duplicate
+cause: the valid replay and tampered-signature negative control reused the
+same fixture idempotency key, allowing duplicate replay handling to mask the
+tampered signature assertion.
+```
+
+The follow-up remediation changed only the local ops proof harness:
+
+```text
+scripts/ops/webhook_replay_local.py
+```
+
+The tampered-signature negative control now derives a separate local-only
+idempotency key and payload identifiers, so it proves signature rejection
+without relying on or changing production webhook behavior.
+
 ## Validation Commands
 
 Executed locally:

--- a/scripts/ops/webhook_replay_local.py
+++ b/scripts/ops/webhook_replay_local.py
@@ -42,10 +42,21 @@ def _stripe_signature(raw_body: bytes, secret: str, *, tampered: bool = False) -
     return f"t={timestamp},v1={digest}"
 
 
-def _payload(state: dict, *, duplicate: bool = False) -> tuple[bytes, str]:
+def _payload(
+    state: dict,
+    *,
+    duplicate: bool = False,
+    replay_variant: str = "primary",
+) -> tuple[bytes, str]:
     idempotency_key = state["webhook_idempotency_key"]
     pi_id = state["stripe_payment_intent_id"]
     event_id = state["stripe_event_id"]
+    if replay_variant == "tampered-negative-control":
+        # Keep the signature negative control independent from the successful
+        # replay so idempotency cannot mask a failed signature check.
+        idempotency_key = f"{idempotency_key}:tampered"
+        pi_id = f"{pi_id}-tampered"
+        event_id = f"{event_id}-tampered"
     if not duplicate:
         # The fresh replay and duplicate replay intentionally use the same
         # key within one run. Freshness is provided by the run-scoped seed.
@@ -71,7 +82,12 @@ def _payload(state: dict, *, duplicate: bool = False) -> tuple[bytes, str]:
 
 
 def _post(api_base_url: str, state: dict, *, tampered: bool = False, duplicate: bool = False) -> dict:
-    raw_body, idempotency_key = _payload(state, duplicate=duplicate)
+    replay_variant = "tampered-negative-control" if tampered else "primary"
+    raw_body, idempotency_key = _payload(
+        state,
+        duplicate=duplicate,
+        replay_variant=replay_variant,
+    )
     headers = {
         "content-type": "application/json",
         "X-Skeldir-Tenant-Key": state["api_key"],


### PR DESCRIPTION
## Summary

Fixes the M4 runtime proof harness discovered by the first protected-main run after M7 landed.

The harness previously sent a valid Stripe replay and then sent the tampered-signature negative control with the same fixture idempotency key. If the valid replay had already inserted the event, duplicate replay handling could mask the tampered-signature assertion. The tampered negative control now uses a separate local-only idempotency key and payload identifiers.

## Scope

- Proof harness only: `scripts/ops/webhook_replay_local.py`
- Evidence pack update: `docs/maintainability/M7 Remediation Evidence Pack .md`
- No production webhook behavior, API route, migration, dependency, LLM, B2.3 semantic, or frontend change

## Local validation

- `python scripts/ci/validate_m4_ops_runbooks.py`
- `python scripts/ci/validate_m7_b24_readiness.py --negative-control`
- `python scripts/check_evidence_placement.py`
- `python -m py_compile scripts/ops/webhook_replay_local.py`
