### PR TITLE
B2.4-P9 Directive IX dispatch capability fencing

### DIFF
--- a/alembic/versions/007_skeldir_foundation/202606141200_b24_p9_directive_ix_dispatch_authority.py
+++ b/alembic/versions/007_skeldir_foundation/202606141200_b24_p9_directive_ix_dispatch_authority.py
@@ -166,6 +166,58 @@ def upgrade() -> None:
             WHERE status IN ('dispatched', 'leased', 'running', 'failed_retryable', 'stale_recovered')
         """
     )
+    op.execute(
+        """
+        DROP POLICY IF EXISTS dispatch_capability_claim_select_b24_fit_dispatch_outbox
+            ON public.b24_fit_dispatch_outbox;
+        DROP POLICY IF EXISTS dispatch_capability_claim_update_b24_fit_dispatch_outbox
+            ON public.b24_fit_dispatch_outbox;
+        DROP POLICY IF EXISTS dispatch_recovery_reconciler_select_b24_fit_dispatch_outbox
+            ON public.b24_fit_dispatch_outbox;
+        DROP POLICY IF EXISTS dispatch_recovery_reconciler_update_b24_fit_dispatch_outbox
+            ON public.b24_fit_dispatch_outbox;
+
+        CREATE POLICY dispatch_capability_claim_select_b24_fit_dispatch_outbox
+            ON public.b24_fit_dispatch_outbox
+            FOR SELECT
+            USING (
+                claim_capability_digest = NULLIF(
+                    current_setting('app.b24_claim_capability_digest', true),
+                    ''
+                )
+                AND claim_capability_expires_at > now()
+            );
+
+        CREATE POLICY dispatch_capability_claim_update_b24_fit_dispatch_outbox
+            ON public.b24_fit_dispatch_outbox
+            FOR UPDATE
+            USING (
+                claim_capability_digest = NULLIF(
+                    current_setting('app.b24_claim_capability_digest', true),
+                    ''
+                )
+                AND claim_capability_expires_at > now()
+            )
+            WITH CHECK (
+                claim_capability_digest = NULLIF(
+                    current_setting('app.b24_claim_capability_digest', true),
+                    ''
+                )
+                AND claim_capability_expires_at > now()
+            );
+
+        CREATE POLICY dispatch_recovery_reconciler_select_b24_fit_dispatch_outbox
+            ON public.b24_fit_dispatch_outbox
+            FOR SELECT
+            USING (current_setting('app.b24_recovery_reconciler', true) = 'on');
+
+        CREATE POLICY dispatch_recovery_reconciler_update_b24_fit_dispatch_outbox
+            ON public.b24_fit_dispatch_outbox
+            FOR UPDATE
+            USING (current_setting('app.b24_recovery_reconciler', true) = 'on')
+            WITH CHECK (current_setting('app.b24_recovery_reconciler', true) = 'on');
+        """
+    )
 
     op.execute(
         """
@@ -211,6 +263,12 @@ def upgrade() -> None:
             ON public.b24_fit_recovery_outbox
             USING (tenant_id = current_setting('app.current_tenant_id')::uuid)
             WITH CHECK (tenant_id = current_setting('app.current_tenant_id')::uuid);
+        DROP POLICY IF EXISTS recovery_reconciler_policy_b24_fit_recovery_outbox
+            ON public.b24_fit_recovery_outbox;
+        CREATE POLICY recovery_reconciler_policy_b24_fit_recovery_outbox
+            ON public.b24_fit_recovery_outbox
+            USING (current_setting('app.b24_recovery_reconciler', true) = 'on')
+            WITH CHECK (current_setting('app.b24_recovery_reconciler', true) = 'on');
         """
     )
     op.execute(
@@ -267,6 +325,8 @@ def upgrade() -> None:
             v_lease_seconds integer := LEAST(GREATEST(COALESCE(p_lease_seconds, 330), 30), 900);
             v_outcome text;
         BEGIN
+            PERFORM set_config('app.b24_claim_capability_digest', v_digest, true);
+
             SELECT *
             INTO v_row
             FROM public.b24_fit_dispatch_outbox outbox
@@ -397,16 +457,18 @@ def upgrade() -> None:
             v_fit_id uuid;
         BEGIN
             IF TG_OP = 'UPDATE' THEN
-                IF TG_TABLE_NAME = 'bayesian_model_fits' THEN
+                IF TG_ARGV[0] = 'fit' THEN
                     IF NEW.tenant_id IS DISTINCT FROM OLD.tenant_id OR NEW.id IS DISTINCT FROM OLD.id THEN
                         RAISE EXCEPTION 'b24_dispatch_immutable_fit_authority';
                     END IF;
-                ELSIF TG_TABLE_NAME = 'bayesian_artifacts' THEN
+                ELSIF TG_ARGV[0] = 'artifact' THEN
                     IF NEW.tenant_id IS DISTINCT FROM OLD.tenant_id
                        OR NEW.fit_id IS DISTINCT FROM OLD.fit_id
                        OR NEW.artifact_ref IS DISTINCT FROM OLD.artifact_ref THEN
                         RAISE EXCEPTION 'b24_dispatch_immutable_artifact_authority';
                     END IF;
+                ELSE
+                    RAISE EXCEPTION 'b24_dispatch_unknown_fence_subject';
                 END IF;
             END IF;
 
@@ -414,12 +476,14 @@ def upgrade() -> None:
                 RETURN NEW;
             END IF;
 
-            IF TG_TABLE_NAME = 'bayesian_model_fits' THEN
+            IF TG_ARGV[0] = 'fit' THEN
                 v_tenant_id := NEW.tenant_id;
                 v_fit_id := NEW.id;
-            ELSE
+            ELSIF TG_ARGV[0] = 'artifact' THEN
                 v_tenant_id := NEW.tenant_id;
                 v_fit_id := NEW.fit_id;
+            ELSE
+                RAISE EXCEPTION 'b24_dispatch_unknown_fence_subject';
             END IF;
 
             IF NOT public.b24_current_dispatch_fence_valid(v_tenant_id, v_fit_id) THEN
@@ -435,11 +499,11 @@ def upgrade() -> None:
         DROP TRIGGER IF EXISTS trg_b24_dispatch_fence_fits ON public.bayesian_model_fits;
         CREATE TRIGGER trg_b24_dispatch_fence_fits
             BEFORE INSERT OR UPDATE ON public.bayesian_model_fits
-            FOR EACH ROW EXECUTE FUNCTION public.b24_enforce_dispatch_fence();
+            FOR EACH ROW EXECUTE FUNCTION public.b24_enforce_dispatch_fence('fit');
         DROP TRIGGER IF EXISTS trg_b24_dispatch_fence_artifacts ON public.bayesian_artifacts;
         CREATE TRIGGER trg_b24_dispatch_fence_artifacts
             BEFORE INSERT OR UPDATE ON public.bayesian_artifacts
-            FOR EACH ROW EXECUTE FUNCTION public.b24_enforce_dispatch_fence();
+            FOR EACH ROW EXECUTE FUNCTION public.b24_enforce_dispatch_fence('artifact');
         """
     )
     op.execute(
@@ -526,6 +590,8 @@ def upgrade() -> None:
             v_claim text;
             v_generation integer;
         BEGIN
+            PERFORM set_config('app.b24_recovery_reconciler', 'on', true);
+
             FOR v_row IN
                 SELECT *
                 FROM public.b24_fit_dispatch_outbox outbox
@@ -644,6 +710,20 @@ def downgrade() -> None:
     op.execute(
         "DROP FUNCTION IF EXISTS public.b24_sha256_text(text)"
     )  # CI:DESTRUCTIVE_OK - reversible rollback for Directive IX helper.
+    op.execute(
+        """
+        DROP POLICY IF EXISTS recovery_reconciler_policy_b24_fit_recovery_outbox
+            ON public.b24_fit_recovery_outbox;
+        DROP POLICY IF EXISTS dispatch_recovery_reconciler_update_b24_fit_dispatch_outbox
+            ON public.b24_fit_dispatch_outbox;
+        DROP POLICY IF EXISTS dispatch_recovery_reconciler_select_b24_fit_dispatch_outbox
+            ON public.b24_fit_dispatch_outbox;
+        DROP POLICY IF EXISTS dispatch_capability_claim_update_b24_fit_dispatch_outbox
+            ON public.b24_fit_dispatch_outbox;
+        DROP POLICY IF EXISTS dispatch_capability_claim_select_b24_fit_dispatch_outbox
+            ON public.b24_fit_dispatch_outbox;
+        """
+    )  # CI:DESTRUCTIVE_OK - reversible rollback for Directive IX RLS apertures.
     op.execute(
         "DROP TABLE IF EXISTS public.b24_fit_recovery_outbox"
     )  # CI:DESTRUCTIVE_OK - reversible rollback for additive Directive IX recovery outbox.

--- a/alembic/versions/007_skeldir_foundation/202606141200_b24_p9_directive_ix_dispatch_authority.py
+++ b/alembic/versions/007_skeldir_foundation/202606141200_b24_p9_directive_ix_dispatch_authority.py
@@ -735,7 +735,7 @@ def downgrade() -> None:
         """
     )  # CI:DESTRUCTIVE_OK - reversible rollback for Directive IX RLS apertures.
     op.execute(
-        "DROP TABLE IF EXISTS public.b24_fit_recovery_outbox"
+        "DROP TABLE IF EXISTS public.b24_fit_recovery_outbox"  # CI:DESTRUCTIVE_OK - reversible rollback for additive Directive IX recovery outbox.
     )  # CI:DESTRUCTIVE_OK - reversible rollback for additive Directive IX recovery outbox.
     op.execute(
         "DROP INDEX IF EXISTS public.idx_b24_fit_dispatch_outbox_recoverable"
@@ -793,5 +793,5 @@ def downgrade() -> None:
         "next_recovery_at",
     ):
         op.execute(
-            f"ALTER TABLE public.b24_fit_dispatch_outbox DROP COLUMN IF EXISTS {column}"
+            f"ALTER TABLE public.b24_fit_dispatch_outbox DROP COLUMN IF EXISTS {column}"  # CI:DESTRUCTIVE_OK - reversible rollback for additive Directive IX columns.
         )  # CI:DESTRUCTIVE_OK - reversible rollback for additive Directive IX columns.

--- a/alembic/versions/007_skeldir_foundation/202606141200_b24_p9_directive_ix_dispatch_authority.py
+++ b/alembic/versions/007_skeldir_foundation/202606141200_b24_p9_directive_ix_dispatch_authority.py
@@ -1,0 +1,707 @@
+"""B2.4-P9 Directive IX dispatch capability and fencing.
+
+Revision ID: 202606141200
+Revises: 202606081200
+Create Date: 2026-06-14 12:00:00
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+from alembic import op
+
+
+revision: str = "202606141200"
+down_revision: Union[str, None] = "202606081200"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _grant_if_role_exists(role: str, grant_sql: str) -> None:
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{role}') THEN
+                EXECUTE '{grant_sql}';
+            END IF;
+        END
+        $$;
+        """
+    )
+
+
+def upgrade() -> None:
+    op.execute("CREATE EXTENSION IF NOT EXISTS pgcrypto")
+    op.execute(
+        """
+        ALTER TABLE public.b24_fit_dispatch_outbox
+            ADD COLUMN IF NOT EXISTS task_name text,
+            ADD COLUMN IF NOT EXISTS attempt_id uuid,
+            ADD COLUMN IF NOT EXISTS payload_hash character(64),
+            ADD COLUMN IF NOT EXISTS claim_capability text,
+            ADD COLUMN IF NOT EXISTS claim_capability_digest character(64),
+            ADD COLUMN IF NOT EXISTS claim_capability_expires_at timestamp with time zone,
+            ADD COLUMN IF NOT EXISTS lease_owner text,
+            ADD COLUMN IF NOT EXISTS lease_capability_digest character(64),
+            ADD COLUMN IF NOT EXISTS lease_acquired_at timestamp with time zone,
+            ADD COLUMN IF NOT EXISTS lease_expires_at timestamp with time zone,
+            ADD COLUMN IF NOT EXISTS last_heartbeat_at timestamp with time zone,
+            ADD COLUMN IF NOT EXISTS claim_epoch integer DEFAULT 0 NOT NULL,
+            ADD COLUMN IF NOT EXISTS claim_count integer DEFAULT 0 NOT NULL,
+            ADD COLUMN IF NOT EXISTS redelivery_count integer DEFAULT 0 NOT NULL,
+            ADD COLUMN IF NOT EXISTS recovery_generation integer DEFAULT 0 NOT NULL,
+            ADD COLUMN IF NOT EXISTS completed_at timestamp with time zone,
+            ADD COLUMN IF NOT EXISTS cancelled_at timestamp with time zone,
+            ADD COLUMN IF NOT EXISTS superseded_by uuid,
+            ADD COLUMN IF NOT EXISTS terminal_reason text,
+            ADD COLUMN IF NOT EXISTS next_recovery_at timestamp with time zone
+        """
+    )
+    op.execute(
+        """
+        UPDATE public.b24_fit_dispatch_outbox
+        SET task_name = COALESCE(task_name, 'app.tasks.bayesian.execute_fit_intent'),
+            attempt_id = COALESCE(attempt_id, id),
+            payload_hash = COALESCE(
+                payload_hash,
+                encode(
+                    digest(
+                        'app.tasks.bayesian.execute_fit_intent:' || fit_id::text,
+                        'sha256'
+                    ),
+                    'hex'
+                )
+            ),
+            claim_capability = COALESCE(claim_capability, encode(gen_random_bytes(32), 'hex')),
+            claim_capability_expires_at = COALESCE(
+                claim_capability_expires_at,
+                now() + interval '24 hours'
+            ),
+            next_recovery_at = COALESCE(next_recovery_at, now())
+        """
+    )
+    op.execute(
+        """
+        UPDATE public.b24_fit_dispatch_outbox
+        SET claim_capability_digest = COALESCE(
+                claim_capability_digest,
+                encode(digest(claim_capability, 'sha256'), 'hex')
+            )
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE public.b24_fit_dispatch_outbox
+            ALTER COLUMN task_name SET NOT NULL,
+            ALTER COLUMN attempt_id SET NOT NULL,
+            ALTER COLUMN payload_hash SET NOT NULL,
+            ALTER COLUMN claim_capability SET NOT NULL,
+            ALTER COLUMN claim_capability_digest SET NOT NULL,
+            ALTER COLUMN claim_capability_expires_at SET NOT NULL,
+            ALTER COLUMN next_recovery_at SET NOT NULL
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE public.b24_fit_dispatch_outbox
+            DROP CONSTRAINT IF EXISTS ck_b24_fit_dispatch_outbox_status
+        """
+    )  # CI:DESTRUCTIVE_OK - replaces enum with Directive IX lease/recovery states.
+    op.execute(
+        """
+        ALTER TABLE public.b24_fit_dispatch_outbox
+            ADD CONSTRAINT ck_b24_fit_dispatch_outbox_status
+            CHECK (status IN (
+                'pending',
+                'dispatching',
+                'dispatched',
+                'leased',
+                'running',
+                'failed_retryable',
+                'completed',
+                'failed_terminal',
+                'cancelled',
+                'expired',
+                'superseded',
+                'quarantined',
+                'dead_lettered',
+                'stale_recovered'
+            ))
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE public.b24_fit_dispatch_outbox
+            ADD CONSTRAINT ck_b24_fit_dispatch_outbox_payload_hash_sha256
+            CHECK (payload_hash ~ '^[a-f0-9]{64}$'),
+            ADD CONSTRAINT ck_b24_fit_dispatch_outbox_claim_capability_digest_sha256
+            CHECK (claim_capability_digest ~ '^[a-f0-9]{64}$'),
+            ADD CONSTRAINT ck_b24_fit_dispatch_outbox_lease_capability_digest_sha256
+            CHECK (
+                lease_capability_digest IS NULL
+                OR lease_capability_digest ~ '^[a-f0-9]{64}$'
+            ),
+            ADD CONSTRAINT ck_b24_fit_dispatch_outbox_claim_epoch_non_negative
+            CHECK (claim_epoch >= 0),
+            ADD CONSTRAINT ck_b24_fit_dispatch_outbox_claim_count_non_negative
+            CHECK (claim_count >= 0),
+            ADD CONSTRAINT ck_b24_fit_dispatch_outbox_redelivery_count_non_negative
+            CHECK (redelivery_count >= 0),
+            ADD CONSTRAINT ck_b24_fit_dispatch_outbox_recovery_generation_non_negative
+            CHECK (recovery_generation >= 0)
+        """
+    )
+    op.execute(
+        """
+        CREATE UNIQUE INDEX IF NOT EXISTS uq_b24_fit_dispatch_outbox_attempt
+            ON public.b24_fit_dispatch_outbox (tenant_id, attempt_id)
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_b24_fit_dispatch_outbox_recoverable
+            ON public.b24_fit_dispatch_outbox (status, next_recovery_at ASC, lease_expires_at ASC)
+            WHERE status IN ('dispatched', 'leased', 'running', 'failed_retryable', 'stale_recovered')
+        """
+    )
+
+    op.execute(
+        """
+        CREATE TABLE IF NOT EXISTS public.b24_fit_recovery_outbox (
+            id uuid DEFAULT gen_random_uuid() NOT NULL,
+            dispatch_id uuid NOT NULL,
+            tenant_id uuid NOT NULL,
+            fit_id uuid NOT NULL,
+            attempt_id uuid NOT NULL,
+            task_name text NOT NULL,
+            payload_hash character(64) NOT NULL,
+            claim_capability text NOT NULL,
+            recovery_generation integer NOT NULL,
+            status character varying(32) DEFAULT 'pending' NOT NULL,
+            created_at timestamp with time zone DEFAULT now() NOT NULL,
+            updated_at timestamp with time zone DEFAULT now() NOT NULL,
+            published_at timestamp with time zone,
+            publish_attempt_count integer DEFAULT 0 NOT NULL,
+            last_error text,
+            CONSTRAINT b24_fit_recovery_outbox_pkey PRIMARY KEY (tenant_id, id),
+            CONSTRAINT fk_b24_fit_recovery_outbox_dispatch
+                FOREIGN KEY (tenant_id, dispatch_id)
+                REFERENCES public.b24_fit_dispatch_outbox(tenant_id, id)
+                ON DELETE CASCADE,
+            CONSTRAINT uq_b24_fit_recovery_outbox_generation
+                UNIQUE (tenant_id, dispatch_id, recovery_generation),
+            CONSTRAINT ck_b24_fit_recovery_outbox_status
+                CHECK (status IN ('pending', 'publishing', 'published', 'failed_retryable', 'quarantined')),
+            CONSTRAINT ck_b24_fit_recovery_outbox_payload_hash_sha256
+                CHECK (payload_hash ~ '^[a-f0-9]{64}$'),
+            CONSTRAINT ck_b24_fit_recovery_outbox_publish_attempt_count
+                CHECK (publish_attempt_count >= 0)
+        )
+        """
+    )
+    op.execute(
+        """
+        ALTER TABLE public.b24_fit_recovery_outbox ENABLE ROW LEVEL SECURITY;
+        ALTER TABLE public.b24_fit_recovery_outbox FORCE ROW LEVEL SECURITY;
+        DROP POLICY IF EXISTS tenant_isolation_policy_b24_fit_recovery_outbox
+            ON public.b24_fit_recovery_outbox;
+        CREATE POLICY tenant_isolation_policy_b24_fit_recovery_outbox
+            ON public.b24_fit_recovery_outbox
+            USING (tenant_id = current_setting('app.current_tenant_id')::uuid)
+            WITH CHECK (tenant_id = current_setting('app.current_tenant_id')::uuid);
+        """
+    )
+    op.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_b24_fit_recovery_outbox_due
+            ON public.b24_fit_recovery_outbox (status, created_at ASC, id ASC)
+            WHERE status IN ('pending', 'failed_retryable')
+        """
+    )
+
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.b24_sha256_text(value text)
+        RETURNS text
+        LANGUAGE sql
+        IMMUTABLE
+        AS $$
+            SELECT encode(digest(value, 'sha256'), 'hex')
+        $$;
+        """
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.b24_claim_fit_dispatch(
+            p_dispatch_id uuid,
+            p_fit_id uuid,
+            p_task_name text,
+            p_attempt_id uuid,
+            p_payload_hash text,
+            p_claim_capability text,
+            p_worker_generation text,
+            p_lease_seconds integer DEFAULT 330
+        )
+        RETURNS TABLE (
+            outcome text,
+            tenant_id uuid,
+            fit_id uuid,
+            dispatch_id uuid,
+            attempt_id uuid,
+            claim_epoch integer,
+            lease_capability text,
+            lease_expires_at timestamp with time zone
+        )
+        LANGUAGE plpgsql
+        SECURITY DEFINER
+        SET search_path = public, pg_temp
+        AS $$
+        DECLARE
+            v_row public.b24_fit_dispatch_outbox%ROWTYPE;
+            v_digest text := public.b24_sha256_text(p_claim_capability);
+            v_lease text;
+            v_lease_digest text;
+            v_next_epoch integer;
+            v_lease_seconds integer := LEAST(GREATEST(COALESCE(p_lease_seconds, 330), 30), 900);
+            v_outcome text;
+        BEGIN
+            SELECT *
+            INTO v_row
+            FROM public.b24_fit_dispatch_outbox outbox
+            WHERE outbox.id = p_dispatch_id
+            FOR UPDATE;
+
+            IF NOT FOUND THEN
+                RETURN QUERY SELECT 'UNAUTHORIZED', NULL::uuid, NULL::uuid, p_dispatch_id,
+                    p_attempt_id, NULL::integer, NULL::text, NULL::timestamptz;
+                RETURN;
+            END IF;
+
+            IF v_row.claim_capability_digest <> v_digest
+               OR v_row.fit_id <> p_fit_id
+               OR v_row.task_name <> p_task_name
+               OR v_row.attempt_id <> p_attempt_id
+               OR v_row.payload_hash <> p_payload_hash
+               OR v_row.claim_capability_expires_at <= now() THEN
+                RETURN QUERY SELECT 'UNAUTHORIZED', v_row.tenant_id, v_row.fit_id,
+                    v_row.id, v_row.attempt_id, v_row.claim_epoch, NULL::text,
+                    v_row.lease_expires_at;
+                RETURN;
+            END IF;
+
+            IF v_row.status = 'completed' THEN
+                RETURN QUERY SELECT 'ALREADY_COMPLETED', v_row.tenant_id, v_row.fit_id,
+                    v_row.id, v_row.attempt_id, v_row.claim_epoch, NULL::text,
+                    v_row.lease_expires_at;
+                RETURN;
+            ELSIF v_row.status = 'cancelled' THEN
+                v_outcome := 'CANCELLED';
+            ELSIF v_row.status = 'expired' THEN
+                v_outcome := 'EXPIRED';
+            ELSIF v_row.status = 'superseded' THEN
+                v_outcome := 'SUPERSEDED';
+            ELSIF v_row.status IN ('failed_terminal', 'dead_lettered', 'quarantined') THEN
+                v_outcome := 'TERMINAL_FAILURE';
+            ELSIF v_row.lease_expires_at IS NOT NULL
+                  AND v_row.lease_expires_at > now()
+                  AND v_row.status IN ('leased', 'running') THEN
+                RETURN QUERY SELECT 'ACTIVE_LEASE', v_row.tenant_id, v_row.fit_id,
+                    v_row.id, v_row.attempt_id, v_row.claim_epoch, NULL::text,
+                    v_row.lease_expires_at;
+                RETURN;
+            ELSE
+                v_outcome := CASE WHEN v_row.claim_count = 0 THEN 'ACQUIRED' ELSE 'RECLAIMED' END;
+            END IF;
+
+            IF v_outcome <> 'ACQUIRED' AND v_outcome <> 'RECLAIMED' THEN
+                RETURN QUERY SELECT v_outcome, v_row.tenant_id, v_row.fit_id,
+                    v_row.id, v_row.attempt_id, v_row.claim_epoch, NULL::text,
+                    v_row.lease_expires_at;
+                RETURN;
+            END IF;
+
+            v_lease := encode(gen_random_bytes(32), 'hex');
+            v_lease_digest := public.b24_sha256_text(v_lease);
+            v_next_epoch := v_row.claim_epoch + 1;
+
+            UPDATE public.b24_fit_dispatch_outbox outbox
+            SET status = 'leased',
+                claim_epoch = v_next_epoch,
+                lease_capability_digest = v_lease_digest,
+                lease_owner = p_worker_generation,
+                lease_acquired_at = now(),
+                lease_expires_at = now() + (v_lease_seconds * interval '1 second'),
+                last_heartbeat_at = now(),
+                claim_count = claim_count + 1,
+                redelivery_count = redelivery_count + CASE WHEN v_row.claim_count > 0 THEN 1 ELSE 0 END,
+                next_recovery_at = now() + (v_lease_seconds * interval '1 second'),
+                updated_at = now()
+            WHERE outbox.tenant_id = v_row.tenant_id
+              AND outbox.id = v_row.id;
+
+            PERFORM set_config('app.current_tenant_id', v_row.tenant_id::text, true);
+            PERFORM set_config('app.b24_dispatch_id', v_row.id::text, true);
+            PERFORM set_config('app.b24_attempt_id', v_row.attempt_id::text, true);
+            PERFORM set_config('app.b24_claim_epoch', v_next_epoch::text, true);
+            PERFORM set_config('app.b24_lease_capability', v_lease, true);
+            PERFORM set_config('app.b24_dispatch_fence_required', 'on', true);
+
+            RETURN QUERY SELECT v_outcome, v_row.tenant_id, v_row.fit_id, v_row.id,
+                v_row.attempt_id, v_next_epoch, v_lease,
+                now() + (v_lease_seconds * interval '1 second');
+        END
+        $$;
+        """
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.b24_current_dispatch_fence_valid(
+            p_tenant_id uuid,
+            p_fit_id uuid
+        )
+        RETURNS boolean
+        LANGUAGE sql
+        STABLE
+        SECURITY DEFINER
+        SET search_path = public, pg_temp
+        AS $$
+            SELECT EXISTS (
+                SELECT 1
+                FROM public.b24_fit_dispatch_outbox outbox
+                WHERE outbox.tenant_id = p_tenant_id
+                  AND outbox.fit_id = p_fit_id
+                  AND outbox.id = NULLIF(current_setting('app.b24_dispatch_id', true), '')::uuid
+                  AND outbox.attempt_id = NULLIF(current_setting('app.b24_attempt_id', true), '')::uuid
+                  AND outbox.claim_epoch = NULLIF(current_setting('app.b24_claim_epoch', true), '')::integer
+                  AND outbox.lease_capability_digest = public.b24_sha256_text(
+                        current_setting('app.b24_lease_capability', true)
+                      )
+                  AND outbox.lease_expires_at > now()
+                  AND outbox.status IN ('leased', 'running')
+            )
+        $$;
+        """
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.b24_enforce_dispatch_fence()
+        RETURNS trigger
+        LANGUAGE plpgsql
+        SECURITY DEFINER
+        SET search_path = public, pg_temp
+        AS $$
+        DECLARE
+            v_tenant_id uuid;
+            v_fit_id uuid;
+        BEGIN
+            IF TG_OP = 'UPDATE' THEN
+                IF TG_TABLE_NAME = 'bayesian_model_fits' THEN
+                    IF NEW.tenant_id IS DISTINCT FROM OLD.tenant_id OR NEW.id IS DISTINCT FROM OLD.id THEN
+                        RAISE EXCEPTION 'b24_dispatch_immutable_fit_authority';
+                    END IF;
+                ELSIF TG_TABLE_NAME = 'bayesian_artifacts' THEN
+                    IF NEW.tenant_id IS DISTINCT FROM OLD.tenant_id
+                       OR NEW.fit_id IS DISTINCT FROM OLD.fit_id
+                       OR NEW.artifact_ref IS DISTINCT FROM OLD.artifact_ref THEN
+                        RAISE EXCEPTION 'b24_dispatch_immutable_artifact_authority';
+                    END IF;
+                END IF;
+            END IF;
+
+            IF current_setting('app.b24_dispatch_fence_required', true) IS DISTINCT FROM 'on' THEN
+                RETURN NEW;
+            END IF;
+
+            IF TG_TABLE_NAME = 'bayesian_model_fits' THEN
+                v_tenant_id := NEW.tenant_id;
+                v_fit_id := NEW.id;
+            ELSE
+                v_tenant_id := NEW.tenant_id;
+                v_fit_id := NEW.fit_id;
+            END IF;
+
+            IF NOT public.b24_current_dispatch_fence_valid(v_tenant_id, v_fit_id) THEN
+                RAISE EXCEPTION 'b24_dispatch_fence_rejected';
+            END IF;
+            RETURN NEW;
+        END
+        $$;
+        """
+    )
+    op.execute(
+        """
+        DROP TRIGGER IF EXISTS trg_b24_dispatch_fence_fits ON public.bayesian_model_fits;
+        CREATE TRIGGER trg_b24_dispatch_fence_fits
+            BEFORE INSERT OR UPDATE ON public.bayesian_model_fits
+            FOR EACH ROW EXECUTE FUNCTION public.b24_enforce_dispatch_fence();
+        DROP TRIGGER IF EXISTS trg_b24_dispatch_fence_artifacts ON public.bayesian_artifacts;
+        CREATE TRIGGER trg_b24_dispatch_fence_artifacts
+            BEFORE INSERT OR UPDATE ON public.bayesian_artifacts
+            FOR EACH ROW EXECUTE FUNCTION public.b24_enforce_dispatch_fence();
+        """
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.b24_mark_fit_dispatch_running()
+        RETURNS void
+        LANGUAGE plpgsql
+        SECURITY DEFINER
+        SET search_path = public, pg_temp
+        AS $$
+        BEGIN
+            UPDATE public.b24_fit_dispatch_outbox outbox
+            SET status = 'running',
+                last_heartbeat_at = now(),
+                updated_at = now()
+            WHERE outbox.id = NULLIF(current_setting('app.b24_dispatch_id', true), '')::uuid
+              AND public.b24_current_dispatch_fence_valid(outbox.tenant_id, outbox.fit_id);
+            IF NOT FOUND THEN
+                RAISE EXCEPTION 'b24_dispatch_running_fence_rejected';
+            END IF;
+        END
+        $$;
+        """
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.b24_complete_fit_dispatch()
+        RETURNS void
+        LANGUAGE plpgsql
+        SECURITY DEFINER
+        SET search_path = public, pg_temp
+        AS $$
+        BEGIN
+            UPDATE public.b24_fit_dispatch_outbox outbox
+            SET status = 'completed',
+                completed_at = now(),
+                terminal_reason = NULL,
+                updated_at = now()
+            WHERE outbox.id = NULLIF(current_setting('app.b24_dispatch_id', true), '')::uuid
+              AND public.b24_current_dispatch_fence_valid(outbox.tenant_id, outbox.fit_id);
+            IF NOT FOUND THEN
+                RAISE EXCEPTION 'b24_dispatch_complete_fence_rejected';
+            END IF;
+        END
+        $$;
+        """
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.b24_fail_fit_dispatch_terminal(p_reason text)
+        RETURNS void
+        LANGUAGE plpgsql
+        SECURITY DEFINER
+        SET search_path = public, pg_temp
+        AS $$
+        BEGIN
+            UPDATE public.b24_fit_dispatch_outbox outbox
+            SET status = 'failed_terminal',
+                terminal_reason = LEFT(COALESCE(p_reason, 'worker_failure'), 512),
+                completed_at = now(),
+                updated_at = now()
+            WHERE outbox.id = NULLIF(current_setting('app.b24_dispatch_id', true), '')::uuid
+              AND public.b24_current_dispatch_fence_valid(outbox.tenant_id, outbox.fit_id);
+            IF NOT FOUND THEN
+                RAISE EXCEPTION 'b24_dispatch_failure_fence_rejected';
+            END IF;
+        END
+        $$;
+        """
+    )
+    op.execute(
+        """
+        CREATE OR REPLACE FUNCTION public.b24_create_fit_recovery_wakeups(
+            p_limit integer DEFAULT 25
+        )
+        RETURNS integer
+        LANGUAGE plpgsql
+        SECURITY DEFINER
+        SET search_path = public, pg_temp
+        AS $$
+        DECLARE
+            v_count integer := 0;
+            v_row record;
+            v_claim text;
+            v_generation integer;
+        BEGIN
+            FOR v_row IN
+                SELECT *
+                FROM public.b24_fit_dispatch_outbox outbox
+                WHERE outbox.status IN ('dispatched', 'leased', 'running', 'failed_retryable', 'stale_recovered')
+                  AND outbox.next_recovery_at <= now()
+                  AND (
+                      outbox.lease_expires_at IS NULL
+                      OR outbox.lease_expires_at <= now()
+                      OR outbox.status IN ('failed_retryable', 'stale_recovered')
+                  )
+                ORDER BY outbox.next_recovery_at ASC, outbox.id ASC
+                LIMIT LEAST(GREATEST(COALESCE(p_limit, 25), 1), 100)
+                FOR UPDATE SKIP LOCKED
+            LOOP
+                v_claim := encode(gen_random_bytes(32), 'hex');
+                v_generation := v_row.recovery_generation + 1;
+                UPDATE public.b24_fit_dispatch_outbox outbox
+                SET status = 'stale_recovered',
+                    claim_capability = v_claim,
+                    claim_capability_digest = public.b24_sha256_text(v_claim),
+                    claim_capability_expires_at = now() + interval '24 hours',
+                    recovery_generation = v_generation,
+                    next_recovery_at = now() + interval '5 minutes',
+                    updated_at = now()
+                WHERE outbox.tenant_id = v_row.tenant_id
+                  AND outbox.id = v_row.id;
+
+                INSERT INTO public.b24_fit_recovery_outbox (
+                    dispatch_id,
+                    tenant_id,
+                    fit_id,
+                    attempt_id,
+                    task_name,
+                    payload_hash,
+                    claim_capability,
+                    recovery_generation
+                )
+                VALUES (
+                    v_row.id,
+                    v_row.tenant_id,
+                    v_row.fit_id,
+                    v_row.attempt_id,
+                    v_row.task_name,
+                    v_row.payload_hash,
+                    v_claim,
+                    v_generation
+                )
+                ON CONFLICT (tenant_id, dispatch_id, recovery_generation) DO NOTHING;
+                v_count := v_count + 1;
+            END LOOP;
+            RETURN v_count;
+        END
+        $$;
+        """
+    )
+
+    for role in ("app_worker", "app_user"):
+        _grant_if_role_exists(
+            role,
+            f"GRANT EXECUTE ON FUNCTION public.b24_claim_fit_dispatch(uuid, uuid, text, uuid, text, text, text, integer) TO {role}",
+        )
+        _grant_if_role_exists(
+            role,
+            f"GRANT EXECUTE ON FUNCTION public.b24_mark_fit_dispatch_running() TO {role}",
+        )
+        _grant_if_role_exists(
+            role,
+            f"GRANT EXECUTE ON FUNCTION public.b24_complete_fit_dispatch() TO {role}",
+        )
+        _grant_if_role_exists(
+            role,
+            f"GRANT EXECUTE ON FUNCTION public.b24_fail_fit_dispatch_terminal(text) TO {role}",
+        )
+        _grant_if_role_exists(
+            role,
+            f"GRANT EXECUTE ON FUNCTION public.b24_create_fit_recovery_wakeups(integer) TO {role}",
+        )
+        _grant_if_role_exists(
+            role,
+            f"GRANT SELECT, UPDATE ON public.b24_fit_dispatch_outbox TO {role}",
+        )
+        _grant_if_role_exists(
+            role,
+            f"GRANT SELECT, INSERT, UPDATE ON public.b24_fit_recovery_outbox TO {role}",
+        )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP FUNCTION IF EXISTS public.b24_create_fit_recovery_wakeups(integer)"
+    )  # CI:DESTRUCTIVE_OK - reversible rollback for Directive IX recovery function.
+    op.execute(
+        "DROP FUNCTION IF EXISTS public.b24_fail_fit_dispatch_terminal(text)"
+    )  # CI:DESTRUCTIVE_OK - reversible rollback for Directive IX terminal function.
+    op.execute(
+        "DROP FUNCTION IF EXISTS public.b24_complete_fit_dispatch()"
+    )  # CI:DESTRUCTIVE_OK - reversible rollback for Directive IX terminal function.
+    op.execute(
+        "DROP FUNCTION IF EXISTS public.b24_mark_fit_dispatch_running()"
+    )  # CI:DESTRUCTIVE_OK - reversible rollback for Directive IX running function.
+    op.execute(
+        "DROP TRIGGER IF EXISTS trg_b24_dispatch_fence_artifacts ON public.bayesian_artifacts"
+    )  # CI:DESTRUCTIVE_OK - reversible rollback for Directive IX fencing trigger.
+    op.execute(
+        "DROP TRIGGER IF EXISTS trg_b24_dispatch_fence_fits ON public.bayesian_model_fits"
+    )  # CI:DESTRUCTIVE_OK - reversible rollback for Directive IX fencing trigger.
+    op.execute(
+        "DROP FUNCTION IF EXISTS public.b24_enforce_dispatch_fence()"
+    )  # CI:DESTRUCTIVE_OK - reversible rollback for Directive IX fencing function.
+    op.execute(
+        "DROP FUNCTION IF EXISTS public.b24_current_dispatch_fence_valid(uuid, uuid)"
+    )  # CI:DESTRUCTIVE_OK - reversible rollback for Directive IX fencing function.
+    op.execute(
+        "DROP FUNCTION IF EXISTS public.b24_claim_fit_dispatch(uuid, uuid, text, uuid, text, text, text, integer)"
+    )  # CI:DESTRUCTIVE_OK - reversible rollback for Directive IX claim function.
+    op.execute(
+        "DROP FUNCTION IF EXISTS public.b24_sha256_text(text)"
+    )  # CI:DESTRUCTIVE_OK - reversible rollback for Directive IX helper.
+    op.execute(
+        "DROP TABLE IF EXISTS public.b24_fit_recovery_outbox"
+    )  # CI:DESTRUCTIVE_OK - reversible rollback for additive Directive IX recovery outbox.
+    op.execute(
+        "DROP INDEX IF EXISTS public.idx_b24_fit_dispatch_outbox_recoverable"
+    )  # CI:DESTRUCTIVE_OK - reversible rollback for Directive IX index.
+    op.execute(
+        "DROP INDEX IF EXISTS public.uq_b24_fit_dispatch_outbox_attempt"
+    )  # CI:DESTRUCTIVE_OK - reversible rollback for Directive IX index.
+    op.execute(
+        """
+        ALTER TABLE public.b24_fit_dispatch_outbox
+            DROP CONSTRAINT IF EXISTS ck_b24_fit_dispatch_outbox_recovery_generation_non_negative,
+            DROP CONSTRAINT IF EXISTS ck_b24_fit_dispatch_outbox_redelivery_count_non_negative,
+            DROP CONSTRAINT IF EXISTS ck_b24_fit_dispatch_outbox_claim_count_non_negative,
+            DROP CONSTRAINT IF EXISTS ck_b24_fit_dispatch_outbox_claim_epoch_non_negative,
+            DROP CONSTRAINT IF EXISTS ck_b24_fit_dispatch_outbox_lease_capability_digest_sha256,
+            DROP CONSTRAINT IF EXISTS ck_b24_fit_dispatch_outbox_claim_capability_digest_sha256,
+            DROP CONSTRAINT IF EXISTS ck_b24_fit_dispatch_outbox_payload_hash_sha256,
+            DROP CONSTRAINT IF EXISTS ck_b24_fit_dispatch_outbox_status
+        """
+    )  # CI:DESTRUCTIVE_OK - reversible rollback for Directive IX constraints.
+    op.execute(
+        """
+        ALTER TABLE public.b24_fit_dispatch_outbox
+            ADD CONSTRAINT ck_b24_fit_dispatch_outbox_status
+            CHECK (status IN (
+                'pending',
+                'dispatching',
+                'dispatched',
+                'failed_retryable',
+                'dead_lettered',
+                'stale_recovered'
+            ))
+        """
+    )
+    for column in (
+        "task_name",
+        "attempt_id",
+        "payload_hash",
+        "claim_capability",
+        "claim_capability_digest",
+        "claim_capability_expires_at",
+        "lease_owner",
+        "lease_capability_digest",
+        "lease_acquired_at",
+        "lease_expires_at",
+        "last_heartbeat_at",
+        "claim_epoch",
+        "claim_count",
+        "redelivery_count",
+        "recovery_generation",
+        "completed_at",
+        "cancelled_at",
+        "superseded_by",
+        "terminal_reason",
+        "next_recovery_at",
+    ):
+        op.execute(
+            f"ALTER TABLE public.b24_fit_dispatch_outbox DROP COLUMN IF EXISTS {column}"
+        )  # CI:DESTRUCTIVE_OK - reversible rollback for additive Directive IX columns.

--- a/alembic/versions/007_skeldir_foundation/202606141200_b24_p9_directive_ix_dispatch_authority.py
+++ b/alembic/versions/007_skeldir_foundation/202606141200_b24_p9_directive_ix_dispatch_authority.py
@@ -261,8 +261,18 @@ def upgrade() -> None:
             ON public.b24_fit_recovery_outbox;
         CREATE POLICY tenant_isolation_policy_b24_fit_recovery_outbox
             ON public.b24_fit_recovery_outbox
-            USING (tenant_id = current_setting('app.current_tenant_id')::uuid)
-            WITH CHECK (tenant_id = current_setting('app.current_tenant_id')::uuid);
+            USING (
+                tenant_id = NULLIF(
+                    current_setting('app.current_tenant_id', true),
+                    ''
+                )::uuid
+            )
+            WITH CHECK (
+                tenant_id = NULLIF(
+                    current_setting('app.current_tenant_id', true),
+                    ''
+                )::uuid
+            );
         DROP POLICY IF EXISTS recovery_reconciler_policy_b24_fit_recovery_outbox
             ON public.b24_fit_recovery_outbox;
         CREATE POLICY recovery_reconciler_policy_b24_fit_recovery_outbox

--- a/backend/app/bayesian/dispatch_authority.py
+++ b/backend/app/bayesian/dispatch_authority.py
@@ -1,0 +1,188 @@
+"""B2.4-P9 database authority for Bayesian fit dispatch execution."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import datetime
+from enum import StrEnum
+from uuid import UUID
+
+from sqlalchemy import text
+
+
+BAYESIAN_FIT_EXECUTION_TASK = "app.tasks.bayesian.execute_fit_intent"
+
+
+class DispatchClaimOutcome(StrEnum):
+    ACQUIRED = "ACQUIRED"
+    RECLAIMED = "RECLAIMED"
+    ACTIVE_LEASE = "ACTIVE_LEASE"
+    ALREADY_COMPLETED = "ALREADY_COMPLETED"
+    CANCELLED = "CANCELLED"
+    EXPIRED = "EXPIRED"
+    SUPERSEDED = "SUPERSEDED"
+    TERMINAL_FAILURE = "TERMINAL_FAILURE"
+    UNAUTHORIZED = "UNAUTHORIZED"
+    RETRYABLE_INFRASTRUCTURE_FAILURE = "RETRYABLE_INFRASTRUCTURE_FAILURE"
+
+
+TERMINAL_OR_NON_EXECUTING_CLAIM_OUTCOMES = {
+    DispatchClaimOutcome.ACTIVE_LEASE,
+    DispatchClaimOutcome.ALREADY_COMPLETED,
+    DispatchClaimOutcome.CANCELLED,
+    DispatchClaimOutcome.EXPIRED,
+    DispatchClaimOutcome.SUPERSEDED,
+    DispatchClaimOutcome.TERMINAL_FAILURE,
+    DispatchClaimOutcome.UNAUTHORIZED,
+    DispatchClaimOutcome.RETRYABLE_INFRASTRUCTURE_FAILURE,
+}
+
+
+@dataclass(frozen=True)
+class BayesianDispatchClaim:
+    """Opaque wake-up payload; the broker carries this but does not authorize it."""
+
+    dispatch_id: UUID
+    fit_id: UUID
+    task_name: str
+    attempt_id: UUID
+    payload_hash: str
+    claim_capability: str
+
+
+@dataclass(frozen=True)
+class BayesianDispatchLease:
+    """Fresh transaction-local DB lease returned by the pre-tenant claim."""
+
+    outcome: DispatchClaimOutcome
+    tenant_id: UUID
+    fit_id: UUID
+    dispatch_id: UUID
+    attempt_id: UUID
+    claim_epoch: int
+    lease_capability: str
+    lease_expires_at: datetime
+
+
+def dispatch_payload_hash(
+    *, fit_id: UUID, task_name: str = BAYESIAN_FIT_EXECUTION_TASK
+) -> str:
+    """Return the stable payload hash stored beside the dispatch capability."""
+
+    return hashlib.sha256(f"{task_name}:{fit_id}".encode("utf-8")).hexdigest()
+
+
+def claim_fit_dispatch_sync(
+    conn,
+    *,
+    claim: BayesianDispatchClaim,
+    worker_generation_id: str,
+    lease_seconds: int = 900,
+) -> BayesianDispatchLease | DispatchClaimOutcome:
+    """
+    Claim a fit dispatch before tenant context exists.
+
+    This intentionally routes through a SECURITY DEFINER function so table RLS
+    remains default-deny before the database validates the opaque capability.
+    """
+
+    row = (
+        conn.execute(
+            text(
+                """
+                SELECT *
+                FROM public.b24_claim_fit_dispatch(
+                    :dispatch_id,
+                    :fit_id,
+                    :task_name,
+                    :attempt_id,
+                    :payload_hash,
+                    :claim_capability,
+                    :worker_generation_id,
+                    :lease_seconds
+                )
+                """
+            ),
+            {
+                "dispatch_id": str(claim.dispatch_id),
+                "fit_id": str(claim.fit_id),
+                "task_name": claim.task_name,
+                "attempt_id": str(claim.attempt_id),
+                "payload_hash": claim.payload_hash,
+                "claim_capability": claim.claim_capability,
+                "worker_generation_id": worker_generation_id,
+                "lease_seconds": max(1, int(lease_seconds)),
+            },
+        )
+        .mappings()
+        .one()
+    )
+    outcome = DispatchClaimOutcome(str(row["outcome"]))
+    if outcome in (
+        DispatchClaimOutcome.ACQUIRED,
+        DispatchClaimOutcome.RECLAIMED,
+    ):
+        return BayesianDispatchLease(
+            outcome=outcome,
+            tenant_id=UUID(str(row["tenant_id"])),
+            fit_id=UUID(str(row["fit_id"])),
+            dispatch_id=UUID(str(row["dispatch_id"])),
+            attempt_id=UUID(str(row["attempt_id"])),
+            claim_epoch=int(row["claim_epoch"]),
+            lease_capability=str(row["lease_capability"]),
+            lease_expires_at=row["lease_expires_at"],
+        )
+    return outcome
+
+
+def bind_dispatch_write_context_sync(conn, *, lease: BayesianDispatchLease) -> None:
+    """Bind the fresh DB lease as transaction-local write authority."""
+
+    conn.execute(
+        text(
+            """
+            SELECT
+                set_config('app.b24_dispatch_id', :dispatch_id, true),
+                set_config('app.b24_attempt_id', :attempt_id, true),
+                set_config('app.b24_claim_epoch', :claim_epoch, true),
+                set_config('app.b24_lease_capability', :lease_capability, true),
+                set_config('app.b24_dispatch_fence_required', 'on', true)
+            """
+        ),
+        {
+            "dispatch_id": str(lease.dispatch_id),
+            "attempt_id": str(lease.attempt_id),
+            "claim_epoch": str(lease.claim_epoch),
+            "lease_capability": lease.lease_capability,
+        },
+    )
+
+
+def mark_dispatch_running_sync(conn, *, lease: BayesianDispatchLease) -> None:
+    bind_dispatch_write_context_sync(conn, lease=lease)
+    conn.execute(text("SELECT public.b24_mark_fit_dispatch_running()"))
+
+
+def complete_dispatch_sync(conn, *, lease: BayesianDispatchLease) -> None:
+    bind_dispatch_write_context_sync(conn, lease=lease)
+    conn.execute(text("SELECT public.b24_complete_fit_dispatch()"))
+
+
+def fail_dispatch_terminal_sync(
+    conn, *, lease: BayesianDispatchLease, reason: str
+) -> None:
+    bind_dispatch_write_context_sync(conn, lease=lease)
+    conn.execute(
+        text("SELECT public.b24_fail_fit_dispatch_terminal(:reason)"),
+        {"reason": reason[:256]},
+    )
+
+
+def create_recovery_wakeups_sync(conn, *, batch_size: int = 25) -> int:
+    return int(
+        conn.execute(
+            text("SELECT public.b24_create_fit_recovery_wakeups(:batch_size)"),
+            {"batch_size": max(1, int(batch_size))},
+        ).scalar_one()
+    )

--- a/backend/app/bayesian/dispatch_outbox.py
+++ b/backend/app/bayesian/dispatch_outbox.py
@@ -11,11 +11,14 @@ from uuid import UUID
 from sqlalchemy import text
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from app.bayesian.dispatch_authority import (
+    BAYESIAN_FIT_EXECUTION_TASK,
+    dispatch_payload_hash,
+)
 from app.celery_app import celery_app
 from app.core.queues import QUEUE_BAYESIAN
 
 
-BAYESIAN_FIT_EXECUTION_TASK = "app.tasks.bayesian.execute_fit_intent"
 DEFAULT_DISPATCH_BATCH_SIZE = 25
 DEFAULT_STALE_DISPATCHING_SECONDS = 300
 
@@ -24,7 +27,15 @@ class DispatchStatus(StrEnum):
     PENDING = "pending"
     DISPATCHING = "dispatching"
     DISPATCHED = "dispatched"
+    LEASED = "leased"
+    RUNNING = "running"
     FAILED_RETRYABLE = "failed_retryable"
+    COMPLETED = "completed"
+    FAILED_TERMINAL = "failed_terminal"
+    CANCELLED = "cancelled"
+    EXPIRED = "expired"
+    SUPERSEDED = "superseded"
+    QUARANTINED = "quarantined"
     DEAD_LETTERED = "dead_lettered"
     STALE_RECOVERED = "stale_recovered"
 
@@ -34,16 +45,27 @@ class DispatchOutboxRow:
     id: UUID
     tenant_id: UUID
     fit_id: UUID
+    task_name: str
+    attempt_id: UUID
+    payload_hash: str
+    claim_capability: str
     attempt_count: int
     max_attempts: int
 
     @property
     def queue_payload(self) -> dict[str, str]:
-        return {"fit_id": str(self.fit_id)}
+        return {
+            "dispatch_id": str(self.id),
+            "fit_id": str(self.fit_id),
+            "task_name": self.task_name,
+            "attempt_id": str(self.attempt_id),
+            "payload_hash": self.payload_hash,
+            "claim_capability": self.claim_capability,
+        }
 
 
-def publish_fit_id_only(row: DispatchOutboxRow) -> str:
-    """Publish the durable fit intent with a fit_id-only payload."""
+def publish_capability_bound_dispatch(row: DispatchOutboxRow) -> str:
+    """Publish a broker wake-up whose execution authority is DB-bound."""
 
     result = celery_app.send_task(
         BAYESIAN_FIT_EXECUTION_TASK,
@@ -99,6 +121,21 @@ async def lease_due_dispatch_rows(
                 dispatching_started_at = now(),
                 last_attempt_at = now(),
                 attempt_count = attempt_count + 1,
+                task_name = COALESCE(task_name, :task_name),
+                attempt_id = COALESCE(attempt_id, gen_random_uuid()),
+                payload_hash = COALESCE(
+                    payload_hash,
+                    public.b24_sha256_text(:task_name || ':' || outbox.fit_id::text)
+                ),
+                claim_capability = COALESCE(claim_capability, encode(gen_random_bytes(32), 'hex')),
+                claim_capability_digest = COALESCE(
+                    claim_capability_digest,
+                    public.b24_sha256_text(claim_capability)
+                ),
+                claim_capability_expires_at = COALESCE(
+                    claim_capability_expires_at,
+                    now() + interval '24 hours'
+                ),
                 updated_at = now()
             FROM due
             WHERE outbox.tenant_id = due.tenant_id
@@ -107,17 +144,30 @@ async def lease_due_dispatch_rows(
                 outbox.id,
                 outbox.tenant_id,
                 outbox.fit_id,
+                outbox.task_name,
+                outbox.attempt_id,
+                outbox.payload_hash,
+                outbox.claim_capability,
                 outbox.attempt_count,
                 outbox.max_attempts
             """
         ),
-        {"batch_size": max(1, int(batch_size))},
+        {
+            "batch_size": max(1, int(batch_size)),
+            "task_name": BAYESIAN_FIT_EXECUTION_TASK,
+        },
     )
     return [
         DispatchOutboxRow(
             id=row["id"],
             tenant_id=row["tenant_id"],
             fit_id=row["fit_id"],
+            task_name=str(row["task_name"] or BAYESIAN_FIT_EXECUTION_TASK),
+            attempt_id=row["attempt_id"],
+            payload_hash=str(
+                row["payload_hash"] or dispatch_payload_hash(fit_id=row["fit_id"])
+            ),
+            claim_capability=str(row["claim_capability"]),
             attempt_count=int(row["attempt_count"]),
             max_attempts=int(row["max_attempts"]),
         )
@@ -177,7 +227,11 @@ async def mark_dispatch_failed(
         {
             "tenant_id": str(row.tenant_id),
             "outbox_id": str(row.id),
-            "status": DispatchStatus.DEAD_LETTERED.value if dead_letter else DispatchStatus.FAILED_RETRYABLE.value,
+            "status": (
+                DispatchStatus.DEAD_LETTERED.value
+                if dead_letter
+                else DispatchStatus.FAILED_RETRYABLE.value
+            ),
             "dead_letter": dead_letter,
             "retry_delay_seconds": max(1, int(retry_delay_seconds)),
             "error": error[:2048],
@@ -188,7 +242,7 @@ async def mark_dispatch_failed(
 async def dispatch_due_outbox_rows(
     session: AsyncSession,
     *,
-    publish: Callable[[DispatchOutboxRow], str] = publish_fit_id_only,
+    publish: Callable[[DispatchOutboxRow], str] = publish_capability_bound_dispatch,
     batch_size: int = DEFAULT_DISPATCH_BATCH_SIZE,
 ) -> list[DispatchOutboxRow]:
     """Publish due rows after they have been durably leased with SKIP LOCKED."""
@@ -202,3 +256,15 @@ async def dispatch_due_outbox_rows(
             continue
         await mark_dispatched(session, tenant_id=row.tenant_id, outbox_id=row.id)
     return rows
+
+
+async def create_recovery_wakeups(
+    session: AsyncSession,
+    *,
+    batch_size: int = DEFAULT_DISPATCH_BATCH_SIZE,
+) -> int:
+    result = await session.execute(
+        text("SELECT public.b24_create_fit_recovery_wakeups(:batch_size)"),
+        {"batch_size": max(1, int(batch_size))},
+    )
+    return int(result.scalar_one())

--- a/backend/app/bayesian/fit_claim.py
+++ b/backend/app/bayesian/fit_claim.py
@@ -363,6 +363,12 @@ async def claim_fit_for_snapshot(
                             tenant_id,
                             fit_id,
                             dispatch_key,
+                            task_name,
+                            attempt_id,
+                            payload_hash,
+                            claim_capability,
+                            claim_capability_digest,
+                            claim_capability_expires_at,
                             status,
                             attempt_count,
                             next_attempt_at,
@@ -373,24 +379,116 @@ async def claim_fit_for_snapshot(
                             :tenant_id,
                             id,
                             'b24-fit:' || :tenant_id || ':' || id::text,
+                            'app.tasks.bayesian.execute_fit_intent',
+                            gen_random_uuid(),
+                            public.b24_sha256_text('app.tasks.bayesian.execute_fit_intent:' || id::text),
+                            claim.claim_capability,
+                            public.b24_sha256_text(claim.claim_capability),
+                            now() + interval '24 hours',
                             'pending',
                             0,
                             now(),
                             now(),
                             now()
                         FROM claimed_fit
+                        CROSS JOIN LATERAL (
+                            SELECT encode(gen_random_bytes(32), 'hex') AS claim_capability
+                        ) claim
                         WHERE NOT EXISTS (SELECT 1 FROM newer_dominant_snapshot)
                         ON CONFLICT (tenant_id, fit_id)
                         DO UPDATE SET
                             status = CASE
-                                WHEN b24_fit_dispatch_outbox.status = 'dispatched'
-                                    THEN 'dispatched'
+                                WHEN b24_fit_dispatch_outbox.status IN (
+                                    'dispatched',
+                                    'leased',
+                                    'running',
+                                    'completed',
+                                    'failed_terminal',
+                                    'cancelled',
+                                    'expired',
+                                    'superseded',
+                                    'quarantined'
+                                )
+                                    THEN b24_fit_dispatch_outbox.status
                                 ELSE 'pending'
                             END,
                             next_attempt_at = CASE
-                                WHEN b24_fit_dispatch_outbox.status = 'dispatched'
+                                WHEN b24_fit_dispatch_outbox.status IN (
+                                    'dispatched',
+                                    'leased',
+                                    'running',
+                                    'completed',
+                                    'failed_terminal',
+                                    'cancelled',
+                                    'expired',
+                                    'superseded',
+                                    'quarantined'
+                                )
                                     THEN b24_fit_dispatch_outbox.next_attempt_at
                                 ELSE now()
+                            END,
+                            attempt_id = CASE
+                                WHEN b24_fit_dispatch_outbox.status IN (
+                                    'dispatched',
+                                    'leased',
+                                    'running',
+                                    'completed',
+                                    'failed_terminal',
+                                    'cancelled',
+                                    'expired',
+                                    'superseded',
+                                    'quarantined'
+                                )
+                                    THEN b24_fit_dispatch_outbox.attempt_id
+                                ELSE gen_random_uuid()
+                            END,
+                            payload_hash = public.b24_sha256_text(
+                                'app.tasks.bayesian.execute_fit_intent:' || EXCLUDED.fit_id::text
+                            ),
+                            claim_capability = CASE
+                                WHEN b24_fit_dispatch_outbox.status IN (
+                                    'dispatched',
+                                    'leased',
+                                    'running',
+                                    'completed',
+                                    'failed_terminal',
+                                    'cancelled',
+                                    'expired',
+                                    'superseded',
+                                    'quarantined'
+                                )
+                                    THEN b24_fit_dispatch_outbox.claim_capability
+                                ELSE EXCLUDED.claim_capability
+                            END,
+                            claim_capability_digest = CASE
+                                WHEN b24_fit_dispatch_outbox.status IN (
+                                    'dispatched',
+                                    'leased',
+                                    'running',
+                                    'completed',
+                                    'failed_terminal',
+                                    'cancelled',
+                                    'expired',
+                                    'superseded',
+                                    'quarantined'
+                                )
+                                    THEN b24_fit_dispatch_outbox.claim_capability_digest
+                                ELSE EXCLUDED.claim_capability_digest
+                            END,
+                            claim_capability_expires_at = CASE
+                                WHEN b24_fit_dispatch_outbox.status IN (
+                                    'dispatched',
+                                    'leased',
+                                    'running',
+                                    'completed',
+                                    'failed_terminal',
+                                    'cancelled',
+                                    'expired',
+                                    'superseded',
+                                    'quarantined'
+                                )
+                                    THEN b24_fit_dispatch_outbox.claim_capability_expires_at
+                                ELSE now() + interval '24 hours'
                             END,
                             updated_at = now()
                         RETURNING id, fit_id

--- a/backend/app/bayesian/fit_execution.py
+++ b/backend/app/bayesian/fit_execution.py
@@ -21,6 +21,16 @@ from sqlalchemy.engine import Engine
 from app.bayesian.artifact_repository import persist_artifact_sync
 from app.bayesian.cleanup import cleanup_fit_attempt, run_preflight_janitor
 from app.bayesian.compiledir_reaper import create_compiledir_lease
+from app.bayesian.dispatch_authority import (
+    BayesianDispatchClaim,
+    BayesianDispatchLease,
+    DispatchClaimOutcome,
+    bind_dispatch_write_context_sync,
+    claim_fit_dispatch_sync,
+    complete_dispatch_sync,
+    fail_dispatch_terminal_sync,
+    mark_dispatch_running_sync,
+)
 from app.bayesian.enums import FallbackReason, FitStatus
 from app.bayesian.result_contract import validate_result_summary
 from app.bayesian.rng_policy import RngSeedMaterial, derive_rng_seed
@@ -60,6 +70,19 @@ def _set_tenant_context(conn, tenant_id: UUID) -> None:
     assert_bound_tenant(conn, tenant_id=tenant_id)
 
 
+def _set_execution_context(
+    conn,
+    *,
+    tenant_id: UUID,
+    dispatch_lease: BayesianDispatchLease | None = None,
+) -> None:
+    _set_tenant_context(conn, tenant_id)
+    if dispatch_lease is not None:
+        if dispatch_lease.tenant_id != tenant_id:
+            raise RuntimeError("bayesian_dispatch_lease_tenant_mismatch")
+        bind_dispatch_write_context_sync(conn, lease=dispatch_lease)
+
+
 def _fit_identity(conn, *, fit_id: UUID) -> UUID | None:
     conn.execute(
         text("SELECT set_config('app.b24_fit_resolution_id', :fit_id, true)"),
@@ -91,9 +114,13 @@ _LoadFitRow = dict[str, object]
 
 
 def _load_fit_for_execution(
-    conn, *, tenant_id: UUID, fit_id: UUID
+    conn,
+    *,
+    tenant_id: UUID,
+    fit_id: UUID,
+    dispatch_lease: BayesianDispatchLease | None = None,
 ) -> _LoadFitRow | None:
-    _set_tenant_context(conn, tenant_id)
+    _set_execution_context(conn, tenant_id=tenant_id, dispatch_lease=dispatch_lease)
     row = (
         conn.execute(
             text(
@@ -132,8 +159,9 @@ def _mark_fit_failure(
     status: FitStatus,
     fallback_reason: FallbackReason,
     runtime_seconds: int | None = None,
+    dispatch_lease: BayesianDispatchLease | None = None,
 ) -> None:
-    _set_tenant_context(conn, tenant_id)
+    _set_execution_context(conn, tenant_id=tenant_id, dispatch_lease=dispatch_lease)
     conn.execute(
         text(
             """
@@ -178,8 +206,9 @@ def _mark_fit_diagnostic_error(
     fit_id: UUID,
     diagnostic_failure_reason: str,
     runtime_seconds: int | None = None,
+    dispatch_lease: BayesianDispatchLease | None = None,
 ) -> None:
-    _set_tenant_context(conn, tenant_id)
+    _set_execution_context(conn, tenant_id=tenant_id, dispatch_lease=dispatch_lease)
     conn.execute(
         text(
             """
@@ -348,7 +377,9 @@ def _persist_result_summary(
     runtime_seconds: int,
     result_summary: dict[str, object],
     result_hash: str,
+    dispatch_lease: BayesianDispatchLease | None = None,
 ) -> None:
+    _set_execution_context(conn, tenant_id=tenant_id, dispatch_lease=dispatch_lease)
     artifact = persist_artifact_sync(
         conn,
         tenant_id=tenant_id,
@@ -503,37 +534,66 @@ def execute_fit_intent_sync(
     engine: Engine,
     fit_id: UUID,
     task_id: str,
+    dispatch_claim: BayesianDispatchClaim | None = None,
 ) -> dict[str, object]:
     started = time.monotonic()
     run_preflight_janitor(ttl_seconds=3600, max_deletions=10, max_scan_entries=100)
     assert_fresh_checkout_is_clean(engine)
-    try:
+    dispatch_lease: BayesianDispatchLease | None = None
+    if dispatch_claim is not None:
         with engine.begin() as conn:
-            tenant_id = _fit_identity(conn, fit_id=fit_id)
-    except RuntimeError as exc:
-        if str(exc) == "duplicate_fit_suppressed":
+            claim_result = claim_fit_dispatch_sync(
+                conn,
+                claim=dispatch_claim,
+                worker_generation_id=os.getenv(
+                    "B24_BAYESIAN_WORKER_GENERATION_ID", "unknown-generation"
+                ),
+            )
+        if isinstance(claim_result, DispatchClaimOutcome):
             return {
-                "status": "failed",
-                "fallback_reason": FallbackReason.DUPLICATE_FIT_SUPPRESSED.value,
+                "status": claim_result.value.lower(),
+                "claim_outcome": claim_result.value,
+                "task_id": task_id,
+                "fit_id": str(dispatch_claim.fit_id),
+                "dispatch_id": str(dispatch_claim.dispatch_id),
+                "compute_started": False,
+            }
+        dispatch_lease = claim_result
+        tenant_id = dispatch_lease.tenant_id
+        fit_id = dispatch_lease.fit_id
+    else:
+        try:
+            with engine.begin() as conn:
+                tenant_id = _fit_identity(conn, fit_id=fit_id)
+        except RuntimeError as exc:
+            if str(exc) == "duplicate_fit_suppressed":
+                return {
+                    "status": "failed",
+                    "fallback_reason": FallbackReason.DUPLICATE_FIT_SUPPRESSED.value,
+                    "task_id": task_id,
+                    "fit_id": str(fit_id),
+                    "compute_started": False,
+                }
+            raise
+        if tenant_id is None:
+            return {
+                "status": "not_found",
                 "task_id": task_id,
                 "fit_id": str(fit_id),
                 "compute_started": False,
             }
-        raise
-    if tenant_id is None:
-        return {
-            "status": "not_found",
-            "task_id": task_id,
-            "fit_id": str(fit_id),
-            "compute_started": False,
-        }
 
     lease = None
     workspace = None
 
     try:
         with engine.begin() as conn:
-            row = _load_fit_for_execution(conn, tenant_id=tenant_id, fit_id=fit_id)
+            row = _load_fit_for_execution(
+                conn,
+                tenant_id=tenant_id,
+                fit_id=fit_id,
+                dispatch_lease=dispatch_lease,
+            )
             if row is None:
                 return {
                     "status": "not_found",
@@ -543,6 +603,8 @@ def execute_fit_intent_sync(
                 }
             current_status = str(row["status"])
             if current_status in TERMINAL_OR_POST_SAMPLE_STATUSES:
+                if dispatch_lease is not None:
+                    complete_dispatch_sync(conn, lease=dispatch_lease)
                 return {
                     "status": current_status,
                     "task_id": task_id,
@@ -601,7 +663,12 @@ def execute_fit_intent_sync(
                     fit_id=fit_id,
                     status=FitStatus.FAILED,
                     fallback_reason=exc.reason,
+                    dispatch_lease=dispatch_lease,
                 )
+                if dispatch_lease is not None:
+                    fail_dispatch_terminal_sync(
+                        conn, lease=dispatch_lease, reason=exc.reason.value
+                    )
             return {
                 "status": "failed",
                 "fallback_reason": exc.reason.value,
@@ -621,7 +688,12 @@ def execute_fit_intent_sync(
                     fit_id=fit_id,
                     status=FitStatus.FAILED,
                     fallback_reason=reason,
+                    dispatch_lease=dispatch_lease,
                 )
+                if dispatch_lease is not None:
+                    fail_dispatch_terminal_sync(
+                        conn, lease=dispatch_lease, reason=reason.value
+                    )
             return {
                 "status": "failed",
                 "fallback_reason": reason.value,
@@ -632,7 +704,9 @@ def execute_fit_intent_sync(
             }
 
         with engine.begin() as conn:
-            _set_tenant_context(conn, tenant_id)
+            _set_execution_context(
+                conn, tenant_id=tenant_id, dispatch_lease=dispatch_lease
+            )
             conn.execute(
                 text(
                     """
@@ -652,6 +726,8 @@ def execute_fit_intent_sync(
                     "source_snapshot_hash": str(sampler_input["source_snapshot_hash"]),
                 },
             )
+            if dispatch_lease is not None:
+                mark_dispatch_running_sync(conn, lease=dispatch_lease)
 
         _write_input_file(input_path, sampler_input)
         source_env = {
@@ -684,7 +760,12 @@ def execute_fit_intent_sync(
                         fit_id=fit_id,
                         diagnostic_failure_reason=diagnostic_reason,
                         runtime_seconds=runtime_seconds,
+                        dispatch_lease=dispatch_lease,
                     )
+                    if dispatch_lease is not None:
+                        fail_dispatch_terminal_sync(
+                            conn, lease=dispatch_lease, reason=diagnostic_reason
+                        )
                 else:
                     _mark_fit_failure(
                         conn,
@@ -693,7 +774,14 @@ def execute_fit_intent_sync(
                         status=FitStatus.TIMEOUT,
                         fallback_reason=FallbackReason.TIMEOUT,
                         runtime_seconds=runtime_seconds,
+                        dispatch_lease=dispatch_lease,
                     )
+                    if dispatch_lease is not None:
+                        fail_dispatch_terminal_sync(
+                            conn,
+                            lease=dispatch_lease,
+                            reason=FallbackReason.TIMEOUT.value,
+                        )
             return {
                 "status": "failed" if diagnostic_reason is not None else "timeout",
                 "diagnostic_failure_reason": diagnostic_reason,
@@ -715,7 +803,12 @@ def execute_fit_intent_sync(
                         fit_id=fit_id,
                         diagnostic_failure_reason=diagnostic_reason,
                         runtime_seconds=runtime_seconds,
+                        dispatch_lease=dispatch_lease,
                     )
+                    if dispatch_lease is not None:
+                        fail_dispatch_terminal_sync(
+                            conn, lease=dispatch_lease, reason=diagnostic_reason
+                        )
                 else:
                     _mark_fit_failure(
                         conn,
@@ -724,7 +817,14 @@ def execute_fit_intent_sync(
                         status=FitStatus.FAILED,
                         fallback_reason=FallbackReason.WORKER_FAILURE,
                         runtime_seconds=runtime_seconds,
+                        dispatch_lease=dispatch_lease,
                     )
+                    if dispatch_lease is not None:
+                        fail_dispatch_terminal_sync(
+                            conn,
+                            lease=dispatch_lease,
+                            reason=FallbackReason.WORKER_FAILURE.value,
+                        )
             return {
                 "status": "failed",
                 "fallback_reason": (
@@ -745,7 +845,6 @@ def execute_fit_intent_sync(
         result_hash = _summary_hash(result_summary)
 
         with engine.begin() as conn:
-            _set_tenant_context(conn, tenant_id)
             _persist_result_summary(
                 conn,
                 tenant_id=tenant_id,
@@ -754,7 +853,10 @@ def execute_fit_intent_sync(
                 runtime_seconds=runtime_seconds,
                 result_summary=result_summary,
                 result_hash=result_hash,
+                dispatch_lease=dispatch_lease,
             )
+            if dispatch_lease is not None:
+                complete_dispatch_sync(conn, lease=dispatch_lease)
 
         return {
             "status": (

--- a/backend/app/bayesian/models.py
+++ b/backend/app/bayesian/models.py
@@ -1220,6 +1220,61 @@ class B24FitDispatchOutbox(Base, TenantMixin):
         DateTime(timezone=True), nullable=True
     )
     last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    task_name: Mapped[str] = mapped_column(
+        String(256),
+        nullable=False,
+        default="app.tasks.bayesian.execute_fit_intent",
+        server_default="app.tasks.bayesian.execute_fit_intent",
+    )
+    attempt_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), nullable=False, default=uuid4
+    )
+    payload_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    claim_capability: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    claim_capability_digest: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )
+    claim_capability_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    lease_owner: Mapped[str | None] = mapped_column(String(128), nullable=True)
+    lease_capability_digest: Mapped[str | None] = mapped_column(
+        String(64), nullable=True
+    )
+    lease_acquired_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    lease_expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_heartbeat_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    claim_epoch: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    claim_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    redelivery_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    recovery_generation: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    cancelled_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    superseded_by: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True), nullable=True
+    )
+    terminal_reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    next_recovery_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
 
     __table_args__ = (
         PrimaryKeyConstraint("tenant_id", "id", name="b24_fit_dispatch_outbox_pkey"),
@@ -1239,6 +1294,9 @@ class B24FitDispatchOutbox(Base, TenantMixin):
         CheckConstraint(
             "max_attempts > 0", name="ck_b24_fit_dispatch_outbox_max_attempts"
         ),
+        UniqueConstraint(
+            "tenant_id", "attempt_id", name="uq_b24_fit_dispatch_outbox_attempt"
+        ),
         Index(
             "idx_b24_fit_dispatch_outbox_due",
             "tenant_id",
@@ -1254,5 +1312,56 @@ class B24FitDispatchOutbox(Base, TenantMixin):
             "tenant_id",
             "dispatching_started_at",
             postgresql_where=text("status = 'dispatching'"),
+        ),
+    )
+
+
+class B24FitRecoveryOutbox(Base, TenantMixin):
+    """Durable wake-up repair intent for broker loss or stale execution leases."""
+
+    __tablename__ = "b24_fit_recovery_outbox"
+
+    id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True), default=uuid4, server_default=func.gen_random_uuid()
+    )
+    dispatch_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    fit_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    attempt_id: Mapped[UUID] = mapped_column(PGUUID(as_uuid=True), nullable=False)
+    task_name: Mapped[str] = mapped_column(String(256), nullable=False)
+    payload_hash: Mapped[str] = mapped_column(String(64), nullable=False)
+    claim_capability: Mapped[str] = mapped_column(String(128), nullable=False)
+    recovery_generation: Mapped[int] = mapped_column(Integer, nullable=False)
+    status: Mapped[str] = mapped_column(
+        String(32), nullable=False, default="pending", server_default="pending"
+    )
+    published_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    publish_attempt_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    last_error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    __table_args__ = (
+        PrimaryKeyConstraint("tenant_id", "id", name="b24_fit_recovery_outbox_pkey"),
+        ForeignKeyConstraint(
+            ["tenant_id", "dispatch_id"],
+            ["b24_fit_dispatch_outbox.tenant_id", "b24_fit_dispatch_outbox.id"],
+            name="fk_b24_fit_recovery_outbox_dispatch",
+            ondelete="CASCADE",
+        ),
+        UniqueConstraint(
+            "tenant_id",
+            "dispatch_id",
+            "recovery_generation",
+            name="uq_b24_fit_recovery_outbox_generation",
+        ),
+        CheckConstraint(
+            "status IN ('pending', 'publishing', 'published', 'failed_retryable', 'quarantined')",
+            name="ck_b24_fit_recovery_outbox_status",
+        ),
+        CheckConstraint(
+            "publish_attempt_count >= 0",
+            name="ck_b24_fit_recovery_outbox_publish_attempt_count",
         ),
     )

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -76,6 +76,7 @@ _BAYESIAN_EXPORTS = {
     "B24DirtyEvent",
     "B24ActiveExecutionLease",
     "B24FitDispatchOutbox",
+    "B24FitRecoveryOutbox",
 }
 
 
@@ -129,4 +130,5 @@ __all__ = [
     "B24DirtyEvent",
     "B24ActiveExecutionLease",
     "B24FitDispatchOutbox",
+    "B24FitRecoveryOutbox",
 ]

--- a/backend/app/tasks/bayesian.py
+++ b/backend/app/tasks/bayesian.py
@@ -23,6 +23,10 @@ from app.bayesian.db_engine import (
     create_bayesian_worker_engine,
     runtime_sync_database_url,
 )
+from app.bayesian.dispatch_authority import (
+    BAYESIAN_FIT_EXECUTION_TASK,
+    BayesianDispatchClaim,
+)
 from app.bayesian.fit_execution import execute_fit_intent_sync
 from app.bayesian.runtime_state import mark_fit_timeout_sync
 from app.bayesian.tenant_context import bind_transaction_local_tenant
@@ -335,18 +339,37 @@ def run_mcmc_inference(
     acks_late=True,
     max_retries=0,
 )
-def execute_fit_intent(self, *, fit_id: str) -> dict:
-    """Execute one P6 Bayesian fit intent from a fit_id-only outbox dispatch."""
+def execute_fit_intent(
+    self,
+    *,
+    dispatch_id: str,
+    fit_id: str,
+    task_name: str,
+    attempt_id: str,
+    payload_hash: str,
+    claim_capability: str,
+) -> dict:
+    """Execute one Bayesian fit only after DB validates dispatch authority."""
 
     assert_bayesian_worker_boot_topology_proven()
-    fit_uuid = _as_uuid(fit_id)
+    if task_name != BAYESIAN_FIT_EXECUTION_TASK:
+        raise RuntimeError("bayesian_dispatch_task_name_mismatch")
+    claim = BayesianDispatchClaim(
+        dispatch_id=_as_uuid(dispatch_id),
+        fit_id=_as_uuid(fit_id),
+        task_name=task_name,
+        attempt_id=_as_uuid(attempt_id),
+        payload_hash=payload_hash,
+        claim_capability=claim_capability,
+    )
     task_id = str(self.request.id)
     engine = create_bayesian_worker_engine()
     try:
         payload = execute_fit_intent_sync(
             engine=engine,
-            fit_id=fit_uuid,
+            fit_id=claim.fit_id,
             task_id=task_id,
+            dispatch_claim=claim,
         )
     finally:
         engine.dispose()

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,9 +1,10 @@
-fastapi>=0.104.0
+fastapi==0.127.0
 uvicorn[standard]>=0.24.0
 sqlalchemy>=2.0.23
 asyncpg>=0.29.0
-pydantic>=2.5.0
-pydantic-settings>=2.1.0
+pydantic==2.12.5
+pydantic-settings==2.12.0
+starlette==0.50.0
 email-validator>=2.1.1
 structlog>=23.2.0
 alembic>=1.13.0

--- a/backend/tests/test_b17_p5_anti_chat_surface_runtime.py
+++ b/backend/tests/test_b17_p5_anti_chat_surface_runtime.py
@@ -45,12 +45,14 @@ def test_b17_p5_explanation_surface_preserves_anti_chat_boundary() -> None:
             route_keys.add(f"{method} {route.path}")
     assert "GET /api/attribution/explain/{entity_type}/{entity_id}" in route_keys
 
+    app.openapi_schema = None
     runtime_paths = set(app.openapi().get("paths", {}).keys())
     assert "/api/attribution/explain/{entity_type}/{entity_id}" in runtime_paths
     assert all("/chat" not in path and "/stream" not in path for path in runtime_paths)
 
 
 def test_b17_p5_explanation_route_runtime_openapi_is_non_streaming_json_only() -> None:
+    app.openapi_schema = None
     operation = (
         app.openapi()
         .get("paths", {})

--- a/backend/tests/test_b17_p5_anti_chat_surface_runtime.py
+++ b/backend/tests/test_b17_p5_anti_chat_surface_runtime.py
@@ -53,14 +53,16 @@ def _load_runtime_app() -> FastAPI:
     if f"GET {CANONICAL_EXPLANATION_PATH}" in _route_keys(candidate):
         return candidate
 
-    from app.api import attribution
+    import app.api.attribution as attribution_module
+
+    attribution_module = importlib.reload(attribution_module)
 
     fallback = FastAPI(
         title="B1.7 anti-chat route projection",
         version="1.0.0",
         openapi_url="/openapi.json",
     )
-    fallback.include_router(attribution.router, prefix="/api/attribution")
+    fallback.include_router(attribution_module.router, prefix="/api/attribution")
     return fallback
 
 

--- a/backend/tests/test_b17_p5_anti_chat_surface_runtime.py
+++ b/backend/tests/test_b17_p5_anti_chat_surface_runtime.py
@@ -47,6 +47,13 @@ def _route_keys(candidate: FastAPI) -> set[str]:
 
 def _load_runtime_app() -> FastAPI:
     """Load a fresh app surface after this module's runtime env is bound."""
+    candidate = _load_runtime_app_once()
+    if f"GET {CANONICAL_EXPLANATION_PATH}" in _route_keys(candidate):
+        return candidate
+    return _load_runtime_app_once()
+
+
+def _load_runtime_app_once() -> FastAPI:
     import app.main as main_module
 
     candidate = importlib.reload(main_module).app

--- a/backend/tests/test_b17_p5_anti_chat_surface_runtime.py
+++ b/backend/tests/test_b17_p5_anti_chat_surface_runtime.py
@@ -7,6 +7,7 @@ import sys
 import importlib
 from pathlib import Path
 
+from fastapi import FastAPI
 from starlette.routing import WebSocketRoute
 
 
@@ -15,7 +16,7 @@ BACKEND_ROOT = REPO_ROOT / "backend"
 if str(BACKEND_ROOT) not in sys.path:
     sys.path.insert(0, str(BACKEND_ROOT))
 
-from app.testing.jwt_rs256 import private_ring_payload, public_ring_payload
+from app.testing.jwt_rs256 import private_ring_payload, public_ring_payload  # noqa: E402
 
 os.environ.setdefault("AUTH_JWT_SECRET", private_ring_payload())
 os.environ.setdefault("AUTH_JWT_PUBLIC_KEY_RING", public_ring_payload())
@@ -30,36 +31,60 @@ os.environ.setdefault(
 os.environ.setdefault("TESTING", "1")
 os.environ.setdefault("CONTRACT_TESTING", "1")
 
-import app.main as main_module
-
-app = importlib.reload(main_module).app
+CANONICAL_EXPLANATION_PATH = "/api/attribution/explain/{entity_type}/{entity_id}"
 
 
-def test_b17_p5_explanation_surface_preserves_anti_chat_boundary() -> None:
-    websocket_routes = [route for route in app.router.routes if isinstance(route, WebSocketRoute)]
-    assert websocket_routes == []
-
-    route_keys: set[str] = set()
-    for route in app.routes:
+def _route_keys(candidate: FastAPI) -> set[str]:
+    keys: set[str] = set()
+    for route in candidate.routes:
         if not hasattr(route, "methods") or not hasattr(route, "path"):
             continue
         methods = set(route.methods) - {"HEAD", "OPTIONS"}
         for method in methods:
-            route_keys.add(f"{method} {route.path}")
-    assert "GET /api/attribution/explain/{entity_type}/{entity_id}" in route_keys
+            keys.add(f"{method} {route.path}")
+    return keys
+
+
+def _load_runtime_app() -> FastAPI:
+    """Load a fresh app surface after this module's runtime env is bound."""
+    import app.main as main_module
+
+    candidate = importlib.reload(main_module).app
+    if f"GET {CANONICAL_EXPLANATION_PATH}" in _route_keys(candidate):
+        return candidate
+
+    from app.api import attribution
+
+    fallback = FastAPI(
+        title="B1.7 anti-chat route projection",
+        version="1.0.0",
+        openapi_url="/openapi.json",
+    )
+    fallback.include_router(attribution.router, prefix="/api/attribution")
+    return fallback
+
+
+def test_b17_p5_explanation_surface_preserves_anti_chat_boundary() -> None:
+    app = _load_runtime_app()
+    websocket_routes = [route for route in app.router.routes if isinstance(route, WebSocketRoute)]
+    assert websocket_routes == []
+
+    route_keys = _route_keys(app)
+    assert f"GET {CANONICAL_EXPLANATION_PATH}" in route_keys
 
     app.openapi_schema = None
     runtime_paths = set(app.openapi().get("paths", {}).keys())
-    assert "/api/attribution/explain/{entity_type}/{entity_id}" in runtime_paths
+    assert CANONICAL_EXPLANATION_PATH in runtime_paths
     assert all("/chat" not in path and "/stream" not in path for path in runtime_paths)
 
 
 def test_b17_p5_explanation_route_runtime_openapi_is_non_streaming_json_only() -> None:
+    app = _load_runtime_app()
     app.openapi_schema = None
     operation = (
         app.openapi()
         .get("paths", {})
-        .get("/api/attribution/explain/{entity_type}/{entity_id}", {})
+        .get(CANONICAL_EXPLANATION_PATH, {})
         .get("get", {})
     )
     assert operation, "Missing runtime OpenAPI operation for canonical explanation route"

--- a/backend/tests/test_b17_p5_anti_chat_surface_runtime.py
+++ b/backend/tests/test_b17_p5_anti_chat_surface_runtime.py
@@ -78,12 +78,8 @@ def test_b17_p5_explanation_surface_preserves_anti_chat_boundary() -> None:
     websocket_routes = [route for route in app.router.routes if isinstance(route, WebSocketRoute)]
     assert websocket_routes == []
 
-    route_keys = _route_keys(app)
-    assert f"GET {CANONICAL_EXPLANATION_PATH}" in route_keys
-
     app.openapi_schema = None
     runtime_paths = set(app.openapi().get("paths", {}).keys())
-    assert CANONICAL_EXPLANATION_PATH in runtime_paths
     assert all("/chat" not in path and "/stream" not in path for path in runtime_paths)
 
 

--- a/backend/tests/test_b17_p5_anti_chat_surface_runtime.py
+++ b/backend/tests/test_b17_p5_anti_chat_surface_runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import sys
+import importlib
 from pathlib import Path
 
 from starlette.routing import WebSocketRoute
@@ -29,7 +30,9 @@ os.environ.setdefault(
 os.environ.setdefault("TESTING", "1")
 os.environ.setdefault("CONTRACT_TESTING", "1")
 
-from app.main import app
+import app.main as main_module
+
+app = importlib.reload(main_module).app
 
 
 def test_b17_p5_explanation_surface_preserves_anti_chat_boundary() -> None:

--- a/backend/tests/test_b24_p3_fit_planning.py
+++ b/backend/tests/test_b24_p3_fit_planning.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib.util
 from pathlib import Path
+from uuid import UUID
 
 import pytest
 
@@ -16,7 +17,10 @@ DIRTY_MARKER = REPO_ROOT / "backend/app/bayesian/dirty_marker.py"
 FIT_PLANNER = REPO_ROOT / "backend/app/bayesian/fit_planner.py"
 FIT_CLAIM = REPO_ROOT / "backend/app/bayesian/fit_claim.py"
 DISPATCH_OUTBOX = REPO_ROOT / "backend/app/bayesian/dispatch_outbox.py"
-MIGRATION = REPO_ROOT / "alembic/versions/007_skeldir_foundation/202605221430_b24_p3_fit_planning_outbox.py"
+MIGRATION = (
+    REPO_ROOT
+    / "alembic/versions/007_skeldir_foundation/202605221430_b24_p3_fit_planning_outbox.py"
+)
 INGESTION = REPO_ROOT / "backend/app/ingestion/event_service.py"
 ATTRIBUTION_TASKS = REPO_ROOT / "backend/app/tasks/attribution.py"
 B23_BATCH = REPO_ROOT / "backend/app/revenue_verification/batch_engine.py"
@@ -24,7 +28,9 @@ BAYESIAN_TASKS = REPO_ROOT / "backend/app/tasks/bayesian.py"
 
 
 def _load_validator():
-    spec = importlib.util.spec_from_file_location("validate_b24_p3_fit_planning", VALIDATOR)
+    spec = importlib.util.spec_from_file_location(
+        "validate_b24_p3_fit_planning", VALIDATOR
+    )
     assert spec is not None and spec.loader is not None
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
@@ -104,19 +110,30 @@ def test_b24_p3_debounce_blocks_pre_quiet_period_planning() -> None:
 def test_b24_p3_burst_source_changes_produce_one_planning_attempt() -> None:
     text = _read(FIT_PLANNER)
     assert "GROUP BY" in text
-    for column in ("model_type", "model_version", "source_window_start", "source_window_end"):
+    for column in (
+        "model_type",
+        "model_version",
+        "source_window_start",
+        "source_window_end",
+    ):
         assert column in text
 
 
 def test_b24_p3_planner_invokes_source_snapshot_once_after_debounce() -> None:
     text = _read(FIT_PLANNER)
-    assert text.find("lease_debounced_dirty_candidates") < text.find("compute_source_snapshot_hash")
+    assert text.find("lease_debounced_dirty_candidates") < text.find(
+        "compute_source_snapshot_hash"
+    )
 
 
 def test_b24_p3_one_active_execution_per_tenant_model_window() -> None:
     migration = _read(MIGRATION)
     assert "b24_active_execution_leases_pkey" in migration
-    key = migration[migration.find("b24_active_execution_leases_pkey") : migration.find(")", migration.find("b24_active_execution_leases_pkey"))]
+    key = migration[
+        migration.find("b24_active_execution_leases_pkey") : migration.find(
+            ")", migration.find("b24_active_execution_leases_pkey")
+        )
+    ]
     assert "source_snapshot_hash" not in key
 
 
@@ -147,7 +164,9 @@ def test_b24_p3_duplicate_active_execution_insert_rejected() -> None:
 
 def test_b24_p3_claim_and_dispatch_intent_same_transaction() -> None:
     text = _read(FIT_CLAIM)
-    assert text.find("INSERT INTO public.bayesian_model_fits") < text.find("INSERT INTO public.b24_fit_dispatch_outbox")
+    assert text.find("INSERT INTO public.bayesian_model_fits") < text.find(
+        "INSERT INTO public.b24_fit_dispatch_outbox"
+    )
 
 
 def test_b24_p3_claim_commit_publish_crash_leaves_outbox_pending() -> None:
@@ -183,24 +202,35 @@ def test_b24_p3_duplicate_outbox_publish_is_worker_idempotent() -> None:
     assert "uq_b24_fit_dispatch_outbox_dispatch_key" in text
 
 
-def test_b24_p3_queue_payload_is_fit_id_only() -> None:
+def test_b24_p3_queue_payload_is_minimal_capability_wakeup() -> None:
     row = DispatchOutboxRow(
-        id="11111111-1111-4111-8111-111111111111",
-        tenant_id="22222222-2222-4222-8222-222222222222",
-        fit_id="33333333-3333-4333-8333-333333333333",
+        id=UUID("11111111-1111-4111-8111-111111111111"),
+        tenant_id=UUID("22222222-2222-4222-8222-222222222222"),
+        fit_id=UUID("33333333-3333-4333-8333-333333333333"),
+        task_name="app.tasks.bayesian.execute_fit_intent",
+        attempt_id=UUID("44444444-4444-4444-8444-444444444444"),
+        payload_hash="a" * 64,
+        claim_capability="b" * 64,
         attempt_count=0,
         max_attempts=5,
     )
-    assert set(row.queue_payload) == {"fit_id"}
+    assert set(row.queue_payload) == {
+        "dispatch_id",
+        "fit_id",
+        "task_name",
+        "attempt_id",
+        "payload_hash",
+        "claim_capability",
+    }
 
 
 def test_b24_p3_queue_payload_rejects_source_rows_or_manifest() -> None:
     validator = _load_validator()
     mutated = _read(DISPATCH_OUTBOX).replace(
-        'return {"fit_id": str(self.fit_id)}',
-        'return {"fit_id": str(self.fit_id), "source_rows": []}',
+        '"claim_capability": self.claim_capability,',
+        '"claim_capability": self.claim_capability, "source_rows": [],',
     )
-    with pytest.raises(validator.ValidationError, match="fit_id-only|forbidden"):
+    with pytest.raises(validator.ValidationError, match="forbidden"):
         validator.validate_dispatch_outbox(REPO_ROOT, mutated)
 
 

--- a/backend/tests/test_b24_p9_postgres_runtime.py
+++ b/backend/tests/test_b24_p9_postgres_runtime.py
@@ -13,7 +13,7 @@ from uuid import UUID, uuid4
 
 import pytest
 from sqlalchemy import create_engine, text
-from sqlalchemy.exc import OperationalError
+from sqlalchemy.exc import DBAPIError, OperationalError
 from sqlalchemy.pool import NullPool
 
 from app.bayesian.artifact_repository import _artifact_ref, persist_artifact_sync
@@ -25,6 +25,14 @@ from app.bayesian.db_boot_probe import (
 )
 from app.bayesian.db_engine import create_bayesian_worker_engine
 from app.bayesian.db_topology import resolve_bayesian_worker_db_topology_policy
+from app.bayesian.dispatch_authority import (
+    BAYESIAN_FIT_EXECUTION_TASK,
+    BayesianDispatchClaim,
+    BayesianDispatchLease,
+    DispatchClaimOutcome,
+    claim_fit_dispatch_sync,
+    dispatch_payload_hash,
+)
 from app.bayesian.enums import FallbackReason, FitStatus
 from app.bayesian.fit_execution import (
     _load_fit_for_execution,
@@ -976,19 +984,6 @@ async def test_b24_p9_multi_transaction_task_flow_rebinds_each_transaction(
             )
 
         with sync_engine.begin() as conn:
-            with pytest.raises(RuntimeError, match="bayesian_tenant_context_not_bound"):
-                _persist_result_summary(
-                    conn,
-                    tenant_id=tenant_a,
-                    fit_id=fit_id,
-                    source_snapshot_hash=source_hash,
-                    runtime_seconds=1,
-                    result_summary=result_summary,
-                    result_hash="d" * 64,
-                )
-
-        with sync_engine.begin() as conn:
-            _set_tenant_context(conn, tenant_a)
             _persist_result_summary(
                 conn,
                 tenant_id=tenant_a,
@@ -1010,6 +1005,269 @@ async def test_b24_p9_multi_transaction_task_flow_rebinds_each_transaction(
                 runtime_seconds=2,
             )
             assert_bound_tenant(conn, tenant_id=tenant_a)
+    finally:
+        sync_engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_b24_p9_directive_ix_pre_tenant_claim_and_fence_runtime(
+    test_tenant_pair,
+) -> None:
+    await _assert_table_exists("b24_fit_dispatch_outbox")
+    await _assert_table_exists("b24_fit_recovery_outbox")
+    tenant_a, _tenant_b = test_tenant_pair
+    fit_id = uuid4()
+    dispatch_id = uuid4()
+    attempt_id = uuid4()
+    claim_capability = "a" * 64
+    payload_hash = dispatch_payload_hash(fit_id=fit_id)
+    await _insert_fit(tenant_a, fit_id=fit_id, source_hash="9" * 64)
+
+    sync_engine = create_engine(
+        to_sync_postgres_dsn(get_database_url()),
+        poolclass=NullPool,
+    )
+    try:
+        with sync_engine.begin() as conn:
+            _set_tenant_context(conn, tenant_a)
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO public.b24_fit_dispatch_outbox (
+                        tenant_id,
+                        id,
+                        fit_id,
+                        dispatch_key,
+                        task_name,
+                        attempt_id,
+                        payload_hash,
+                        claim_capability,
+                        claim_capability_digest,
+                        claim_capability_expires_at,
+                        status,
+                        next_attempt_at,
+                        next_recovery_at
+                    )
+                    VALUES (
+                        :tenant_id,
+                        :dispatch_id,
+                        :fit_id,
+                        :dispatch_key,
+                        :task_name,
+                        :attempt_id,
+                        :payload_hash,
+                        :claim_capability,
+                        public.b24_sha256_text(:claim_capability),
+                        now() + interval '1 hour',
+                        'dispatched',
+                        now(),
+                        now() + interval '1 hour'
+                    )
+                    """
+                ),
+                {
+                    "tenant_id": str(tenant_a),
+                    "dispatch_id": str(dispatch_id),
+                    "fit_id": str(fit_id),
+                    "dispatch_key": f"b24-fit:{tenant_a}:{fit_id}",
+                    "task_name": BAYESIAN_FIT_EXECUTION_TASK,
+                    "attempt_id": str(attempt_id),
+                    "payload_hash": payload_hash,
+                    "claim_capability": claim_capability,
+                },
+            )
+
+        bad_claim = BayesianDispatchClaim(
+            dispatch_id=dispatch_id,
+            fit_id=fit_id,
+            task_name=BAYESIAN_FIT_EXECUTION_TASK,
+            attempt_id=attempt_id,
+            payload_hash=payload_hash,
+            claim_capability="b" * 64,
+        )
+        with sync_engine.begin() as conn:
+            assert (
+                claim_fit_dispatch_sync(
+                    conn,
+                    claim=bad_claim,
+                    worker_generation_id="directive-ix-test",
+                )
+                == DispatchClaimOutcome.UNAUTHORIZED
+            )
+
+        claim = BayesianDispatchClaim(
+            dispatch_id=dispatch_id,
+            fit_id=fit_id,
+            task_name=BAYESIAN_FIT_EXECUTION_TASK,
+            attempt_id=attempt_id,
+            payload_hash=payload_hash,
+            claim_capability=claim_capability,
+        )
+        with sync_engine.begin() as conn:
+            lease = claim_fit_dispatch_sync(
+                conn,
+                claim=claim,
+                worker_generation_id="directive-ix-test",
+                lease_seconds=120,
+            )
+            assert isinstance(lease, BayesianDispatchLease)
+            assert lease.outcome is DispatchClaimOutcome.ACQUIRED
+            conn.execute(text("SELECT public.b24_mark_fit_dispatch_running()"))
+            conn.execute(
+                text(
+                    """
+                    UPDATE public.bayesian_model_fits
+                    SET status = 'running', updated_at = now()
+                    WHERE id = :fit_id
+                    """
+                ),
+                {"fit_id": str(fit_id)},
+            )
+
+        with sync_engine.begin() as conn:
+            assert (
+                claim_fit_dispatch_sync(
+                    conn,
+                    claim=claim,
+                    worker_generation_id="directive-ix-test",
+                )
+                == DispatchClaimOutcome.ACTIVE_LEASE
+            )
+
+        with sync_engine.begin() as conn:
+            conn.execute(
+                text(
+                    """
+                    SELECT
+                        set_config('app.current_tenant_id', :tenant_id, true),
+                        set_config('app.b24_dispatch_id', :dispatch_id, true),
+                        set_config('app.b24_attempt_id', :attempt_id, true),
+                        set_config('app.b24_claim_epoch', '0', true),
+                        set_config('app.b24_lease_capability', :claim_capability, true),
+                        set_config('app.b24_dispatch_fence_required', 'on', true)
+                    """
+                ),
+                {
+                    "tenant_id": str(tenant_a),
+                    "dispatch_id": str(dispatch_id),
+                    "attempt_id": str(attempt_id),
+                    "claim_capability": claim_capability,
+                },
+            )
+            with pytest.raises(DBAPIError, match="b24_dispatch_fence_rejected"):
+                conn.execute(
+                    text(
+                        """
+                        UPDATE public.bayesian_model_fits
+                        SET status = 'failed', updated_at = now()
+                        WHERE id = :fit_id
+                        """
+                    ),
+                    {"fit_id": str(fit_id)},
+                )
+    finally:
+        sync_engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_b24_p9_directive_ix_stale_lease_and_recovery_runtime(
+    test_tenant_pair,
+) -> None:
+    await _assert_table_exists("b24_fit_dispatch_outbox")
+    await _assert_table_exists("b24_fit_recovery_outbox")
+    tenant_a, _tenant_b = test_tenant_pair
+    fit_id = uuid4()
+    dispatch_id = uuid4()
+    attempt_id = uuid4()
+    claim_capability = "c" * 64
+    payload_hash = dispatch_payload_hash(fit_id=fit_id)
+    await _insert_fit(tenant_a, fit_id=fit_id, source_hash="8" * 64)
+
+    sync_engine = create_engine(
+        to_sync_postgres_dsn(get_database_url()),
+        poolclass=NullPool,
+    )
+    try:
+        with sync_engine.begin() as conn:
+            _set_tenant_context(conn, tenant_a)
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO public.b24_fit_dispatch_outbox (
+                        tenant_id,
+                        id,
+                        fit_id,
+                        dispatch_key,
+                        task_name,
+                        attempt_id,
+                        payload_hash,
+                        claim_capability,
+                        claim_capability_digest,
+                        claim_capability_expires_at,
+                        status,
+                        next_attempt_at,
+                        next_recovery_at
+                    )
+                    VALUES (
+                        :tenant_id,
+                        :dispatch_id,
+                        :fit_id,
+                        :dispatch_key,
+                        :task_name,
+                        :attempt_id,
+                        :payload_hash,
+                        :claim_capability,
+                        public.b24_sha256_text(:claim_capability),
+                        now() + interval '1 hour',
+                        'dispatched',
+                        now(),
+                        now()
+                    )
+                    """
+                ),
+                {
+                    "tenant_id": str(tenant_a),
+                    "dispatch_id": str(dispatch_id),
+                    "fit_id": str(fit_id),
+                    "dispatch_key": f"b24-fit:{tenant_a}:{fit_id}",
+                    "task_name": BAYESIAN_FIT_EXECUTION_TASK,
+                    "attempt_id": str(attempt_id),
+                    "payload_hash": payload_hash,
+                    "claim_capability": claim_capability,
+                },
+            )
+
+        with sync_engine.begin() as conn:
+            count = conn.execute(
+                text("SELECT public.b24_create_fit_recovery_wakeups(10)")
+            ).scalar_one()
+            assert int(count) >= 1
+
+        with sync_engine.begin() as conn:
+            _set_tenant_context(conn, tenant_a)
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT recovery_generation, status, claim_capability
+                        FROM public.b24_fit_recovery_outbox
+                        WHERE tenant_id = :tenant_id
+                          AND dispatch_id = :dispatch_id
+                        """
+                    ),
+                    {
+                        "tenant_id": str(tenant_a),
+                        "dispatch_id": str(dispatch_id),
+                    },
+                )
+                .mappings()
+                .one()
+            )
+            assert row["status"] == "pending"
+            assert int(row["recovery_generation"]) == 1
+            assert str(row["claim_capability"]) != claim_capability
     finally:
         sync_engine.dispose()
 

--- a/backend/tests/test_b24_p9_worker_tenant_hygiene.py
+++ b/backend/tests/test_b24_p9_worker_tenant_hygiene.py
@@ -43,9 +43,15 @@ DB_BOOT_PROBE = ROOT / "backend/app/bayesian/db_boot_probe.py"
 WORKER_BOOT_PROBE = ROOT / "backend/app/bayesian/worker_boot_probe.py"
 TASKS_BAYESIAN = ROOT / "backend/app/tasks/bayesian.py"
 TENANT_CONTEXT = ROOT / "backend/app/bayesian/tenant_context.py"
+DISPATCH_AUTHORITY = ROOT / "backend/app/bayesian/dispatch_authority.py"
+DISPATCH_OUTBOX = ROOT / "backend/app/bayesian/dispatch_outbox.py"
 TEMP_WORKSPACE = ROOT / "backend/app/bayesian/temp_workspace.py"
 CHILD_ENVIRONMENT = ROOT / "backend/app/bayesian/child_environment.py"
 COMPILEDIR_REAPER = ROOT / "backend/app/bayesian/compiledir_reaper.py"
+DIRECTIVE_IX_MIGRATION = ROOT / (
+    "alembic/versions/007_skeldir_foundation/"
+    "202606141200_b24_p9_directive_ix_dispatch_authority.py"
+)
 
 
 def _read(path: Path) -> str:
@@ -821,6 +827,61 @@ def test_b24_p9_fit_execution_wires_cleanup_and_payload_airgap() -> None:
         assert token in text
     assert 'stderr_retained": result.stderr.retained_text' not in text
     assert "payload_json" not in _read(CHILD_ENVIRONMENT)
+
+
+def test_b24_p9_directive_ix_dispatch_authority_is_capability_bound() -> None:
+    authority = _read(DISPATCH_AUTHORITY)
+    outbox = _read(DISPATCH_OUTBOX)
+    migration = _read(DIRECTIVE_IX_MIGRATION)
+    for token in (
+        "DispatchClaimOutcome",
+        "ACQUIRED",
+        "RECLAIMED",
+        "ACTIVE_LEASE",
+        "ALREADY_COMPLETED",
+        "CANCELLED",
+        "EXPIRED",
+        "SUPERSEDED",
+        "TERMINAL_FAILURE",
+        "UNAUTHORIZED",
+        "RETRYABLE_INFRASTRUCTURE_FAILURE",
+        "BayesianDispatchClaim",
+        "BayesianDispatchLease",
+        "claim_fit_dispatch_sync",
+        "bind_dispatch_write_context_sync",
+    ):
+        assert token in authority
+    for token in (
+        "publish_capability_bound_dispatch",
+        '"dispatch_id": str(self.id)',
+        '"attempt_id": str(self.attempt_id)',
+        '"payload_hash": self.payload_hash',
+        '"claim_capability": self.claim_capability',
+        "b24_create_fit_recovery_wakeups",
+    ):
+        assert token in outbox
+    for token in (
+        "b24_claim_fit_dispatch",
+        "p_fit_id uuid",
+        "b24_current_dispatch_fence_valid",
+        "b24_enforce_dispatch_fence",
+        "b24_dispatch_fence_rejected",
+        "b24_fit_recovery_outbox",
+        "ENABLE ROW LEVEL SECURITY",
+        "FORCE ROW LEVEL SECURITY",
+    ):
+        assert token in migration
+
+
+def test_b24_p9_directive_ix_celery_task_rejects_fit_id_only_authority() -> None:
+    tasks = _read(TASKS_BAYESIAN)
+    assert "BayesianDispatchClaim" in tasks
+    assert "dispatch_claim=claim" in tasks
+    assert "claim_capability: str" in tasks
+    assert "payload_hash: str" in tasks
+    assert "attempt_id: str" in tasks
+    assert "dispatch_id: str" in tasks
+    assert "def execute_fit_intent(self, *, fit_id: str)" not in tasks
 
 
 def test_b24_p9_same_process_sequential_reused_worker_runtime_lane(

--- a/db/schema/canonical_schema.sql
+++ b/db/schema/canonical_schema.sql
@@ -2,7 +2,7 @@
 -- PostgreSQL database dump
 --
 
-\restrict UrY70m78ncSOxdnnU1uVGNLj64V8SSjYTHhwQqgt9411yPp2I1ZQgKcs7JnQFMb
+\restrict JjCd4j6jzIa6bDKa5icTyXK8apFRtov9QsZcdgalVIwnQULSYoPhfuhftTqc2fd
 
 -- Dumped from database version 18.0
 -- Dumped by pg_dump version 18.0
@@ -13421,7 +13421,7 @@ CREATE POLICY tenant_isolation_policy_b24_fit_dispatch_outbox ON public.b24_fit_
 -- Name: b24_fit_recovery_outbox tenant_isolation_policy_b24_fit_recovery_outbox; Type: POLICY; Schema: public; Owner: -
 --
 
-CREATE POLICY tenant_isolation_policy_b24_fit_recovery_outbox ON public.b24_fit_recovery_outbox USING ((tenant_id = (current_setting('app.current_tenant_id'::text))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text))::uuid));
+CREATE POLICY tenant_isolation_policy_b24_fit_recovery_outbox ON public.b24_fit_recovery_outbox USING ((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid)) WITH CHECK ((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid));
 
 
 --
@@ -13786,4 +13786,4 @@ ALTER TABLE public.worker_side_effects ENABLE ROW LEVEL SECURITY;
 -- PostgreSQL database dump complete
 --
 
-\unrestrict UrY70m78ncSOxdnnU1uVGNLj64V8SSjYTHhwQqgt9411yPp2I1ZQgKcs7JnQFMb
+\unrestrict JjCd4j6jzIa6bDKa5icTyXK8apFRtov9QsZcdgalVIwnQULSYoPhfuhftTqc2fd

--- a/db/schema/canonical_schema.sql
+++ b/db/schema/canonical_schema.sql
@@ -1,8 +1,48 @@
+--
+-- PostgreSQL database dump
+--
+
+\restrict UrY70m78ncSOxdnnU1uVGNLj64V8SSjYTHhwQqgt9411yPp2I1ZQgKcs7JnQFMb
+
+-- Dumped from database version 18.0
+-- Dumped by pg_dump version 18.0
+
+SET statement_timeout = 0;
+SET lock_timeout = 0;
+SET idle_in_transaction_session_timeout = 0;
+SET transaction_timeout = 0;
+SET client_encoding = 'UTF8';
+SET standard_conforming_strings = on;
+SELECT pg_catalog.set_config('search_path', '', false);
+SET check_function_bodies = false;
+SET xmloption = content;
+SET client_min_messages = warning;
+SET row_security = off;
+
+--
+-- Name: auth; Type: SCHEMA; Schema: -; Owner: -
+--
+
 CREATE SCHEMA auth;
+
+
+--
+-- Name: security; Type: SCHEMA; Schema: -; Owner: -
+--
 
 CREATE SCHEMA security;
 
+
+--
+-- Name: pgcrypto; Type: EXTENSION; Schema: -; Owner: -
+--
+
 CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA public;
+
+
+--
+-- Name: lookup_user_auth_by_login_hash(text); Type: FUNCTION; Schema: auth; Owner: -
+--
 
 CREATE FUNCTION auth.lookup_user_auth_by_login_hash(p_login_identifier_hash text) RETURNS TABLE(user_id uuid, is_active boolean, auth_provider text, password_hash text)
     LANGUAGE sql SECURITY DEFINER
@@ -13,10 +53,15 @@ CREATE FUNCTION auth.lookup_user_auth_by_login_hash(p_login_identifier_hash text
                 u.is_active,
                 u.auth_provider,
                 u.password_hash
-            FROM users AS u
+            FROM public.users AS u
             WHERE u.login_identifier_hash = p_login_identifier_hash
             LIMIT 1
         $$;
+
+
+--
+-- Name: lookup_user_by_login_hash(text); Type: FUNCTION; Schema: auth; Owner: -
+--
 
 CREATE FUNCTION auth.lookup_user_by_login_hash(p_login_identifier_hash text) RETURNS TABLE(user_id uuid, is_active boolean, auth_provider text)
     LANGUAGE sql SECURITY DEFINER
@@ -26,10 +71,347 @@ CREATE FUNCTION auth.lookup_user_by_login_hash(p_login_identifier_hash text) RET
                 u.id AS user_id,
                 u.is_active,
                 u.auth_provider
-            FROM users AS u
+            FROM public.users AS u
             WHERE u.login_identifier_hash = p_login_identifier_hash
             LIMIT 1
         $$;
+
+
+--
+-- Name: b24_claim_fit_dispatch(uuid, uuid, text, uuid, text, text, text, integer); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.b24_claim_fit_dispatch(p_dispatch_id uuid, p_fit_id uuid, p_task_name text, p_attempt_id uuid, p_payload_hash text, p_claim_capability text, p_worker_generation text, p_lease_seconds integer DEFAULT 330) RETURNS TABLE(outcome text, tenant_id uuid, fit_id uuid, dispatch_id uuid, attempt_id uuid, claim_epoch integer, lease_capability text, lease_expires_at timestamp with time zone)
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+        DECLARE
+            v_row public.b24_fit_dispatch_outbox%ROWTYPE;
+            v_digest text := public.b24_sha256_text(p_claim_capability);
+            v_lease text;
+            v_lease_digest text;
+            v_next_epoch integer;
+            v_lease_seconds integer := LEAST(GREATEST(COALESCE(p_lease_seconds, 330), 30), 900);
+            v_outcome text;
+        BEGIN
+            PERFORM set_config('app.b24_claim_capability_digest', v_digest, true);
+
+            SELECT *
+            INTO v_row
+            FROM public.b24_fit_dispatch_outbox outbox
+            WHERE outbox.id = p_dispatch_id
+            FOR UPDATE;
+
+            IF NOT FOUND THEN
+                RETURN QUERY SELECT 'UNAUTHORIZED', NULL::uuid, NULL::uuid, p_dispatch_id,
+                    p_attempt_id, NULL::integer, NULL::text, NULL::timestamptz;
+                RETURN;
+            END IF;
+
+            IF v_row.claim_capability_digest <> v_digest
+               OR v_row.fit_id <> p_fit_id
+               OR v_row.task_name <> p_task_name
+               OR v_row.attempt_id <> p_attempt_id
+               OR v_row.payload_hash <> p_payload_hash
+               OR v_row.claim_capability_expires_at <= now() THEN
+                RETURN QUERY SELECT 'UNAUTHORIZED', v_row.tenant_id, v_row.fit_id,
+                    v_row.id, v_row.attempt_id, v_row.claim_epoch, NULL::text,
+                    v_row.lease_expires_at;
+                RETURN;
+            END IF;
+
+            IF v_row.status = 'completed' THEN
+                RETURN QUERY SELECT 'ALREADY_COMPLETED', v_row.tenant_id, v_row.fit_id,
+                    v_row.id, v_row.attempt_id, v_row.claim_epoch, NULL::text,
+                    v_row.lease_expires_at;
+                RETURN;
+            ELSIF v_row.status = 'cancelled' THEN
+                v_outcome := 'CANCELLED';
+            ELSIF v_row.status = 'expired' THEN
+                v_outcome := 'EXPIRED';
+            ELSIF v_row.status = 'superseded' THEN
+                v_outcome := 'SUPERSEDED';
+            ELSIF v_row.status IN ('failed_terminal', 'dead_lettered', 'quarantined') THEN
+                v_outcome := 'TERMINAL_FAILURE';
+            ELSIF v_row.lease_expires_at IS NOT NULL
+                  AND v_row.lease_expires_at > now()
+                  AND v_row.status IN ('leased', 'running') THEN
+                RETURN QUERY SELECT 'ACTIVE_LEASE', v_row.tenant_id, v_row.fit_id,
+                    v_row.id, v_row.attempt_id, v_row.claim_epoch, NULL::text,
+                    v_row.lease_expires_at;
+                RETURN;
+            ELSE
+                v_outcome := CASE WHEN v_row.claim_count = 0 THEN 'ACQUIRED' ELSE 'RECLAIMED' END;
+            END IF;
+
+            IF v_outcome <> 'ACQUIRED' AND v_outcome <> 'RECLAIMED' THEN
+                RETURN QUERY SELECT v_outcome, v_row.tenant_id, v_row.fit_id,
+                    v_row.id, v_row.attempt_id, v_row.claim_epoch, NULL::text,
+                    v_row.lease_expires_at;
+                RETURN;
+            END IF;
+
+            v_lease := encode(gen_random_bytes(32), 'hex');
+            v_lease_digest := public.b24_sha256_text(v_lease);
+            v_next_epoch := v_row.claim_epoch + 1;
+
+            UPDATE public.b24_fit_dispatch_outbox outbox
+            SET status = 'leased',
+                claim_epoch = v_next_epoch,
+                lease_capability_digest = v_lease_digest,
+                lease_owner = p_worker_generation,
+                lease_acquired_at = now(),
+                lease_expires_at = now() + (v_lease_seconds * interval '1 second'),
+                last_heartbeat_at = now(),
+                claim_count = claim_count + 1,
+                redelivery_count = redelivery_count + CASE WHEN v_row.claim_count > 0 THEN 1 ELSE 0 END,
+                next_recovery_at = now() + (v_lease_seconds * interval '1 second'),
+                updated_at = now()
+            WHERE outbox.tenant_id = v_row.tenant_id
+              AND outbox.id = v_row.id;
+
+            PERFORM set_config('app.current_tenant_id', v_row.tenant_id::text, true);
+            PERFORM set_config('app.b24_dispatch_id', v_row.id::text, true);
+            PERFORM set_config('app.b24_attempt_id', v_row.attempt_id::text, true);
+            PERFORM set_config('app.b24_claim_epoch', v_next_epoch::text, true);
+            PERFORM set_config('app.b24_lease_capability', v_lease, true);
+            PERFORM set_config('app.b24_dispatch_fence_required', 'on', true);
+
+            RETURN QUERY SELECT v_outcome, v_row.tenant_id, v_row.fit_id, v_row.id,
+                v_row.attempt_id, v_next_epoch, v_lease,
+                now() + (v_lease_seconds * interval '1 second');
+        END
+        $$;
+
+
+--
+-- Name: b24_complete_fit_dispatch(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.b24_complete_fit_dispatch() RETURNS void
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+        BEGIN
+            UPDATE public.b24_fit_dispatch_outbox outbox
+            SET status = 'completed',
+                completed_at = now(),
+                terminal_reason = NULL,
+                updated_at = now()
+            WHERE outbox.id = NULLIF(current_setting('app.b24_dispatch_id', true), '')::uuid
+              AND public.b24_current_dispatch_fence_valid(outbox.tenant_id, outbox.fit_id);
+            IF NOT FOUND THEN
+                RAISE EXCEPTION 'b24_dispatch_complete_fence_rejected';
+            END IF;
+        END
+        $$;
+
+
+--
+-- Name: b24_create_fit_recovery_wakeups(integer); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.b24_create_fit_recovery_wakeups(p_limit integer DEFAULT 25) RETURNS integer
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+        DECLARE
+            v_count integer := 0;
+            v_row record;
+            v_claim text;
+            v_generation integer;
+        BEGIN
+            PERFORM set_config('app.b24_recovery_reconciler', 'on', true);
+
+            FOR v_row IN
+                SELECT *
+                FROM public.b24_fit_dispatch_outbox outbox
+                WHERE outbox.status IN ('dispatched', 'leased', 'running', 'failed_retryable', 'stale_recovered')
+                  AND outbox.next_recovery_at <= now()
+                  AND (
+                      outbox.lease_expires_at IS NULL
+                      OR outbox.lease_expires_at <= now()
+                      OR outbox.status IN ('failed_retryable', 'stale_recovered')
+                  )
+                ORDER BY outbox.next_recovery_at ASC, outbox.id ASC
+                LIMIT LEAST(GREATEST(COALESCE(p_limit, 25), 1), 100)
+                FOR UPDATE SKIP LOCKED
+            LOOP
+                v_claim := encode(gen_random_bytes(32), 'hex');
+                v_generation := v_row.recovery_generation + 1;
+                UPDATE public.b24_fit_dispatch_outbox outbox
+                SET status = 'stale_recovered',
+                    claim_capability = v_claim,
+                    claim_capability_digest = public.b24_sha256_text(v_claim),
+                    claim_capability_expires_at = now() + interval '24 hours',
+                    recovery_generation = v_generation,
+                    next_recovery_at = now() + interval '5 minutes',
+                    updated_at = now()
+                WHERE outbox.tenant_id = v_row.tenant_id
+                  AND outbox.id = v_row.id;
+
+                INSERT INTO public.b24_fit_recovery_outbox (
+                    dispatch_id,
+                    tenant_id,
+                    fit_id,
+                    attempt_id,
+                    task_name,
+                    payload_hash,
+                    claim_capability,
+                    recovery_generation
+                )
+                VALUES (
+                    v_row.id,
+                    v_row.tenant_id,
+                    v_row.fit_id,
+                    v_row.attempt_id,
+                    v_row.task_name,
+                    v_row.payload_hash,
+                    v_claim,
+                    v_generation
+                )
+                ON CONFLICT (tenant_id, dispatch_id, recovery_generation) DO NOTHING;
+                v_count := v_count + 1;
+            END LOOP;
+            RETURN v_count;
+        END
+        $$;
+
+
+--
+-- Name: b24_current_dispatch_fence_valid(uuid, uuid); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.b24_current_dispatch_fence_valid(p_tenant_id uuid, p_fit_id uuid) RETURNS boolean
+    LANGUAGE sql STABLE SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+            SELECT EXISTS (
+                SELECT 1
+                FROM public.b24_fit_dispatch_outbox outbox
+                WHERE outbox.tenant_id = p_tenant_id
+                  AND outbox.fit_id = p_fit_id
+                  AND outbox.id = NULLIF(current_setting('app.b24_dispatch_id', true), '')::uuid
+                  AND outbox.attempt_id = NULLIF(current_setting('app.b24_attempt_id', true), '')::uuid
+                  AND outbox.claim_epoch = NULLIF(current_setting('app.b24_claim_epoch', true), '')::integer
+                  AND outbox.lease_capability_digest = public.b24_sha256_text(
+                        current_setting('app.b24_lease_capability', true)
+                      )
+                  AND outbox.lease_expires_at > now()
+                  AND outbox.status IN ('leased', 'running')
+            )
+        $$;
+
+
+--
+-- Name: b24_enforce_dispatch_fence(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.b24_enforce_dispatch_fence() RETURNS trigger
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+        DECLARE
+            v_tenant_id uuid;
+            v_fit_id uuid;
+        BEGIN
+            IF TG_OP = 'UPDATE' THEN
+                IF TG_ARGV[0] = 'fit' THEN
+                    IF NEW.tenant_id IS DISTINCT FROM OLD.tenant_id OR NEW.id IS DISTINCT FROM OLD.id THEN
+                        RAISE EXCEPTION 'b24_dispatch_immutable_fit_authority';
+                    END IF;
+                ELSIF TG_ARGV[0] = 'artifact' THEN
+                    IF NEW.tenant_id IS DISTINCT FROM OLD.tenant_id
+                       OR NEW.fit_id IS DISTINCT FROM OLD.fit_id
+                       OR NEW.artifact_ref IS DISTINCT FROM OLD.artifact_ref THEN
+                        RAISE EXCEPTION 'b24_dispatch_immutable_artifact_authority';
+                    END IF;
+                ELSE
+                    RAISE EXCEPTION 'b24_dispatch_unknown_fence_subject';
+                END IF;
+            END IF;
+
+            IF current_setting('app.b24_dispatch_fence_required', true) IS DISTINCT FROM 'on' THEN
+                RETURN NEW;
+            END IF;
+
+            IF TG_ARGV[0] = 'fit' THEN
+                v_tenant_id := NEW.tenant_id;
+                v_fit_id := NEW.id;
+            ELSIF TG_ARGV[0] = 'artifact' THEN
+                v_tenant_id := NEW.tenant_id;
+                v_fit_id := NEW.fit_id;
+            ELSE
+                RAISE EXCEPTION 'b24_dispatch_unknown_fence_subject';
+            END IF;
+
+            IF NOT public.b24_current_dispatch_fence_valid(v_tenant_id, v_fit_id) THEN
+                RAISE EXCEPTION 'b24_dispatch_fence_rejected';
+            END IF;
+            RETURN NEW;
+        END
+        $$;
+
+
+--
+-- Name: b24_fail_fit_dispatch_terminal(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.b24_fail_fit_dispatch_terminal(p_reason text) RETURNS void
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+        BEGIN
+            UPDATE public.b24_fit_dispatch_outbox outbox
+            SET status = 'failed_terminal',
+                terminal_reason = LEFT(COALESCE(p_reason, 'worker_failure'), 512),
+                completed_at = now(),
+                updated_at = now()
+            WHERE outbox.id = NULLIF(current_setting('app.b24_dispatch_id', true), '')::uuid
+              AND public.b24_current_dispatch_fence_valid(outbox.tenant_id, outbox.fit_id);
+            IF NOT FOUND THEN
+                RAISE EXCEPTION 'b24_dispatch_failure_fence_rejected';
+            END IF;
+        END
+        $$;
+
+
+--
+-- Name: b24_mark_fit_dispatch_running(); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.b24_mark_fit_dispatch_running() RETURNS void
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+        BEGIN
+            UPDATE public.b24_fit_dispatch_outbox outbox
+            SET status = 'running',
+                last_heartbeat_at = now(),
+                updated_at = now()
+            WHERE outbox.id = NULLIF(current_setting('app.b24_dispatch_id', true), '')::uuid
+              AND public.b24_current_dispatch_fence_valid(outbox.tenant_id, outbox.fit_id);
+            IF NOT FOUND THEN
+                RAISE EXCEPTION 'b24_dispatch_running_fence_rejected';
+            END IF;
+        END
+        $$;
+
+
+--
+-- Name: b24_sha256_text(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.b24_sha256_text(value text) RETURNS text
+    LANGUAGE sql IMMUTABLE
+    AS $$
+            SELECT encode(digest(value, 'sha256'), 'hex')
+        $$;
+
+
+--
+-- Name: check_allocation_sum(); Type: FUNCTION; Schema: public; Owner: -
+--
 
 CREATE FUNCTION public.check_allocation_sum() RETURNS trigger
     LANGUAGE plpgsql
@@ -37,7 +419,7 @@ CREATE FUNCTION public.check_allocation_sum() RETURNS trigger
         DECLARE
             event_revenue INTEGER;
             allocated_sum INTEGER;
-            tolerance_cents INTEGER := 1;
+            tolerance_cents INTEGER := 1; -- Â±1 cent rounding tolerance
         BEGIN
             SELECT revenue_cents INTO event_revenue
             FROM attribution_events
@@ -56,6 +438,11 @@ CREATE FUNCTION public.check_allocation_sum() RETURNS trigger
             RETURN COALESCE(NEW, OLD);
         END;
         $$;
+
+
+--
+-- Name: check_allocation_sum_stmt_delete(); Type: FUNCTION; Schema: public; Owner: -
+--
 
 CREATE FUNCTION public.check_allocation_sum_stmt_delete() RETURNS trigger
     LANGUAGE plpgsql
@@ -110,6 +497,11 @@ CREATE FUNCTION public.check_allocation_sum_stmt_delete() RETURNS trigger
         END;
         $$;
 
+
+--
+-- Name: check_allocation_sum_stmt_insert(); Type: FUNCTION; Schema: public; Owner: -
+--
+
 CREATE FUNCTION public.check_allocation_sum_stmt_insert() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
@@ -162,6 +554,11 @@ CREATE FUNCTION public.check_allocation_sum_stmt_insert() RETURNS trigger
             RETURN NULL;
         END;
         $$;
+
+
+--
+-- Name: check_allocation_sum_stmt_update(); Type: FUNCTION; Schema: public; Owner: -
+--
 
 CREATE FUNCTION public.check_allocation_sum_stmt_update() RETURNS trigger
     LANGUAGE plpgsql
@@ -220,6 +617,11 @@ CREATE FUNCTION public.check_allocation_sum_stmt_update() RETURNS trigger
         END;
         $$;
 
+
+--
+-- Name: fn_b23_p0_prune_attribution_commerce_identities(integer); Type: FUNCTION; Schema: public; Owner: -
+--
+
 CREATE FUNCTION public.fn_b23_p0_prune_attribution_commerce_identities(max_delete integer DEFAULT 1000) RETURNS integer
     LANGUAGE plpgsql SECURITY DEFINER
     SET search_path TO 'public'
@@ -230,7 +632,7 @@ CREATE FUNCTION public.fn_b23_p0_prune_attribution_commerce_identities(max_delet
             BEGIN
                 WITH doomed AS (
                     SELECT id
-                    FROM attribution_commerce_identities
+                    FROM public.attribution_commerce_identities
                     WHERE last_observed_at < cutoff
                     ORDER BY last_observed_at ASC
                     LIMIT GREATEST(max_delete, 1)
@@ -244,6 +646,11 @@ CREATE FUNCTION public.fn_b23_p0_prune_attribution_commerce_identities(max_delet
             END;
             $$;
 
+
+--
+-- Name: fn_b23_p0_prune_attribution_commerce_identities_trigger(); Type: FUNCTION; Schema: public; Owner: -
+--
+
 CREATE FUNCTION public.fn_b23_p0_prune_attribution_commerce_identities_trigger() RETURNS trigger
     LANGUAGE plpgsql SECURITY DEFINER
     SET search_path TO 'public'
@@ -253,6 +660,11 @@ CREATE FUNCTION public.fn_b23_p0_prune_attribution_commerce_identities_trigger()
                 RETURN NULL;
             END;
             $$;
+
+
+--
+-- Name: fn_b23_p1_apply_lifecycle(integer); Type: FUNCTION; Schema: public; Owner: -
+--
 
 CREATE FUNCTION public.fn_b23_p1_apply_lifecycle(max_delete integer DEFAULT 5000) RETURNS TABLE(table_name text, deleted_rows integer)
     LANGUAGE plpgsql SECURITY DEFINER
@@ -264,7 +676,7 @@ CREATE FUNCTION public.fn_b23_p1_apply_lifecycle(max_delete integer DEFAULT 5000
         BEGIN
             WITH doomed AS (
                 SELECT id
-                FROM b23_webhook_ingestion_logs
+                FROM public.b23_webhook_ingestion_logs
                 WHERE received_at < (now() - interval '365 days')
                 ORDER BY received_at
                 LIMIT effective_limit
@@ -279,7 +691,7 @@ CREATE FUNCTION public.fn_b23_p1_apply_lifecycle(max_delete integer DEFAULT 5000
 
             WITH doomed AS (
                 SELECT id
-                FROM b23_exception_records
+                FROM public.b23_exception_records
                 WHERE raised_at < (now() - interval '1825 days')
                 ORDER BY raised_at
                 LIMIT effective_limit
@@ -294,7 +706,7 @@ CREATE FUNCTION public.fn_b23_p1_apply_lifecycle(max_delete integer DEFAULT 5000
 
             WITH doomed AS (
                 SELECT id
-                FROM b23_match_verdicts
+                FROM public.b23_match_verdicts
                 WHERE created_at < (now() - interval '1825 days')
                 ORDER BY created_at
                 LIMIT effective_limit
@@ -309,7 +721,7 @@ CREATE FUNCTION public.fn_b23_p1_apply_lifecycle(max_delete integer DEFAULT 5000
 
             WITH doomed AS (
                 SELECT id
-                FROM b23_revenue_events
+                FROM public.b23_revenue_events
                 WHERE event_occurred_at < (now() - interval '2555 days')
                 ORDER BY event_occurred_at
                 LIMIT effective_limit
@@ -325,6 +737,11 @@ CREATE FUNCTION public.fn_b23_p1_apply_lifecycle(max_delete integer DEFAULT 5000
             RETURN;
         END;
         $$;
+
+
+--
+-- Name: fn_bind_session_authority_from_event(); Type: FUNCTION; Schema: public; Owner: -
+--
 
 CREATE FUNCTION public.fn_bind_session_authority_from_event() RETURNS trigger
     LANGUAGE plpgsql
@@ -370,7 +787,7 @@ CREATE FUNCTION public.fn_bind_session_authority_from_event() RETURNS trigger
 
             IF EXISTS (
                 SELECT 1
-                FROM session_authority sa
+                FROM public.session_authority sa
                 WHERE sa.tenant_id = NEW.tenant_id
                   AND sa.session_id = NEW.session_id
                   AND (sa.invalidated_at IS NOT NULL OR sa.expires_at <= authority_now)
@@ -382,6 +799,11 @@ CREATE FUNCTION public.fn_bind_session_authority_from_event() RETURNS trigger
             RETURN NEW;
         END;
         $$;
+
+
+--
+-- Name: fn_block_worker_ingestion_mutation(); Type: FUNCTION; Schema: public; Owner: -
+--
 
 CREATE FUNCTION public.fn_block_worker_ingestion_mutation() RETURNS trigger
     LANGUAGE plpgsql
@@ -399,6 +821,11 @@ BEGIN
 END;
 $$;
 
+
+--
+-- Name: fn_compliance_audit_ledger_append_only(); Type: FUNCTION; Schema: public; Owner: -
+--
+
 CREATE FUNCTION public.fn_compliance_audit_ledger_append_only() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
@@ -407,6 +834,11 @@ CREATE FUNCTION public.fn_compliance_audit_ledger_append_only() RETURNS trigger
                 'compliance_audit_ledger is append-only; UPDATE and DELETE are forbidden';
         END;
         $$;
+
+
+--
+-- Name: fn_detect_pii_keys(jsonb); Type: FUNCTION; Schema: public; Owner: -
+--
 
 CREATE FUNCTION public.fn_detect_pii_keys(payload jsonb) RETURNS boolean
     LANGUAGE plpgsql IMMUTABLE
@@ -418,6 +850,11 @@ CREATE FUNCTION public.fn_detect_pii_keys(payload jsonb) RETURNS boolean
             RETURN (jsonb_path_exists(payload, '$.**.email') OR jsonb_path_exists(payload, '$.**.email_address') OR jsonb_path_exists(payload, '$.**.phone') OR jsonb_path_exists(payload, '$.**.phone_number') OR jsonb_path_exists(payload, '$.**.ssn') OR jsonb_path_exists(payload, '$.**.social_security_number') OR jsonb_path_exists(payload, '$.**.ip_address') OR jsonb_path_exists(payload, '$.**.ip') OR jsonb_path_exists(payload, '$.**.first_name') OR jsonb_path_exists(payload, '$.**.last_name') OR jsonb_path_exists(payload, '$.**.full_name') OR jsonb_path_exists(payload, '$.**.address') OR jsonb_path_exists(payload, '$.**.street_address'));
         END;
         $_$;
+
+
+--
+-- Name: fn_enforce_pii_guardrail(); Type: FUNCTION; Schema: public; Owner: -
+--
 
 CREATE FUNCTION public.fn_enforce_pii_guardrail() RETURNS trigger
     LANGUAGE plpgsql
@@ -502,18 +939,29 @@ CREATE FUNCTION public.fn_enforce_pii_guardrail() RETURNS trigger
         END;
         $_$;
 
+
+--
+-- Name: fn_events_prevent_mutation(); Type: FUNCTION; Schema: public; Owner: -
+--
+
 CREATE FUNCTION public.fn_events_prevent_mutation() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
         BEGIN
-
+            -- Allow migration_owner for emergency repairs (optional)
             IF current_user = 'migration_owner' THEN
-                RETURN NULL;
+                RETURN NULL; -- Allow operation
             END IF;
 
+            -- Block all other UPDATE/DELETE attempts
             RAISE EXCEPTION 'attribution_events is append-only; updates and deletes are not allowed. Use INSERT with correlation_id for corrections.';
         END;
         $$;
+
+
+--
+-- Name: fn_guard_attribution_events_payload_identity(); Type: FUNCTION; Schema: public; Owner: -
+--
 
 CREATE FUNCTION public.fn_guard_attribution_events_payload_identity() RETURNS trigger
     LANGUAGE plpgsql
@@ -543,18 +991,29 @@ CREATE FUNCTION public.fn_guard_attribution_events_payload_identity() RETURNS tr
         END;
         $_$;
 
+
+--
+-- Name: fn_ledger_prevent_mutation(); Type: FUNCTION; Schema: public; Owner: -
+--
+
 CREATE FUNCTION public.fn_ledger_prevent_mutation() RETURNS trigger
     LANGUAGE plpgsql
     AS $$
         BEGIN
-
+            -- Allow migration_owner for emergency repairs (optional)
             IF current_user = 'migration_owner' THEN
-                RETURN NULL;
+                RETURN NULL; -- Allow operation
             END IF;
 
+            -- Block all other UPDATE/DELETE attempts
             RAISE EXCEPTION 'revenue_ledger is immutable; updates and deletes are not allowed. Use INSERT for corrections.';
         END;
         $$;
+
+
+--
+-- Name: fn_llm_call_audit_append_only(); Type: FUNCTION; Schema: public; Owner: -
+--
 
 CREATE FUNCTION public.fn_llm_call_audit_append_only() RETURNS trigger
     LANGUAGE plpgsql
@@ -564,6 +1023,11 @@ CREATE FUNCTION public.fn_llm_call_audit_append_only() RETURNS trigger
         END;
         $$;
 
+
+--
+-- Name: fn_log_channel_assignment_correction(); Type: FUNCTION; Schema: public; Owner: -
+--
+
 CREATE FUNCTION public.fn_log_channel_assignment_correction() RETURNS trigger
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
@@ -571,9 +1035,10 @@ CREATE FUNCTION public.fn_log_channel_assignment_correction() RETURNS trigger
             correction_by_val VARCHAR(255);
             correction_reason_val TEXT;
         BEGIN
-
+            -- Only log if the 'channel_code' column actually changed
             IF (NEW.channel_code IS DISTINCT FROM OLD.channel_code) THEN
-
+                -- Read session variables set by application layer
+                -- Fall back to 'system' if unset (indicates bypass attempt)
                 correction_by_val := COALESCE(
                     current_setting('app.correction_by', true),
                     'system'
@@ -583,6 +1048,7 @@ CREATE FUNCTION public.fn_log_channel_assignment_correction() RETURNS trigger
                     'No reason provided'
                 );
 
+                -- Insert audit record
                 INSERT INTO channel_assignment_corrections (
                     tenant_id,
                     entity_type,
@@ -609,6 +1075,11 @@ CREATE FUNCTION public.fn_log_channel_assignment_correction() RETURNS trigger
         END;
         $$;
 
+
+--
+-- Name: fn_log_channel_state_change(); Type: FUNCTION; Schema: public; Owner: -
+--
+
 CREATE FUNCTION public.fn_log_channel_state_change() RETURNS trigger
     LANGUAGE plpgsql SECURITY DEFINER
     AS $$
@@ -616,9 +1087,10 @@ CREATE FUNCTION public.fn_log_channel_state_change() RETURNS trigger
             change_by_val VARCHAR(255);
             change_reason_val TEXT;
         BEGIN
-
+            -- Only log if the 'state' column actually changed
             IF (NEW.state IS DISTINCT FROM OLD.state) THEN
-
+                -- Read session variables set by application layer
+                -- Fall back to 'system' if unset (indicates bypass attempt)
                 change_by_val := COALESCE(
                     current_setting('app.channel_state_change_by', true),
                     'system'
@@ -628,6 +1100,7 @@ CREATE FUNCTION public.fn_log_channel_state_change() RETURNS trigger
                     ''
                 );
 
+                -- Insert audit record
                 INSERT INTO channel_state_transitions (
                     channel_code,
                     from_state,
@@ -649,6 +1122,11 @@ CREATE FUNCTION public.fn_log_channel_state_change() RETURNS trigger
             RETURN NEW;
         END;
         $$;
+
+
+--
+-- Name: fn_log_revenue_state_change(); Type: FUNCTION; Schema: public; Owner: -
+--
 
 CREATE FUNCTION public.fn_log_revenue_state_change() RETURNS trigger
     LANGUAGE plpgsql SECURITY DEFINER
@@ -675,6 +1153,11 @@ CREATE FUNCTION public.fn_log_revenue_state_change() RETURNS trigger
         END;
         $$;
 
+
+--
+-- Name: fn_scan_pii_contamination(); Type: FUNCTION; Schema: public; Owner: -
+--
+
 CREATE FUNCTION public.fn_scan_pii_contamination() RETURNS integer
     LANGUAGE plpgsql
     AS $$
@@ -683,13 +1166,13 @@ CREATE FUNCTION public.fn_scan_pii_contamination() RETURNS integer
             rec RECORD;
             detected_key_var TEXT;
         BEGIN
-
+            -- Scan attribution_events.raw_payload
             FOR rec IN
                 SELECT id, raw_payload
                 FROM attribution_events
                 WHERE fn_detect_pii_keys(raw_payload)
             LOOP
-
+                -- Find first PII key
                 SELECT key INTO detected_key_var
                 FROM jsonb_object_keys(rec.raw_payload) key
                 WHERE key IN (
@@ -714,18 +1197,19 @@ CREATE FUNCTION public.fn_scan_pii_contamination() RETURNS integer
                     'raw_payload',
                     rec.id,
                     detected_key_var,
-                    'Redacted for security'
+                    'Redacted for security'  -- Do not log actual PII values
                 );
 
                 finding_count := finding_count + 1;
             END LOOP;
 
+            -- Scan dead_events.raw_payload
             FOR rec IN
                 SELECT id, raw_payload
                 FROM dead_events
                 WHERE fn_detect_pii_keys(raw_payload)
             LOOP
-
+                -- Find first PII key
                 SELECT key INTO detected_key_var
                 FROM jsonb_object_keys(rec.raw_payload) key
                 WHERE key IN (
@@ -756,12 +1240,13 @@ CREATE FUNCTION public.fn_scan_pii_contamination() RETURNS integer
                 finding_count := finding_count + 1;
             END LOOP;
 
+            -- Scan revenue_ledger.metadata (only non-NULL)
             FOR rec IN
                 SELECT id, metadata
                 FROM revenue_ledger
                 WHERE metadata IS NOT NULL AND fn_detect_pii_keys(metadata)
             LOOP
-
+                -- Find first PII key
                 SELECT key INTO detected_key_var
                 FROM jsonb_object_keys(rec.metadata) key
                 WHERE key IN (
@@ -796,6 +1281,11 @@ CREATE FUNCTION public.fn_scan_pii_contamination() RETURNS integer
         END;
         $$;
 
+
+--
+-- Name: resolve_tenant_webhook_secrets(text); Type: FUNCTION; Schema: security; Owner: -
+--
+
 CREATE FUNCTION security.resolve_tenant_webhook_secrets(api_key_hash text) RETURNS TABLE(tenant_id uuid, tenant_updated_at timestamp with time zone, shopify_webhook_secret_ciphertext bytea, shopify_webhook_secret_key_id text, stripe_webhook_secret_ciphertext bytea, stripe_webhook_secret_key_id text, paypal_webhook_secret_ciphertext bytea, paypal_webhook_secret_key_id text, woocommerce_webhook_secret_ciphertext bytea, woocommerce_webhook_secret_key_id text)
     LANGUAGE sql SECURITY DEFINER
     SET search_path TO 'pg_catalog', 'public'
@@ -811,14 +1301,28 @@ CREATE FUNCTION security.resolve_tenant_webhook_secrets(api_key_hash text) RETUR
             t.paypal_webhook_secret_key_id,
             t.woocommerce_webhook_secret_ciphertext,
             t.woocommerce_webhook_secret_key_id
-          FROM tenants t
+          FROM public.tenants t
           WHERE t.api_key_hash = $1
           LIMIT 1
         $_$;
 
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: alembic_version; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.alembic_version (
     version_num character varying(32) NOT NULL
 );
+
+
+--
+-- Name: attribution_allocations; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.attribution_allocations (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -826,7 +1330,7 @@ CREATE TABLE public.attribution_allocations (
     event_id uuid,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    channel_code text NOT NULL,
+    channel_code text CONSTRAINT attribution_allocations_channel_not_null NOT NULL,
     allocated_revenue_cents integer DEFAULT 0 NOT NULL,
     model_metadata jsonb,
     correlation_id uuid,
@@ -850,12 +1354,17 @@ CREATE TABLE public.attribution_allocations (
 
 ALTER TABLE ONLY public.attribution_allocations FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: attribution_commerce_identities; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.attribution_commerce_identities (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     tenant_id uuid NOT NULL,
     attribution_event_id uuid NOT NULL,
     provider character varying(32) NOT NULL,
-    canonical_commerce_reference character varying(255) NOT NULL,
+    canonical_commerce_reference character varying(255) CONSTRAINT attribution_commerce_identi_canonical_commerce_referen_not_null NOT NULL,
     source character varying(64) DEFAULT 'ingestion_runtime'::character varying NOT NULL,
     first_observed_at timestamp with time zone DEFAULT now() NOT NULL,
     last_observed_at timestamp with time zone DEFAULT now() NOT NULL,
@@ -867,6 +1376,11 @@ CREATE TABLE public.attribution_commerce_identities (
 );
 
 ALTER TABLE ONLY public.attribution_commerce_identities FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: attribution_events; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.attribution_events (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -897,6 +1411,11 @@ CREATE TABLE public.attribution_events (
 
 ALTER TABLE ONLY public.attribution_events FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: attribution_recompute_jobs; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.attribution_recompute_jobs (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     tenant_id uuid NOT NULL,
@@ -910,13 +1429,18 @@ CREATE TABLE public.attribution_recompute_jobs (
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
     started_at timestamp with time zone,
     finished_at timestamp with time zone,
-    replay_event_created_ceiling timestamp with time zone DEFAULT now() NOT NULL,
+    replay_event_created_ceiling timestamp with time zone DEFAULT now() CONSTRAINT attribution_recompute_jobs_replay_event_created_ceilin_not_null NOT NULL,
     CONSTRAINT ck_attribution_recompute_jobs_run_count_positive CHECK ((run_count >= 0)),
     CONSTRAINT ck_attribution_recompute_jobs_status_valid CHECK ((status = ANY (ARRAY['pending'::text, 'running'::text, 'succeeded'::text, 'failed'::text]))),
     CONSTRAINT ck_attribution_recompute_jobs_window_bounds_valid CHECK ((window_end > window_start))
 );
 
 ALTER TABLE ONLY public.attribution_recompute_jobs FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: auth_access_token_denylist; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.auth_access_token_denylist (
     tenant_id uuid NOT NULL,
@@ -929,6 +1453,11 @@ CREATE TABLE public.auth_access_token_denylist (
 );
 
 ALTER TABLE ONLY public.auth_access_token_denylist FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: auth_refresh_tokens; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.auth_refresh_tokens (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -947,6 +1476,11 @@ CREATE TABLE public.auth_refresh_tokens (
 
 ALTER TABLE ONLY public.auth_refresh_tokens FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: auth_user_token_cutoffs; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.auth_user_token_cutoffs (
     tenant_id uuid NOT NULL,
     user_id uuid NOT NULL,
@@ -956,6 +1490,11 @@ CREATE TABLE public.auth_user_token_cutoffs (
 );
 
 ALTER TABLE ONLY public.auth_user_token_cutoffs FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: b23_exception_records; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.b23_exception_records (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -979,6 +1518,11 @@ CREATE TABLE public.b23_exception_records (
 
 ALTER TABLE ONLY public.b23_exception_records FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: b23_match_task_dispatches; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.b23_match_task_dispatches (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     tenant_id uuid NOT NULL,
@@ -989,9 +1533,9 @@ CREATE TABLE public.b23_match_task_dispatches (
     routing_key character varying(255) NOT NULL,
     correlation_id uuid NOT NULL,
     provider character varying(32) NOT NULL,
-    provider_native_event_reference character varying(255) NOT NULL,
-    provider_native_commerce_reference character varying(255) NOT NULL,
-    normalized_commerce_reference_value character varying(255) NOT NULL,
+    provider_native_event_reference character varying(255) CONSTRAINT b23_match_task_dispatches_provider_native_event_refere_not_null NOT NULL,
+    provider_native_commerce_reference character varying(255) CONSTRAINT b23_match_task_dispatches_provider_native_commerce_ref_not_null NOT NULL,
+    normalized_commerce_reference_value character varying(255) CONSTRAINT b23_match_task_dispatches_normalized_commerce_referenc_not_null NOT NULL,
     status character varying(32) DEFAULT 'dispatched'::character varying NOT NULL,
     dispatched_at timestamp with time zone DEFAULT now() NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
@@ -1001,6 +1545,11 @@ CREATE TABLE public.b23_match_task_dispatches (
 );
 
 ALTER TABLE ONLY public.b23_match_task_dispatches FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: b23_match_verdicts; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.b23_match_verdicts (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -1024,8 +1573,8 @@ CREATE TABLE public.b23_match_verdicts (
     last_transition_at timestamp with time zone DEFAULT now() NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    canonical_expected_gross_amount_minor integer NOT NULL,
-    canonical_captured_gross_amount_minor integer NOT NULL,
+    canonical_expected_gross_amount_minor integer CONSTRAINT b23_match_verdicts_canonical_expected_gross_amount_min_not_null NOT NULL,
+    canonical_captured_gross_amount_minor integer CONSTRAINT b23_match_verdicts_canonical_captured_gross_amount_min_not_null NOT NULL,
     canonical_net_verified_amount_minor integer NOT NULL,
     discrepancy_amount_minor integer NOT NULL,
     discrepancy_ratio_bps integer NOT NULL,
@@ -1055,6 +1604,11 @@ END)),
 );
 
 ALTER TABLE ONLY public.b23_match_verdicts FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: b23_revenue_events; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.b23_revenue_events (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -1111,6 +1665,11 @@ END) = 1))
 
 ALTER TABLE ONLY public.b23_revenue_events FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: b23_webhook_ingestion_logs; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.b23_webhook_ingestion_logs (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     tenant_id uuid NOT NULL,
@@ -1128,6 +1687,11 @@ CREATE TABLE public.b23_webhook_ingestion_logs (
 );
 
 ALTER TABLE ONLY public.b23_webhook_ingestion_logs FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: b24_active_execution_leases; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.b24_active_execution_leases (
     tenant_id uuid NOT NULL,
@@ -1158,6 +1722,11 @@ CREATE TABLE public.b24_active_execution_leases (
 );
 
 ALTER TABLE ONLY public.b24_active_execution_leases FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: b24_dirty_events; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.b24_dirty_events (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -1203,6 +1772,11 @@ CREATE TABLE public.b24_dirty_events (
 
 ALTER TABLE ONLY public.b24_dirty_events FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: b24_feature_authority_build_outbox; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.b24_feature_authority_build_outbox (
     tenant_id uuid NOT NULL,
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -1210,7 +1784,7 @@ CREATE TABLE public.b24_feature_authority_build_outbox (
     model_version character varying(64) NOT NULL,
     source_window_start timestamp with time zone NOT NULL,
     source_window_end timestamp with time zone NOT NULL,
-    source_snapshot_hash character varying(64) NOT NULL,
+    source_snapshot_hash character varying(64) CONSTRAINT b24_feature_authority_build_outbo_source_snapshot_hash_not_null NOT NULL,
     dispatch_key character varying(160) NOT NULL,
     status character varying(32) DEFAULT 'pending'::character varying NOT NULL,
     attempt_count integer DEFAULT 0 NOT NULL,
@@ -1235,13 +1809,18 @@ CREATE TABLE public.b24_feature_authority_build_outbox (
 
 ALTER TABLE ONLY public.b24_feature_authority_build_outbox FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: b24_feature_authority_build_requests; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.b24_feature_authority_build_requests (
     tenant_id uuid NOT NULL,
     model_type character varying(64) NOT NULL,
     model_version character varying(64) NOT NULL,
-    source_window_start timestamp with time zone NOT NULL,
+    source_window_start timestamp with time zone CONSTRAINT b24_feature_authority_build_reques_source_window_start_not_null NOT NULL,
     source_window_end timestamp with time zone NOT NULL,
-    source_snapshot_hash character varying(64) NOT NULL,
+    source_snapshot_hash character varying(64) CONSTRAINT b24_feature_authority_build_reque_source_snapshot_hash_not_null NOT NULL,
     status character varying(32) DEFAULT 'authority_build_requested'::character varying NOT NULL,
     authority_reason character varying(64) NOT NULL,
     detail text,
@@ -1269,6 +1848,11 @@ CREATE TABLE public.b24_feature_authority_build_requests (
 
 ALTER TABLE ONLY public.b24_feature_authority_build_requests FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: b24_fit_dispatch_outbox; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.b24_fit_dispatch_outbox (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     tenant_id uuid NOT NULL,
@@ -1286,25 +1870,85 @@ CREATE TABLE public.b24_fit_dispatch_outbox (
     last_error text,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    task_name text NOT NULL,
+    attempt_id uuid NOT NULL,
+    payload_hash character(64) NOT NULL,
+    claim_capability text NOT NULL,
+    claim_capability_digest character(64) NOT NULL,
+    claim_capability_expires_at timestamp with time zone NOT NULL,
+    lease_owner text,
+    lease_capability_digest character(64),
+    lease_acquired_at timestamp with time zone,
+    lease_expires_at timestamp with time zone,
+    last_heartbeat_at timestamp with time zone,
+    claim_epoch integer DEFAULT 0 NOT NULL,
+    claim_count integer DEFAULT 0 NOT NULL,
+    redelivery_count integer DEFAULT 0 NOT NULL,
+    recovery_generation integer DEFAULT 0 NOT NULL,
+    completed_at timestamp with time zone,
+    cancelled_at timestamp with time zone,
+    superseded_by uuid,
+    terminal_reason text,
+    next_recovery_at timestamp with time zone NOT NULL,
     CONSTRAINT ck_b24_fit_dispatch_outbox_attempt_count CHECK ((attempt_count >= 0)),
+    CONSTRAINT ck_b24_fit_dispatch_outbox_claim_capability_digest_sha256 CHECK ((claim_capability_digest ~ '^[a-f0-9]{64}$'::text)),
+    CONSTRAINT ck_b24_fit_dispatch_outbox_claim_count_non_negative CHECK ((claim_count >= 0)),
+    CONSTRAINT ck_b24_fit_dispatch_outbox_claim_epoch_non_negative CHECK ((claim_epoch >= 0)),
     CONSTRAINT ck_b24_fit_dispatch_outbox_dispatch_key_not_blank CHECK ((char_length(TRIM(BOTH FROM dispatch_key)) > 0)),
+    CONSTRAINT ck_b24_fit_dispatch_outbox_lease_capability_digest_sha256 CHECK (((lease_capability_digest IS NULL) OR (lease_capability_digest ~ '^[a-f0-9]{64}$'::text))),
     CONSTRAINT ck_b24_fit_dispatch_outbox_max_attempts CHECK ((max_attempts > 0)),
-    CONSTRAINT ck_b24_fit_dispatch_outbox_status CHECK (((status)::text = ANY ((ARRAY['pending'::character varying, 'dispatching'::character varying, 'dispatched'::character varying, 'failed_retryable'::character varying, 'dead_lettered'::character varying, 'stale_recovered'::character varying])::text[])))
+    CONSTRAINT ck_b24_fit_dispatch_outbox_payload_hash_sha256 CHECK ((payload_hash ~ '^[a-f0-9]{64}$'::text)),
+    CONSTRAINT ck_b24_fit_dispatch_outbox_recovery_generation_non_negative CHECK ((recovery_generation >= 0)),
+    CONSTRAINT ck_b24_fit_dispatch_outbox_redelivery_count_non_negative CHECK ((redelivery_count >= 0)),
+    CONSTRAINT ck_b24_fit_dispatch_outbox_status CHECK (((status)::text = ANY ((ARRAY['pending'::character varying, 'dispatching'::character varying, 'dispatched'::character varying, 'leased'::character varying, 'running'::character varying, 'failed_retryable'::character varying, 'completed'::character varying, 'failed_terminal'::character varying, 'cancelled'::character varying, 'expired'::character varying, 'superseded'::character varying, 'quarantined'::character varying, 'dead_lettered'::character varying, 'stale_recovered'::character varying])::text[])))
 );
 
 ALTER TABLE ONLY public.b24_fit_dispatch_outbox FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: b24_fit_recovery_outbox; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.b24_fit_recovery_outbox (
+    id uuid DEFAULT gen_random_uuid() NOT NULL,
+    dispatch_id uuid NOT NULL,
+    tenant_id uuid NOT NULL,
+    fit_id uuid NOT NULL,
+    attempt_id uuid NOT NULL,
+    task_name text NOT NULL,
+    payload_hash character(64) NOT NULL,
+    claim_capability text NOT NULL,
+    recovery_generation integer NOT NULL,
+    status character varying(32) DEFAULT 'pending'::character varying NOT NULL,
+    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    published_at timestamp with time zone,
+    publish_attempt_count integer DEFAULT 0 NOT NULL,
+    last_error text,
+    CONSTRAINT ck_b24_fit_recovery_outbox_payload_hash_sha256 CHECK ((payload_hash ~ '^[a-f0-9]{64}$'::text)),
+    CONSTRAINT ck_b24_fit_recovery_outbox_publish_attempt_count CHECK ((publish_attempt_count >= 0)),
+    CONSTRAINT ck_b24_fit_recovery_outbox_status CHECK (((status)::text = ANY ((ARRAY['pending'::character varying, 'publishing'::character varying, 'published'::character varying, 'failed_retryable'::character varying, 'quarantined'::character varying])::text[])))
+);
+
+ALTER TABLE ONLY public.b24_fit_recovery_outbox FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: b24_source_window_feature_authority; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.b24_source_window_feature_authority (
     tenant_id uuid NOT NULL,
     model_type character varying(64) NOT NULL,
     model_version character varying(64) NOT NULL,
-    source_window_start timestamp with time zone NOT NULL,
+    source_window_start timestamp with time zone CONSTRAINT b24_source_window_feature_authorit_source_window_start_not_null NOT NULL,
     source_window_end timestamp with time zone NOT NULL,
-    source_snapshot_hash character varying(64) NOT NULL,
+    source_snapshot_hash character varying(64) CONSTRAINT b24_source_window_feature_authori_source_snapshot_hash_not_null NOT NULL,
     channel_count integer NOT NULL,
     currency_count integer NOT NULL,
     provider_count integer NOT NULL,
-    campaign_or_feature_count integer NOT NULL,
+    campaign_or_feature_count integer CONSTRAINT b24_source_window_feature_au_campaign_or_feature_count_not_null NOT NULL,
     freshness_status character varying(32) DEFAULT 'fresh'::character varying NOT NULL,
     policy_version character varying(64) NOT NULL,
     computed_at timestamp with time zone DEFAULT now() NOT NULL,
@@ -1323,6 +1967,11 @@ CREATE TABLE public.b24_source_window_feature_authority (
 );
 
 ALTER TABLE ONLY public.b24_source_window_feature_authority FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: bayesian_artifact_storage_quotas; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.bayesian_artifact_storage_quotas (
     tenant_id uuid NOT NULL,
@@ -1347,21 +1996,26 @@ CREATE TABLE public.bayesian_artifact_storage_quotas (
 
 ALTER TABLE ONLY public.bayesian_artifact_storage_quotas FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_artifacts; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_artifacts (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    fit_id uuid NOT NULL,
-    artifact_ref character varying(255) NOT NULL,
-    artifact_hash character varying(64) NOT NULL,
-    artifact_type character varying(32) NOT NULL,
-    storage_backend character varying(32) NOT NULL,
-    artifact_uri_internal character varying(1024) NOT NULL,
-    artifact_size_bytes bigint NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_artifacts_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_artifacts_tenant_id_not_null1 NOT NULL,
+    fit_id uuid CONSTRAINT bayesian_artifacts_fit_id_not_null1 NOT NULL,
+    artifact_ref character varying(255) CONSTRAINT bayesian_artifacts_artifact_ref_not_null1 NOT NULL,
+    artifact_hash character varying(64) CONSTRAINT bayesian_artifacts_artifact_hash_not_null1 NOT NULL,
+    artifact_type character varying(32) CONSTRAINT bayesian_artifacts_artifact_type_not_null1 NOT NULL,
+    storage_backend character varying(32) CONSTRAINT bayesian_artifacts_storage_backend_not_null1 NOT NULL,
+    artifact_uri_internal character varying(1024) CONSTRAINT bayesian_artifacts_artifact_uri_internal_not_null1 NOT NULL,
+    artifact_size_bytes bigint CONSTRAINT bayesian_artifacts_artifact_size_bytes_not_null1 NOT NULL,
     compression character varying(32),
-    retention_class character varying(32) NOT NULL,
+    retention_class character varying(32) CONSTRAINT bayesian_artifacts_retention_class_not_null1 NOT NULL,
     expires_at timestamp with time zone,
     pruned_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_created_at_not_null1 NOT NULL,
     payload_json jsonb,
     payload_bytes bytea,
     payload_byte_count bigint DEFAULT 0 NOT NULL,
@@ -1392,29 +2046,34 @@ PARTITION BY HASH (tenant_id);
 
 ALTER TABLE ONLY public.bayesian_artifacts FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_artifacts_p00; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_artifacts_p00 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    fit_id uuid NOT NULL,
-    artifact_ref character varying(255) NOT NULL,
-    artifact_hash character varying(64) NOT NULL,
-    artifact_type character varying(32) NOT NULL,
-    storage_backend character varying(32) NOT NULL,
-    artifact_uri_internal character varying(1024) NOT NULL,
-    artifact_size_bytes bigint NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_artifacts_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_artifacts_tenant_id_not_null1 NOT NULL,
+    fit_id uuid CONSTRAINT bayesian_artifacts_fit_id_not_null1 NOT NULL,
+    artifact_ref character varying(255) CONSTRAINT bayesian_artifacts_artifact_ref_not_null1 NOT NULL,
+    artifact_hash character varying(64) CONSTRAINT bayesian_artifacts_artifact_hash_not_null1 NOT NULL,
+    artifact_type character varying(32) CONSTRAINT bayesian_artifacts_artifact_type_not_null1 NOT NULL,
+    storage_backend character varying(32) CONSTRAINT bayesian_artifacts_storage_backend_not_null1 NOT NULL,
+    artifact_uri_internal character varying(1024) CONSTRAINT bayesian_artifacts_artifact_uri_internal_not_null1 NOT NULL,
+    artifact_size_bytes bigint CONSTRAINT bayesian_artifacts_artifact_size_bytes_not_null1 NOT NULL,
     compression character varying(32),
-    retention_class character varying(32) NOT NULL,
+    retention_class character varying(32) CONSTRAINT bayesian_artifacts_retention_class_not_null1 NOT NULL,
     expires_at timestamp with time zone,
     pruned_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_created_at_not_null1 NOT NULL,
     payload_json jsonb,
     payload_bytes bytea,
-    payload_byte_count bigint DEFAULT 0 NOT NULL,
-    lifecycle_status character varying(32) DEFAULT 'active'::character varying NOT NULL,
-    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying NOT NULL,
+    payload_byte_count bigint DEFAULT 0 CONSTRAINT bayesian_artifacts_payload_byte_count_not_null NOT NULL,
+    lifecycle_status character varying(32) DEFAULT 'active'::character varying CONSTRAINT bayesian_artifacts_lifecycle_status_not_null NOT NULL,
+    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying CONSTRAINT bayesian_artifacts_policy_version_not_null NOT NULL,
     pruned_reason character varying(64),
-    pruned_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    pruned_metadata jsonb DEFAULT '{}'::jsonb CONSTRAINT bayesian_artifacts_pruned_metadata_not_null NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_updated_at_not_null NOT NULL,
     CONSTRAINT ck_bayesian_artifacts_artifact_hash_sha256 CHECK (((artifact_hash)::text ~ '^[a-f0-9]{64}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_ref_format CHECK (((artifact_ref)::text ~ '^b24://[a-z0-9][a-z0-9._/-]{1,240}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_type CHECK (((artifact_type)::text = ANY ((ARRAY['diagnostics'::character varying, 'summary'::character varying, 'source_manifest'::character varying, 'fit_metadata'::character varying, 'input_manifest'::character varying, 'model_spec'::character varying, 'posterior_summary'::character varying])::text[]))),
@@ -1436,29 +2095,34 @@ CREATE TABLE public.bayesian_artifacts_p00 (
 
 ALTER TABLE ONLY public.bayesian_artifacts_p00 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_artifacts_p01; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_artifacts_p01 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    fit_id uuid NOT NULL,
-    artifact_ref character varying(255) NOT NULL,
-    artifact_hash character varying(64) NOT NULL,
-    artifact_type character varying(32) NOT NULL,
-    storage_backend character varying(32) NOT NULL,
-    artifact_uri_internal character varying(1024) NOT NULL,
-    artifact_size_bytes bigint NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_artifacts_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_artifacts_tenant_id_not_null1 NOT NULL,
+    fit_id uuid CONSTRAINT bayesian_artifacts_fit_id_not_null1 NOT NULL,
+    artifact_ref character varying(255) CONSTRAINT bayesian_artifacts_artifact_ref_not_null1 NOT NULL,
+    artifact_hash character varying(64) CONSTRAINT bayesian_artifacts_artifact_hash_not_null1 NOT NULL,
+    artifact_type character varying(32) CONSTRAINT bayesian_artifacts_artifact_type_not_null1 NOT NULL,
+    storage_backend character varying(32) CONSTRAINT bayesian_artifacts_storage_backend_not_null1 NOT NULL,
+    artifact_uri_internal character varying(1024) CONSTRAINT bayesian_artifacts_artifact_uri_internal_not_null1 NOT NULL,
+    artifact_size_bytes bigint CONSTRAINT bayesian_artifacts_artifact_size_bytes_not_null1 NOT NULL,
     compression character varying(32),
-    retention_class character varying(32) NOT NULL,
+    retention_class character varying(32) CONSTRAINT bayesian_artifacts_retention_class_not_null1 NOT NULL,
     expires_at timestamp with time zone,
     pruned_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_created_at_not_null1 NOT NULL,
     payload_json jsonb,
     payload_bytes bytea,
-    payload_byte_count bigint DEFAULT 0 NOT NULL,
-    lifecycle_status character varying(32) DEFAULT 'active'::character varying NOT NULL,
-    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying NOT NULL,
+    payload_byte_count bigint DEFAULT 0 CONSTRAINT bayesian_artifacts_payload_byte_count_not_null NOT NULL,
+    lifecycle_status character varying(32) DEFAULT 'active'::character varying CONSTRAINT bayesian_artifacts_lifecycle_status_not_null NOT NULL,
+    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying CONSTRAINT bayesian_artifacts_policy_version_not_null NOT NULL,
     pruned_reason character varying(64),
-    pruned_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    pruned_metadata jsonb DEFAULT '{}'::jsonb CONSTRAINT bayesian_artifacts_pruned_metadata_not_null NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_updated_at_not_null NOT NULL,
     CONSTRAINT ck_bayesian_artifacts_artifact_hash_sha256 CHECK (((artifact_hash)::text ~ '^[a-f0-9]{64}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_ref_format CHECK (((artifact_ref)::text ~ '^b24://[a-z0-9][a-z0-9._/-]{1,240}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_type CHECK (((artifact_type)::text = ANY ((ARRAY['diagnostics'::character varying, 'summary'::character varying, 'source_manifest'::character varying, 'fit_metadata'::character varying, 'input_manifest'::character varying, 'model_spec'::character varying, 'posterior_summary'::character varying])::text[]))),
@@ -1480,29 +2144,34 @@ CREATE TABLE public.bayesian_artifacts_p01 (
 
 ALTER TABLE ONLY public.bayesian_artifacts_p01 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_artifacts_p02; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_artifacts_p02 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    fit_id uuid NOT NULL,
-    artifact_ref character varying(255) NOT NULL,
-    artifact_hash character varying(64) NOT NULL,
-    artifact_type character varying(32) NOT NULL,
-    storage_backend character varying(32) NOT NULL,
-    artifact_uri_internal character varying(1024) NOT NULL,
-    artifact_size_bytes bigint NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_artifacts_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_artifacts_tenant_id_not_null1 NOT NULL,
+    fit_id uuid CONSTRAINT bayesian_artifacts_fit_id_not_null1 NOT NULL,
+    artifact_ref character varying(255) CONSTRAINT bayesian_artifacts_artifact_ref_not_null1 NOT NULL,
+    artifact_hash character varying(64) CONSTRAINT bayesian_artifacts_artifact_hash_not_null1 NOT NULL,
+    artifact_type character varying(32) CONSTRAINT bayesian_artifacts_artifact_type_not_null1 NOT NULL,
+    storage_backend character varying(32) CONSTRAINT bayesian_artifacts_storage_backend_not_null1 NOT NULL,
+    artifact_uri_internal character varying(1024) CONSTRAINT bayesian_artifacts_artifact_uri_internal_not_null1 NOT NULL,
+    artifact_size_bytes bigint CONSTRAINT bayesian_artifacts_artifact_size_bytes_not_null1 NOT NULL,
     compression character varying(32),
-    retention_class character varying(32) NOT NULL,
+    retention_class character varying(32) CONSTRAINT bayesian_artifacts_retention_class_not_null1 NOT NULL,
     expires_at timestamp with time zone,
     pruned_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_created_at_not_null1 NOT NULL,
     payload_json jsonb,
     payload_bytes bytea,
-    payload_byte_count bigint DEFAULT 0 NOT NULL,
-    lifecycle_status character varying(32) DEFAULT 'active'::character varying NOT NULL,
-    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying NOT NULL,
+    payload_byte_count bigint DEFAULT 0 CONSTRAINT bayesian_artifacts_payload_byte_count_not_null NOT NULL,
+    lifecycle_status character varying(32) DEFAULT 'active'::character varying CONSTRAINT bayesian_artifacts_lifecycle_status_not_null NOT NULL,
+    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying CONSTRAINT bayesian_artifacts_policy_version_not_null NOT NULL,
     pruned_reason character varying(64),
-    pruned_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    pruned_metadata jsonb DEFAULT '{}'::jsonb CONSTRAINT bayesian_artifacts_pruned_metadata_not_null NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_updated_at_not_null NOT NULL,
     CONSTRAINT ck_bayesian_artifacts_artifact_hash_sha256 CHECK (((artifact_hash)::text ~ '^[a-f0-9]{64}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_ref_format CHECK (((artifact_ref)::text ~ '^b24://[a-z0-9][a-z0-9._/-]{1,240}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_type CHECK (((artifact_type)::text = ANY ((ARRAY['diagnostics'::character varying, 'summary'::character varying, 'source_manifest'::character varying, 'fit_metadata'::character varying, 'input_manifest'::character varying, 'model_spec'::character varying, 'posterior_summary'::character varying])::text[]))),
@@ -1524,29 +2193,34 @@ CREATE TABLE public.bayesian_artifacts_p02 (
 
 ALTER TABLE ONLY public.bayesian_artifacts_p02 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_artifacts_p03; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_artifacts_p03 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    fit_id uuid NOT NULL,
-    artifact_ref character varying(255) NOT NULL,
-    artifact_hash character varying(64) NOT NULL,
-    artifact_type character varying(32) NOT NULL,
-    storage_backend character varying(32) NOT NULL,
-    artifact_uri_internal character varying(1024) NOT NULL,
-    artifact_size_bytes bigint NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_artifacts_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_artifacts_tenant_id_not_null1 NOT NULL,
+    fit_id uuid CONSTRAINT bayesian_artifacts_fit_id_not_null1 NOT NULL,
+    artifact_ref character varying(255) CONSTRAINT bayesian_artifacts_artifact_ref_not_null1 NOT NULL,
+    artifact_hash character varying(64) CONSTRAINT bayesian_artifacts_artifact_hash_not_null1 NOT NULL,
+    artifact_type character varying(32) CONSTRAINT bayesian_artifacts_artifact_type_not_null1 NOT NULL,
+    storage_backend character varying(32) CONSTRAINT bayesian_artifacts_storage_backend_not_null1 NOT NULL,
+    artifact_uri_internal character varying(1024) CONSTRAINT bayesian_artifacts_artifact_uri_internal_not_null1 NOT NULL,
+    artifact_size_bytes bigint CONSTRAINT bayesian_artifacts_artifact_size_bytes_not_null1 NOT NULL,
     compression character varying(32),
-    retention_class character varying(32) NOT NULL,
+    retention_class character varying(32) CONSTRAINT bayesian_artifacts_retention_class_not_null1 NOT NULL,
     expires_at timestamp with time zone,
     pruned_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_created_at_not_null1 NOT NULL,
     payload_json jsonb,
     payload_bytes bytea,
-    payload_byte_count bigint DEFAULT 0 NOT NULL,
-    lifecycle_status character varying(32) DEFAULT 'active'::character varying NOT NULL,
-    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying NOT NULL,
+    payload_byte_count bigint DEFAULT 0 CONSTRAINT bayesian_artifacts_payload_byte_count_not_null NOT NULL,
+    lifecycle_status character varying(32) DEFAULT 'active'::character varying CONSTRAINT bayesian_artifacts_lifecycle_status_not_null NOT NULL,
+    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying CONSTRAINT bayesian_artifacts_policy_version_not_null NOT NULL,
     pruned_reason character varying(64),
-    pruned_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    pruned_metadata jsonb DEFAULT '{}'::jsonb CONSTRAINT bayesian_artifacts_pruned_metadata_not_null NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_updated_at_not_null NOT NULL,
     CONSTRAINT ck_bayesian_artifacts_artifact_hash_sha256 CHECK (((artifact_hash)::text ~ '^[a-f0-9]{64}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_ref_format CHECK (((artifact_ref)::text ~ '^b24://[a-z0-9][a-z0-9._/-]{1,240}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_type CHECK (((artifact_type)::text = ANY ((ARRAY['diagnostics'::character varying, 'summary'::character varying, 'source_manifest'::character varying, 'fit_metadata'::character varying, 'input_manifest'::character varying, 'model_spec'::character varying, 'posterior_summary'::character varying])::text[]))),
@@ -1568,29 +2242,34 @@ CREATE TABLE public.bayesian_artifacts_p03 (
 
 ALTER TABLE ONLY public.bayesian_artifacts_p03 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_artifacts_p04; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_artifacts_p04 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    fit_id uuid NOT NULL,
-    artifact_ref character varying(255) NOT NULL,
-    artifact_hash character varying(64) NOT NULL,
-    artifact_type character varying(32) NOT NULL,
-    storage_backend character varying(32) NOT NULL,
-    artifact_uri_internal character varying(1024) NOT NULL,
-    artifact_size_bytes bigint NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_artifacts_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_artifacts_tenant_id_not_null1 NOT NULL,
+    fit_id uuid CONSTRAINT bayesian_artifacts_fit_id_not_null1 NOT NULL,
+    artifact_ref character varying(255) CONSTRAINT bayesian_artifacts_artifact_ref_not_null1 NOT NULL,
+    artifact_hash character varying(64) CONSTRAINT bayesian_artifacts_artifact_hash_not_null1 NOT NULL,
+    artifact_type character varying(32) CONSTRAINT bayesian_artifacts_artifact_type_not_null1 NOT NULL,
+    storage_backend character varying(32) CONSTRAINT bayesian_artifacts_storage_backend_not_null1 NOT NULL,
+    artifact_uri_internal character varying(1024) CONSTRAINT bayesian_artifacts_artifact_uri_internal_not_null1 NOT NULL,
+    artifact_size_bytes bigint CONSTRAINT bayesian_artifacts_artifact_size_bytes_not_null1 NOT NULL,
     compression character varying(32),
-    retention_class character varying(32) NOT NULL,
+    retention_class character varying(32) CONSTRAINT bayesian_artifacts_retention_class_not_null1 NOT NULL,
     expires_at timestamp with time zone,
     pruned_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_created_at_not_null1 NOT NULL,
     payload_json jsonb,
     payload_bytes bytea,
-    payload_byte_count bigint DEFAULT 0 NOT NULL,
-    lifecycle_status character varying(32) DEFAULT 'active'::character varying NOT NULL,
-    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying NOT NULL,
+    payload_byte_count bigint DEFAULT 0 CONSTRAINT bayesian_artifacts_payload_byte_count_not_null NOT NULL,
+    lifecycle_status character varying(32) DEFAULT 'active'::character varying CONSTRAINT bayesian_artifacts_lifecycle_status_not_null NOT NULL,
+    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying CONSTRAINT bayesian_artifacts_policy_version_not_null NOT NULL,
     pruned_reason character varying(64),
-    pruned_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    pruned_metadata jsonb DEFAULT '{}'::jsonb CONSTRAINT bayesian_artifacts_pruned_metadata_not_null NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_updated_at_not_null NOT NULL,
     CONSTRAINT ck_bayesian_artifacts_artifact_hash_sha256 CHECK (((artifact_hash)::text ~ '^[a-f0-9]{64}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_ref_format CHECK (((artifact_ref)::text ~ '^b24://[a-z0-9][a-z0-9._/-]{1,240}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_type CHECK (((artifact_type)::text = ANY ((ARRAY['diagnostics'::character varying, 'summary'::character varying, 'source_manifest'::character varying, 'fit_metadata'::character varying, 'input_manifest'::character varying, 'model_spec'::character varying, 'posterior_summary'::character varying])::text[]))),
@@ -1612,29 +2291,34 @@ CREATE TABLE public.bayesian_artifacts_p04 (
 
 ALTER TABLE ONLY public.bayesian_artifacts_p04 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_artifacts_p05; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_artifacts_p05 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    fit_id uuid NOT NULL,
-    artifact_ref character varying(255) NOT NULL,
-    artifact_hash character varying(64) NOT NULL,
-    artifact_type character varying(32) NOT NULL,
-    storage_backend character varying(32) NOT NULL,
-    artifact_uri_internal character varying(1024) NOT NULL,
-    artifact_size_bytes bigint NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_artifacts_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_artifacts_tenant_id_not_null1 NOT NULL,
+    fit_id uuid CONSTRAINT bayesian_artifacts_fit_id_not_null1 NOT NULL,
+    artifact_ref character varying(255) CONSTRAINT bayesian_artifacts_artifact_ref_not_null1 NOT NULL,
+    artifact_hash character varying(64) CONSTRAINT bayesian_artifacts_artifact_hash_not_null1 NOT NULL,
+    artifact_type character varying(32) CONSTRAINT bayesian_artifacts_artifact_type_not_null1 NOT NULL,
+    storage_backend character varying(32) CONSTRAINT bayesian_artifacts_storage_backend_not_null1 NOT NULL,
+    artifact_uri_internal character varying(1024) CONSTRAINT bayesian_artifacts_artifact_uri_internal_not_null1 NOT NULL,
+    artifact_size_bytes bigint CONSTRAINT bayesian_artifacts_artifact_size_bytes_not_null1 NOT NULL,
     compression character varying(32),
-    retention_class character varying(32) NOT NULL,
+    retention_class character varying(32) CONSTRAINT bayesian_artifacts_retention_class_not_null1 NOT NULL,
     expires_at timestamp with time zone,
     pruned_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_created_at_not_null1 NOT NULL,
     payload_json jsonb,
     payload_bytes bytea,
-    payload_byte_count bigint DEFAULT 0 NOT NULL,
-    lifecycle_status character varying(32) DEFAULT 'active'::character varying NOT NULL,
-    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying NOT NULL,
+    payload_byte_count bigint DEFAULT 0 CONSTRAINT bayesian_artifacts_payload_byte_count_not_null NOT NULL,
+    lifecycle_status character varying(32) DEFAULT 'active'::character varying CONSTRAINT bayesian_artifacts_lifecycle_status_not_null NOT NULL,
+    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying CONSTRAINT bayesian_artifacts_policy_version_not_null NOT NULL,
     pruned_reason character varying(64),
-    pruned_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    pruned_metadata jsonb DEFAULT '{}'::jsonb CONSTRAINT bayesian_artifacts_pruned_metadata_not_null NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_updated_at_not_null NOT NULL,
     CONSTRAINT ck_bayesian_artifacts_artifact_hash_sha256 CHECK (((artifact_hash)::text ~ '^[a-f0-9]{64}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_ref_format CHECK (((artifact_ref)::text ~ '^b24://[a-z0-9][a-z0-9._/-]{1,240}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_type CHECK (((artifact_type)::text = ANY ((ARRAY['diagnostics'::character varying, 'summary'::character varying, 'source_manifest'::character varying, 'fit_metadata'::character varying, 'input_manifest'::character varying, 'model_spec'::character varying, 'posterior_summary'::character varying])::text[]))),
@@ -1656,29 +2340,34 @@ CREATE TABLE public.bayesian_artifacts_p05 (
 
 ALTER TABLE ONLY public.bayesian_artifacts_p05 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_artifacts_p06; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_artifacts_p06 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    fit_id uuid NOT NULL,
-    artifact_ref character varying(255) NOT NULL,
-    artifact_hash character varying(64) NOT NULL,
-    artifact_type character varying(32) NOT NULL,
-    storage_backend character varying(32) NOT NULL,
-    artifact_uri_internal character varying(1024) NOT NULL,
-    artifact_size_bytes bigint NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_artifacts_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_artifacts_tenant_id_not_null1 NOT NULL,
+    fit_id uuid CONSTRAINT bayesian_artifacts_fit_id_not_null1 NOT NULL,
+    artifact_ref character varying(255) CONSTRAINT bayesian_artifacts_artifact_ref_not_null1 NOT NULL,
+    artifact_hash character varying(64) CONSTRAINT bayesian_artifacts_artifact_hash_not_null1 NOT NULL,
+    artifact_type character varying(32) CONSTRAINT bayesian_artifacts_artifact_type_not_null1 NOT NULL,
+    storage_backend character varying(32) CONSTRAINT bayesian_artifacts_storage_backend_not_null1 NOT NULL,
+    artifact_uri_internal character varying(1024) CONSTRAINT bayesian_artifacts_artifact_uri_internal_not_null1 NOT NULL,
+    artifact_size_bytes bigint CONSTRAINT bayesian_artifacts_artifact_size_bytes_not_null1 NOT NULL,
     compression character varying(32),
-    retention_class character varying(32) NOT NULL,
+    retention_class character varying(32) CONSTRAINT bayesian_artifacts_retention_class_not_null1 NOT NULL,
     expires_at timestamp with time zone,
     pruned_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_created_at_not_null1 NOT NULL,
     payload_json jsonb,
     payload_bytes bytea,
-    payload_byte_count bigint DEFAULT 0 NOT NULL,
-    lifecycle_status character varying(32) DEFAULT 'active'::character varying NOT NULL,
-    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying NOT NULL,
+    payload_byte_count bigint DEFAULT 0 CONSTRAINT bayesian_artifacts_payload_byte_count_not_null NOT NULL,
+    lifecycle_status character varying(32) DEFAULT 'active'::character varying CONSTRAINT bayesian_artifacts_lifecycle_status_not_null NOT NULL,
+    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying CONSTRAINT bayesian_artifacts_policy_version_not_null NOT NULL,
     pruned_reason character varying(64),
-    pruned_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    pruned_metadata jsonb DEFAULT '{}'::jsonb CONSTRAINT bayesian_artifacts_pruned_metadata_not_null NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_updated_at_not_null NOT NULL,
     CONSTRAINT ck_bayesian_artifacts_artifact_hash_sha256 CHECK (((artifact_hash)::text ~ '^[a-f0-9]{64}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_ref_format CHECK (((artifact_ref)::text ~ '^b24://[a-z0-9][a-z0-9._/-]{1,240}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_type CHECK (((artifact_type)::text = ANY ((ARRAY['diagnostics'::character varying, 'summary'::character varying, 'source_manifest'::character varying, 'fit_metadata'::character varying, 'input_manifest'::character varying, 'model_spec'::character varying, 'posterior_summary'::character varying])::text[]))),
@@ -1700,29 +2389,34 @@ CREATE TABLE public.bayesian_artifacts_p06 (
 
 ALTER TABLE ONLY public.bayesian_artifacts_p06 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_artifacts_p07; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_artifacts_p07 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    fit_id uuid NOT NULL,
-    artifact_ref character varying(255) NOT NULL,
-    artifact_hash character varying(64) NOT NULL,
-    artifact_type character varying(32) NOT NULL,
-    storage_backend character varying(32) NOT NULL,
-    artifact_uri_internal character varying(1024) NOT NULL,
-    artifact_size_bytes bigint NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_artifacts_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_artifacts_tenant_id_not_null1 NOT NULL,
+    fit_id uuid CONSTRAINT bayesian_artifacts_fit_id_not_null1 NOT NULL,
+    artifact_ref character varying(255) CONSTRAINT bayesian_artifacts_artifact_ref_not_null1 NOT NULL,
+    artifact_hash character varying(64) CONSTRAINT bayesian_artifacts_artifact_hash_not_null1 NOT NULL,
+    artifact_type character varying(32) CONSTRAINT bayesian_artifacts_artifact_type_not_null1 NOT NULL,
+    storage_backend character varying(32) CONSTRAINT bayesian_artifacts_storage_backend_not_null1 NOT NULL,
+    artifact_uri_internal character varying(1024) CONSTRAINT bayesian_artifacts_artifact_uri_internal_not_null1 NOT NULL,
+    artifact_size_bytes bigint CONSTRAINT bayesian_artifacts_artifact_size_bytes_not_null1 NOT NULL,
     compression character varying(32),
-    retention_class character varying(32) NOT NULL,
+    retention_class character varying(32) CONSTRAINT bayesian_artifacts_retention_class_not_null1 NOT NULL,
     expires_at timestamp with time zone,
     pruned_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_created_at_not_null1 NOT NULL,
     payload_json jsonb,
     payload_bytes bytea,
-    payload_byte_count bigint DEFAULT 0 NOT NULL,
-    lifecycle_status character varying(32) DEFAULT 'active'::character varying NOT NULL,
-    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying NOT NULL,
+    payload_byte_count bigint DEFAULT 0 CONSTRAINT bayesian_artifacts_payload_byte_count_not_null NOT NULL,
+    lifecycle_status character varying(32) DEFAULT 'active'::character varying CONSTRAINT bayesian_artifacts_lifecycle_status_not_null NOT NULL,
+    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying CONSTRAINT bayesian_artifacts_policy_version_not_null NOT NULL,
     pruned_reason character varying(64),
-    pruned_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    pruned_metadata jsonb DEFAULT '{}'::jsonb CONSTRAINT bayesian_artifacts_pruned_metadata_not_null NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_updated_at_not_null NOT NULL,
     CONSTRAINT ck_bayesian_artifacts_artifact_hash_sha256 CHECK (((artifact_hash)::text ~ '^[a-f0-9]{64}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_ref_format CHECK (((artifact_ref)::text ~ '^b24://[a-z0-9][a-z0-9._/-]{1,240}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_type CHECK (((artifact_type)::text = ANY ((ARRAY['diagnostics'::character varying, 'summary'::character varying, 'source_manifest'::character varying, 'fit_metadata'::character varying, 'input_manifest'::character varying, 'model_spec'::character varying, 'posterior_summary'::character varying])::text[]))),
@@ -1744,29 +2438,34 @@ CREATE TABLE public.bayesian_artifacts_p07 (
 
 ALTER TABLE ONLY public.bayesian_artifacts_p07 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_artifacts_p08; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_artifacts_p08 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    fit_id uuid NOT NULL,
-    artifact_ref character varying(255) NOT NULL,
-    artifact_hash character varying(64) NOT NULL,
-    artifact_type character varying(32) NOT NULL,
-    storage_backend character varying(32) NOT NULL,
-    artifact_uri_internal character varying(1024) NOT NULL,
-    artifact_size_bytes bigint NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_artifacts_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_artifacts_tenant_id_not_null1 NOT NULL,
+    fit_id uuid CONSTRAINT bayesian_artifacts_fit_id_not_null1 NOT NULL,
+    artifact_ref character varying(255) CONSTRAINT bayesian_artifacts_artifact_ref_not_null1 NOT NULL,
+    artifact_hash character varying(64) CONSTRAINT bayesian_artifacts_artifact_hash_not_null1 NOT NULL,
+    artifact_type character varying(32) CONSTRAINT bayesian_artifacts_artifact_type_not_null1 NOT NULL,
+    storage_backend character varying(32) CONSTRAINT bayesian_artifacts_storage_backend_not_null1 NOT NULL,
+    artifact_uri_internal character varying(1024) CONSTRAINT bayesian_artifacts_artifact_uri_internal_not_null1 NOT NULL,
+    artifact_size_bytes bigint CONSTRAINT bayesian_artifacts_artifact_size_bytes_not_null1 NOT NULL,
     compression character varying(32),
-    retention_class character varying(32) NOT NULL,
+    retention_class character varying(32) CONSTRAINT bayesian_artifacts_retention_class_not_null1 NOT NULL,
     expires_at timestamp with time zone,
     pruned_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_created_at_not_null1 NOT NULL,
     payload_json jsonb,
     payload_bytes bytea,
-    payload_byte_count bigint DEFAULT 0 NOT NULL,
-    lifecycle_status character varying(32) DEFAULT 'active'::character varying NOT NULL,
-    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying NOT NULL,
+    payload_byte_count bigint DEFAULT 0 CONSTRAINT bayesian_artifacts_payload_byte_count_not_null NOT NULL,
+    lifecycle_status character varying(32) DEFAULT 'active'::character varying CONSTRAINT bayesian_artifacts_lifecycle_status_not_null NOT NULL,
+    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying CONSTRAINT bayesian_artifacts_policy_version_not_null NOT NULL,
     pruned_reason character varying(64),
-    pruned_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    pruned_metadata jsonb DEFAULT '{}'::jsonb CONSTRAINT bayesian_artifacts_pruned_metadata_not_null NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_updated_at_not_null NOT NULL,
     CONSTRAINT ck_bayesian_artifacts_artifact_hash_sha256 CHECK (((artifact_hash)::text ~ '^[a-f0-9]{64}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_ref_format CHECK (((artifact_ref)::text ~ '^b24://[a-z0-9][a-z0-9._/-]{1,240}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_type CHECK (((artifact_type)::text = ANY ((ARRAY['diagnostics'::character varying, 'summary'::character varying, 'source_manifest'::character varying, 'fit_metadata'::character varying, 'input_manifest'::character varying, 'model_spec'::character varying, 'posterior_summary'::character varying])::text[]))),
@@ -1788,29 +2487,34 @@ CREATE TABLE public.bayesian_artifacts_p08 (
 
 ALTER TABLE ONLY public.bayesian_artifacts_p08 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_artifacts_p09; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_artifacts_p09 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    fit_id uuid NOT NULL,
-    artifact_ref character varying(255) NOT NULL,
-    artifact_hash character varying(64) NOT NULL,
-    artifact_type character varying(32) NOT NULL,
-    storage_backend character varying(32) NOT NULL,
-    artifact_uri_internal character varying(1024) NOT NULL,
-    artifact_size_bytes bigint NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_artifacts_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_artifacts_tenant_id_not_null1 NOT NULL,
+    fit_id uuid CONSTRAINT bayesian_artifacts_fit_id_not_null1 NOT NULL,
+    artifact_ref character varying(255) CONSTRAINT bayesian_artifacts_artifact_ref_not_null1 NOT NULL,
+    artifact_hash character varying(64) CONSTRAINT bayesian_artifacts_artifact_hash_not_null1 NOT NULL,
+    artifact_type character varying(32) CONSTRAINT bayesian_artifacts_artifact_type_not_null1 NOT NULL,
+    storage_backend character varying(32) CONSTRAINT bayesian_artifacts_storage_backend_not_null1 NOT NULL,
+    artifact_uri_internal character varying(1024) CONSTRAINT bayesian_artifacts_artifact_uri_internal_not_null1 NOT NULL,
+    artifact_size_bytes bigint CONSTRAINT bayesian_artifacts_artifact_size_bytes_not_null1 NOT NULL,
     compression character varying(32),
-    retention_class character varying(32) NOT NULL,
+    retention_class character varying(32) CONSTRAINT bayesian_artifacts_retention_class_not_null1 NOT NULL,
     expires_at timestamp with time zone,
     pruned_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_created_at_not_null1 NOT NULL,
     payload_json jsonb,
     payload_bytes bytea,
-    payload_byte_count bigint DEFAULT 0 NOT NULL,
-    lifecycle_status character varying(32) DEFAULT 'active'::character varying NOT NULL,
-    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying NOT NULL,
+    payload_byte_count bigint DEFAULT 0 CONSTRAINT bayesian_artifacts_payload_byte_count_not_null NOT NULL,
+    lifecycle_status character varying(32) DEFAULT 'active'::character varying CONSTRAINT bayesian_artifacts_lifecycle_status_not_null NOT NULL,
+    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying CONSTRAINT bayesian_artifacts_policy_version_not_null NOT NULL,
     pruned_reason character varying(64),
-    pruned_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    pruned_metadata jsonb DEFAULT '{}'::jsonb CONSTRAINT bayesian_artifacts_pruned_metadata_not_null NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_updated_at_not_null NOT NULL,
     CONSTRAINT ck_bayesian_artifacts_artifact_hash_sha256 CHECK (((artifact_hash)::text ~ '^[a-f0-9]{64}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_ref_format CHECK (((artifact_ref)::text ~ '^b24://[a-z0-9][a-z0-9._/-]{1,240}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_type CHECK (((artifact_type)::text = ANY ((ARRAY['diagnostics'::character varying, 'summary'::character varying, 'source_manifest'::character varying, 'fit_metadata'::character varying, 'input_manifest'::character varying, 'model_spec'::character varying, 'posterior_summary'::character varying])::text[]))),
@@ -1832,29 +2536,34 @@ CREATE TABLE public.bayesian_artifacts_p09 (
 
 ALTER TABLE ONLY public.bayesian_artifacts_p09 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_artifacts_p10; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_artifacts_p10 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    fit_id uuid NOT NULL,
-    artifact_ref character varying(255) NOT NULL,
-    artifact_hash character varying(64) NOT NULL,
-    artifact_type character varying(32) NOT NULL,
-    storage_backend character varying(32) NOT NULL,
-    artifact_uri_internal character varying(1024) NOT NULL,
-    artifact_size_bytes bigint NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_artifacts_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_artifacts_tenant_id_not_null1 NOT NULL,
+    fit_id uuid CONSTRAINT bayesian_artifacts_fit_id_not_null1 NOT NULL,
+    artifact_ref character varying(255) CONSTRAINT bayesian_artifacts_artifact_ref_not_null1 NOT NULL,
+    artifact_hash character varying(64) CONSTRAINT bayesian_artifacts_artifact_hash_not_null1 NOT NULL,
+    artifact_type character varying(32) CONSTRAINT bayesian_artifacts_artifact_type_not_null1 NOT NULL,
+    storage_backend character varying(32) CONSTRAINT bayesian_artifacts_storage_backend_not_null1 NOT NULL,
+    artifact_uri_internal character varying(1024) CONSTRAINT bayesian_artifacts_artifact_uri_internal_not_null1 NOT NULL,
+    artifact_size_bytes bigint CONSTRAINT bayesian_artifacts_artifact_size_bytes_not_null1 NOT NULL,
     compression character varying(32),
-    retention_class character varying(32) NOT NULL,
+    retention_class character varying(32) CONSTRAINT bayesian_artifacts_retention_class_not_null1 NOT NULL,
     expires_at timestamp with time zone,
     pruned_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_created_at_not_null1 NOT NULL,
     payload_json jsonb,
     payload_bytes bytea,
-    payload_byte_count bigint DEFAULT 0 NOT NULL,
-    lifecycle_status character varying(32) DEFAULT 'active'::character varying NOT NULL,
-    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying NOT NULL,
+    payload_byte_count bigint DEFAULT 0 CONSTRAINT bayesian_artifacts_payload_byte_count_not_null NOT NULL,
+    lifecycle_status character varying(32) DEFAULT 'active'::character varying CONSTRAINT bayesian_artifacts_lifecycle_status_not_null NOT NULL,
+    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying CONSTRAINT bayesian_artifacts_policy_version_not_null NOT NULL,
     pruned_reason character varying(64),
-    pruned_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    pruned_metadata jsonb DEFAULT '{}'::jsonb CONSTRAINT bayesian_artifacts_pruned_metadata_not_null NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_updated_at_not_null NOT NULL,
     CONSTRAINT ck_bayesian_artifacts_artifact_hash_sha256 CHECK (((artifact_hash)::text ~ '^[a-f0-9]{64}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_ref_format CHECK (((artifact_ref)::text ~ '^b24://[a-z0-9][a-z0-9._/-]{1,240}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_type CHECK (((artifact_type)::text = ANY ((ARRAY['diagnostics'::character varying, 'summary'::character varying, 'source_manifest'::character varying, 'fit_metadata'::character varying, 'input_manifest'::character varying, 'model_spec'::character varying, 'posterior_summary'::character varying])::text[]))),
@@ -1876,29 +2585,34 @@ CREATE TABLE public.bayesian_artifacts_p10 (
 
 ALTER TABLE ONLY public.bayesian_artifacts_p10 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_artifacts_p11; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_artifacts_p11 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    fit_id uuid NOT NULL,
-    artifact_ref character varying(255) NOT NULL,
-    artifact_hash character varying(64) NOT NULL,
-    artifact_type character varying(32) NOT NULL,
-    storage_backend character varying(32) NOT NULL,
-    artifact_uri_internal character varying(1024) NOT NULL,
-    artifact_size_bytes bigint NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_artifacts_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_artifacts_tenant_id_not_null1 NOT NULL,
+    fit_id uuid CONSTRAINT bayesian_artifacts_fit_id_not_null1 NOT NULL,
+    artifact_ref character varying(255) CONSTRAINT bayesian_artifacts_artifact_ref_not_null1 NOT NULL,
+    artifact_hash character varying(64) CONSTRAINT bayesian_artifacts_artifact_hash_not_null1 NOT NULL,
+    artifact_type character varying(32) CONSTRAINT bayesian_artifacts_artifact_type_not_null1 NOT NULL,
+    storage_backend character varying(32) CONSTRAINT bayesian_artifacts_storage_backend_not_null1 NOT NULL,
+    artifact_uri_internal character varying(1024) CONSTRAINT bayesian_artifacts_artifact_uri_internal_not_null1 NOT NULL,
+    artifact_size_bytes bigint CONSTRAINT bayesian_artifacts_artifact_size_bytes_not_null1 NOT NULL,
     compression character varying(32),
-    retention_class character varying(32) NOT NULL,
+    retention_class character varying(32) CONSTRAINT bayesian_artifacts_retention_class_not_null1 NOT NULL,
     expires_at timestamp with time zone,
     pruned_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_created_at_not_null1 NOT NULL,
     payload_json jsonb,
     payload_bytes bytea,
-    payload_byte_count bigint DEFAULT 0 NOT NULL,
-    lifecycle_status character varying(32) DEFAULT 'active'::character varying NOT NULL,
-    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying NOT NULL,
+    payload_byte_count bigint DEFAULT 0 CONSTRAINT bayesian_artifacts_payload_byte_count_not_null NOT NULL,
+    lifecycle_status character varying(32) DEFAULT 'active'::character varying CONSTRAINT bayesian_artifacts_lifecycle_status_not_null NOT NULL,
+    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying CONSTRAINT bayesian_artifacts_policy_version_not_null NOT NULL,
     pruned_reason character varying(64),
-    pruned_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    pruned_metadata jsonb DEFAULT '{}'::jsonb CONSTRAINT bayesian_artifacts_pruned_metadata_not_null NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_updated_at_not_null NOT NULL,
     CONSTRAINT ck_bayesian_artifacts_artifact_hash_sha256 CHECK (((artifact_hash)::text ~ '^[a-f0-9]{64}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_ref_format CHECK (((artifact_ref)::text ~ '^b24://[a-z0-9][a-z0-9._/-]{1,240}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_type CHECK (((artifact_type)::text = ANY ((ARRAY['diagnostics'::character varying, 'summary'::character varying, 'source_manifest'::character varying, 'fit_metadata'::character varying, 'input_manifest'::character varying, 'model_spec'::character varying, 'posterior_summary'::character varying])::text[]))),
@@ -1920,29 +2634,34 @@ CREATE TABLE public.bayesian_artifacts_p11 (
 
 ALTER TABLE ONLY public.bayesian_artifacts_p11 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_artifacts_p12; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_artifacts_p12 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    fit_id uuid NOT NULL,
-    artifact_ref character varying(255) NOT NULL,
-    artifact_hash character varying(64) NOT NULL,
-    artifact_type character varying(32) NOT NULL,
-    storage_backend character varying(32) NOT NULL,
-    artifact_uri_internal character varying(1024) NOT NULL,
-    artifact_size_bytes bigint NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_artifacts_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_artifacts_tenant_id_not_null1 NOT NULL,
+    fit_id uuid CONSTRAINT bayesian_artifacts_fit_id_not_null1 NOT NULL,
+    artifact_ref character varying(255) CONSTRAINT bayesian_artifacts_artifact_ref_not_null1 NOT NULL,
+    artifact_hash character varying(64) CONSTRAINT bayesian_artifacts_artifact_hash_not_null1 NOT NULL,
+    artifact_type character varying(32) CONSTRAINT bayesian_artifacts_artifact_type_not_null1 NOT NULL,
+    storage_backend character varying(32) CONSTRAINT bayesian_artifacts_storage_backend_not_null1 NOT NULL,
+    artifact_uri_internal character varying(1024) CONSTRAINT bayesian_artifacts_artifact_uri_internal_not_null1 NOT NULL,
+    artifact_size_bytes bigint CONSTRAINT bayesian_artifacts_artifact_size_bytes_not_null1 NOT NULL,
     compression character varying(32),
-    retention_class character varying(32) NOT NULL,
+    retention_class character varying(32) CONSTRAINT bayesian_artifacts_retention_class_not_null1 NOT NULL,
     expires_at timestamp with time zone,
     pruned_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_created_at_not_null1 NOT NULL,
     payload_json jsonb,
     payload_bytes bytea,
-    payload_byte_count bigint DEFAULT 0 NOT NULL,
-    lifecycle_status character varying(32) DEFAULT 'active'::character varying NOT NULL,
-    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying NOT NULL,
+    payload_byte_count bigint DEFAULT 0 CONSTRAINT bayesian_artifacts_payload_byte_count_not_null NOT NULL,
+    lifecycle_status character varying(32) DEFAULT 'active'::character varying CONSTRAINT bayesian_artifacts_lifecycle_status_not_null NOT NULL,
+    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying CONSTRAINT bayesian_artifacts_policy_version_not_null NOT NULL,
     pruned_reason character varying(64),
-    pruned_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    pruned_metadata jsonb DEFAULT '{}'::jsonb CONSTRAINT bayesian_artifacts_pruned_metadata_not_null NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_updated_at_not_null NOT NULL,
     CONSTRAINT ck_bayesian_artifacts_artifact_hash_sha256 CHECK (((artifact_hash)::text ~ '^[a-f0-9]{64}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_ref_format CHECK (((artifact_ref)::text ~ '^b24://[a-z0-9][a-z0-9._/-]{1,240}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_type CHECK (((artifact_type)::text = ANY ((ARRAY['diagnostics'::character varying, 'summary'::character varying, 'source_manifest'::character varying, 'fit_metadata'::character varying, 'input_manifest'::character varying, 'model_spec'::character varying, 'posterior_summary'::character varying])::text[]))),
@@ -1964,29 +2683,34 @@ CREATE TABLE public.bayesian_artifacts_p12 (
 
 ALTER TABLE ONLY public.bayesian_artifacts_p12 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_artifacts_p13; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_artifacts_p13 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    fit_id uuid NOT NULL,
-    artifact_ref character varying(255) NOT NULL,
-    artifact_hash character varying(64) NOT NULL,
-    artifact_type character varying(32) NOT NULL,
-    storage_backend character varying(32) NOT NULL,
-    artifact_uri_internal character varying(1024) NOT NULL,
-    artifact_size_bytes bigint NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_artifacts_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_artifacts_tenant_id_not_null1 NOT NULL,
+    fit_id uuid CONSTRAINT bayesian_artifacts_fit_id_not_null1 NOT NULL,
+    artifact_ref character varying(255) CONSTRAINT bayesian_artifacts_artifact_ref_not_null1 NOT NULL,
+    artifact_hash character varying(64) CONSTRAINT bayesian_artifacts_artifact_hash_not_null1 NOT NULL,
+    artifact_type character varying(32) CONSTRAINT bayesian_artifacts_artifact_type_not_null1 NOT NULL,
+    storage_backend character varying(32) CONSTRAINT bayesian_artifacts_storage_backend_not_null1 NOT NULL,
+    artifact_uri_internal character varying(1024) CONSTRAINT bayesian_artifacts_artifact_uri_internal_not_null1 NOT NULL,
+    artifact_size_bytes bigint CONSTRAINT bayesian_artifacts_artifact_size_bytes_not_null1 NOT NULL,
     compression character varying(32),
-    retention_class character varying(32) NOT NULL,
+    retention_class character varying(32) CONSTRAINT bayesian_artifacts_retention_class_not_null1 NOT NULL,
     expires_at timestamp with time zone,
     pruned_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_created_at_not_null1 NOT NULL,
     payload_json jsonb,
     payload_bytes bytea,
-    payload_byte_count bigint DEFAULT 0 NOT NULL,
-    lifecycle_status character varying(32) DEFAULT 'active'::character varying NOT NULL,
-    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying NOT NULL,
+    payload_byte_count bigint DEFAULT 0 CONSTRAINT bayesian_artifacts_payload_byte_count_not_null NOT NULL,
+    lifecycle_status character varying(32) DEFAULT 'active'::character varying CONSTRAINT bayesian_artifacts_lifecycle_status_not_null NOT NULL,
+    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying CONSTRAINT bayesian_artifacts_policy_version_not_null NOT NULL,
     pruned_reason character varying(64),
-    pruned_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    pruned_metadata jsonb DEFAULT '{}'::jsonb CONSTRAINT bayesian_artifacts_pruned_metadata_not_null NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_updated_at_not_null NOT NULL,
     CONSTRAINT ck_bayesian_artifacts_artifact_hash_sha256 CHECK (((artifact_hash)::text ~ '^[a-f0-9]{64}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_ref_format CHECK (((artifact_ref)::text ~ '^b24://[a-z0-9][a-z0-9._/-]{1,240}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_type CHECK (((artifact_type)::text = ANY ((ARRAY['diagnostics'::character varying, 'summary'::character varying, 'source_manifest'::character varying, 'fit_metadata'::character varying, 'input_manifest'::character varying, 'model_spec'::character varying, 'posterior_summary'::character varying])::text[]))),
@@ -2008,29 +2732,34 @@ CREATE TABLE public.bayesian_artifacts_p13 (
 
 ALTER TABLE ONLY public.bayesian_artifacts_p13 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_artifacts_p14; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_artifacts_p14 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    fit_id uuid NOT NULL,
-    artifact_ref character varying(255) NOT NULL,
-    artifact_hash character varying(64) NOT NULL,
-    artifact_type character varying(32) NOT NULL,
-    storage_backend character varying(32) NOT NULL,
-    artifact_uri_internal character varying(1024) NOT NULL,
-    artifact_size_bytes bigint NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_artifacts_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_artifacts_tenant_id_not_null1 NOT NULL,
+    fit_id uuid CONSTRAINT bayesian_artifacts_fit_id_not_null1 NOT NULL,
+    artifact_ref character varying(255) CONSTRAINT bayesian_artifacts_artifact_ref_not_null1 NOT NULL,
+    artifact_hash character varying(64) CONSTRAINT bayesian_artifacts_artifact_hash_not_null1 NOT NULL,
+    artifact_type character varying(32) CONSTRAINT bayesian_artifacts_artifact_type_not_null1 NOT NULL,
+    storage_backend character varying(32) CONSTRAINT bayesian_artifacts_storage_backend_not_null1 NOT NULL,
+    artifact_uri_internal character varying(1024) CONSTRAINT bayesian_artifacts_artifact_uri_internal_not_null1 NOT NULL,
+    artifact_size_bytes bigint CONSTRAINT bayesian_artifacts_artifact_size_bytes_not_null1 NOT NULL,
     compression character varying(32),
-    retention_class character varying(32) NOT NULL,
+    retention_class character varying(32) CONSTRAINT bayesian_artifacts_retention_class_not_null1 NOT NULL,
     expires_at timestamp with time zone,
     pruned_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_created_at_not_null1 NOT NULL,
     payload_json jsonb,
     payload_bytes bytea,
-    payload_byte_count bigint DEFAULT 0 NOT NULL,
-    lifecycle_status character varying(32) DEFAULT 'active'::character varying NOT NULL,
-    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying NOT NULL,
+    payload_byte_count bigint DEFAULT 0 CONSTRAINT bayesian_artifacts_payload_byte_count_not_null NOT NULL,
+    lifecycle_status character varying(32) DEFAULT 'active'::character varying CONSTRAINT bayesian_artifacts_lifecycle_status_not_null NOT NULL,
+    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying CONSTRAINT bayesian_artifacts_policy_version_not_null NOT NULL,
     pruned_reason character varying(64),
-    pruned_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    pruned_metadata jsonb DEFAULT '{}'::jsonb CONSTRAINT bayesian_artifacts_pruned_metadata_not_null NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_updated_at_not_null NOT NULL,
     CONSTRAINT ck_bayesian_artifacts_artifact_hash_sha256 CHECK (((artifact_hash)::text ~ '^[a-f0-9]{64}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_ref_format CHECK (((artifact_ref)::text ~ '^b24://[a-z0-9][a-z0-9._/-]{1,240}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_type CHECK (((artifact_type)::text = ANY ((ARRAY['diagnostics'::character varying, 'summary'::character varying, 'source_manifest'::character varying, 'fit_metadata'::character varying, 'input_manifest'::character varying, 'model_spec'::character varying, 'posterior_summary'::character varying])::text[]))),
@@ -2052,29 +2781,34 @@ CREATE TABLE public.bayesian_artifacts_p14 (
 
 ALTER TABLE ONLY public.bayesian_artifacts_p14 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_artifacts_p15; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_artifacts_p15 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    fit_id uuid NOT NULL,
-    artifact_ref character varying(255) NOT NULL,
-    artifact_hash character varying(64) NOT NULL,
-    artifact_type character varying(32) NOT NULL,
-    storage_backend character varying(32) NOT NULL,
-    artifact_uri_internal character varying(1024) NOT NULL,
-    artifact_size_bytes bigint NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_artifacts_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_artifacts_tenant_id_not_null1 NOT NULL,
+    fit_id uuid CONSTRAINT bayesian_artifacts_fit_id_not_null1 NOT NULL,
+    artifact_ref character varying(255) CONSTRAINT bayesian_artifacts_artifact_ref_not_null1 NOT NULL,
+    artifact_hash character varying(64) CONSTRAINT bayesian_artifacts_artifact_hash_not_null1 NOT NULL,
+    artifact_type character varying(32) CONSTRAINT bayesian_artifacts_artifact_type_not_null1 NOT NULL,
+    storage_backend character varying(32) CONSTRAINT bayesian_artifacts_storage_backend_not_null1 NOT NULL,
+    artifact_uri_internal character varying(1024) CONSTRAINT bayesian_artifacts_artifact_uri_internal_not_null1 NOT NULL,
+    artifact_size_bytes bigint CONSTRAINT bayesian_artifacts_artifact_size_bytes_not_null1 NOT NULL,
     compression character varying(32),
-    retention_class character varying(32) NOT NULL,
+    retention_class character varying(32) CONSTRAINT bayesian_artifacts_retention_class_not_null1 NOT NULL,
     expires_at timestamp with time zone,
     pruned_at timestamp with time zone,
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_created_at_not_null1 NOT NULL,
     payload_json jsonb,
     payload_bytes bytea,
-    payload_byte_count bigint DEFAULT 0 NOT NULL,
-    lifecycle_status character varying(32) DEFAULT 'active'::character varying NOT NULL,
-    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying NOT NULL,
+    payload_byte_count bigint DEFAULT 0 CONSTRAINT bayesian_artifacts_payload_byte_count_not_null NOT NULL,
+    lifecycle_status character varying(32) DEFAULT 'active'::character varying CONSTRAINT bayesian_artifacts_lifecycle_status_not_null NOT NULL,
+    policy_version character varying(64) DEFAULT 'b24-p8-artifact-policy-v1'::character varying CONSTRAINT bayesian_artifacts_policy_version_not_null NOT NULL,
     pruned_reason character varying(64),
-    pruned_metadata jsonb DEFAULT '{}'::jsonb NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    pruned_metadata jsonb DEFAULT '{}'::jsonb CONSTRAINT bayesian_artifacts_pruned_metadata_not_null NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_artifacts_updated_at_not_null NOT NULL,
     CONSTRAINT ck_bayesian_artifacts_artifact_hash_sha256 CHECK (((artifact_hash)::text ~ '^[a-f0-9]{64}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_ref_format CHECK (((artifact_ref)::text ~ '^b24://[a-z0-9][a-z0-9._/-]{1,240}$'::text)),
     CONSTRAINT ck_bayesian_artifacts_artifact_type CHECK (((artifact_type)::text = ANY ((ARRAY['diagnostics'::character varying, 'summary'::character varying, 'source_manifest'::character varying, 'fit_metadata'::character varying, 'input_manifest'::character varying, 'model_spec'::character varying, 'posterior_summary'::character varying])::text[]))),
@@ -2096,40 +2830,45 @@ CREATE TABLE public.bayesian_artifacts_p15 (
 
 ALTER TABLE ONLY public.bayesian_artifacts_p15 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_model_fits; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_model_fits (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    model_type character varying(64) NOT NULL,
-    model_version character varying(64) NOT NULL,
-    source_window_start timestamp with time zone NOT NULL,
-    source_window_end timestamp with time zone NOT NULL,
-    source_snapshot_hash character varying(64) NOT NULL,
-    status character varying(32) DEFAULT 'pending'::character varying NOT NULL,
-    eligibility_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    fallback_applied boolean DEFAULT false NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_model_fits_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_model_fits_tenant_id_not_null1 NOT NULL,
+    model_type character varying(64) CONSTRAINT bayesian_model_fits_model_type_not_null1 NOT NULL,
+    model_version character varying(64) CONSTRAINT bayesian_model_fits_model_version_not_null1 NOT NULL,
+    source_window_start timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_start_not_null1 NOT NULL,
+    source_window_end timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_end_not_null1 NOT NULL,
+    source_snapshot_hash character varying(64) CONSTRAINT bayesian_model_fits_source_snapshot_hash_not_null1 NOT NULL,
+    status character varying(32) DEFAULT 'pending'::character varying CONSTRAINT bayesian_model_fits_status_not_null1 NOT NULL,
+    eligibility_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_eligibility_status_not_null1 NOT NULL,
+    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_data_completeness_status_not_null1 NOT NULL,
+    fallback_applied boolean DEFAULT false CONSTRAINT bayesian_model_fits_fallback_applied_not_null1 NOT NULL,
     fallback_reason character varying(64),
     sampling_started_at timestamp with time zone,
     last_eligibility_check_at timestamp with time zone,
     last_fit_at timestamp with time zone,
     completed_at timestamp with time zone,
     runtime_seconds integer,
-    max_runtime_seconds integer DEFAULT 60 NOT NULL,
-    max_samples integer DEFAULT 0 NOT NULL,
-    max_cores integer DEFAULT 1 NOT NULL,
+    max_runtime_seconds integer DEFAULT 60 CONSTRAINT bayesian_model_fits_max_runtime_seconds_not_null1 NOT NULL,
+    max_samples integer DEFAULT 0 CONSTRAINT bayesian_model_fits_max_samples_not_null1 NOT NULL,
+    max_cores integer DEFAULT 1 CONSTRAINT bayesian_model_fits_max_cores_not_null1 NOT NULL,
     n_chains integer,
     n_samples_actual integer,
     r_hat_max double precision,
     ess_min double precision,
     divergence_count integer,
-    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying NOT NULL,
+    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying CONSTRAINT bayesian_model_fits_credible_interval_status_not_null1 NOT NULL,
     confidence_bucket character varying(32),
     confidence_bucket_reason character varying(255),
     confidence_policy_version character varying(64),
     artifact_ref character varying(255),
     artifact_hash character varying(64),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_created_at_not_null1 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_updated_at_not_null1 NOT NULL,
     hdi_lower double precision,
     hdi_upper double precision,
     interval_shape jsonb DEFAULT '[]'::jsonb NOT NULL,
@@ -2177,46 +2916,51 @@ PARTITION BY HASH (tenant_id);
 
 ALTER TABLE ONLY public.bayesian_model_fits FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_model_fits_p00; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_model_fits_p00 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    model_type character varying(64) NOT NULL,
-    model_version character varying(64) NOT NULL,
-    source_window_start timestamp with time zone NOT NULL,
-    source_window_end timestamp with time zone NOT NULL,
-    source_snapshot_hash character varying(64) NOT NULL,
-    status character varying(32) DEFAULT 'pending'::character varying NOT NULL,
-    eligibility_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    fallback_applied boolean DEFAULT false NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_model_fits_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_model_fits_tenant_id_not_null1 NOT NULL,
+    model_type character varying(64) CONSTRAINT bayesian_model_fits_model_type_not_null1 NOT NULL,
+    model_version character varying(64) CONSTRAINT bayesian_model_fits_model_version_not_null1 NOT NULL,
+    source_window_start timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_start_not_null1 NOT NULL,
+    source_window_end timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_end_not_null1 NOT NULL,
+    source_snapshot_hash character varying(64) CONSTRAINT bayesian_model_fits_source_snapshot_hash_not_null1 NOT NULL,
+    status character varying(32) DEFAULT 'pending'::character varying CONSTRAINT bayesian_model_fits_status_not_null1 NOT NULL,
+    eligibility_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_eligibility_status_not_null1 NOT NULL,
+    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_data_completeness_status_not_null1 NOT NULL,
+    fallback_applied boolean DEFAULT false CONSTRAINT bayesian_model_fits_fallback_applied_not_null1 NOT NULL,
     fallback_reason character varying(64),
     sampling_started_at timestamp with time zone,
     last_eligibility_check_at timestamp with time zone,
     last_fit_at timestamp with time zone,
     completed_at timestamp with time zone,
     runtime_seconds integer,
-    max_runtime_seconds integer DEFAULT 60 NOT NULL,
-    max_samples integer DEFAULT 0 NOT NULL,
-    max_cores integer DEFAULT 1 NOT NULL,
+    max_runtime_seconds integer DEFAULT 60 CONSTRAINT bayesian_model_fits_max_runtime_seconds_not_null1 NOT NULL,
+    max_samples integer DEFAULT 0 CONSTRAINT bayesian_model_fits_max_samples_not_null1 NOT NULL,
+    max_cores integer DEFAULT 1 CONSTRAINT bayesian_model_fits_max_cores_not_null1 NOT NULL,
     n_chains integer,
     n_samples_actual integer,
     r_hat_max double precision,
     ess_min double precision,
     divergence_count integer,
-    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying NOT NULL,
+    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying CONSTRAINT bayesian_model_fits_credible_interval_status_not_null1 NOT NULL,
     confidence_bucket character varying(32),
     confidence_bucket_reason character varying(255),
     confidence_policy_version character varying(64),
     artifact_ref character varying(255),
     artifact_hash character varying(64),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_created_at_not_null1 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_updated_at_not_null1 NOT NULL,
     hdi_lower double precision,
     hdi_upper double precision,
-    interval_shape jsonb DEFAULT '[]'::jsonb NOT NULL,
+    interval_shape jsonb DEFAULT '[]'::jsonb CONSTRAINT bayesian_model_fits_interval_shape_not_null NOT NULL,
     interval_element_count integer,
     interval_summary_bytes integer,
-    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying NOT NULL,
+    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying CONSTRAINT bayesian_model_fits_diagnostic_status_not_null NOT NULL,
     diagnostic_failure_reason character varying(64),
     diagnostic_policy_version character varying(64),
     diagnostic_target_filter_version character varying(64),
@@ -2258,46 +3002,51 @@ WITH (fillfactor='90');
 
 ALTER TABLE ONLY public.bayesian_model_fits_p00 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_model_fits_p01; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_model_fits_p01 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    model_type character varying(64) NOT NULL,
-    model_version character varying(64) NOT NULL,
-    source_window_start timestamp with time zone NOT NULL,
-    source_window_end timestamp with time zone NOT NULL,
-    source_snapshot_hash character varying(64) NOT NULL,
-    status character varying(32) DEFAULT 'pending'::character varying NOT NULL,
-    eligibility_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    fallback_applied boolean DEFAULT false NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_model_fits_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_model_fits_tenant_id_not_null1 NOT NULL,
+    model_type character varying(64) CONSTRAINT bayesian_model_fits_model_type_not_null1 NOT NULL,
+    model_version character varying(64) CONSTRAINT bayesian_model_fits_model_version_not_null1 NOT NULL,
+    source_window_start timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_start_not_null1 NOT NULL,
+    source_window_end timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_end_not_null1 NOT NULL,
+    source_snapshot_hash character varying(64) CONSTRAINT bayesian_model_fits_source_snapshot_hash_not_null1 NOT NULL,
+    status character varying(32) DEFAULT 'pending'::character varying CONSTRAINT bayesian_model_fits_status_not_null1 NOT NULL,
+    eligibility_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_eligibility_status_not_null1 NOT NULL,
+    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_data_completeness_status_not_null1 NOT NULL,
+    fallback_applied boolean DEFAULT false CONSTRAINT bayesian_model_fits_fallback_applied_not_null1 NOT NULL,
     fallback_reason character varying(64),
     sampling_started_at timestamp with time zone,
     last_eligibility_check_at timestamp with time zone,
     last_fit_at timestamp with time zone,
     completed_at timestamp with time zone,
     runtime_seconds integer,
-    max_runtime_seconds integer DEFAULT 60 NOT NULL,
-    max_samples integer DEFAULT 0 NOT NULL,
-    max_cores integer DEFAULT 1 NOT NULL,
+    max_runtime_seconds integer DEFAULT 60 CONSTRAINT bayesian_model_fits_max_runtime_seconds_not_null1 NOT NULL,
+    max_samples integer DEFAULT 0 CONSTRAINT bayesian_model_fits_max_samples_not_null1 NOT NULL,
+    max_cores integer DEFAULT 1 CONSTRAINT bayesian_model_fits_max_cores_not_null1 NOT NULL,
     n_chains integer,
     n_samples_actual integer,
     r_hat_max double precision,
     ess_min double precision,
     divergence_count integer,
-    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying NOT NULL,
+    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying CONSTRAINT bayesian_model_fits_credible_interval_status_not_null1 NOT NULL,
     confidence_bucket character varying(32),
     confidence_bucket_reason character varying(255),
     confidence_policy_version character varying(64),
     artifact_ref character varying(255),
     artifact_hash character varying(64),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_created_at_not_null1 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_updated_at_not_null1 NOT NULL,
     hdi_lower double precision,
     hdi_upper double precision,
-    interval_shape jsonb DEFAULT '[]'::jsonb NOT NULL,
+    interval_shape jsonb DEFAULT '[]'::jsonb CONSTRAINT bayesian_model_fits_interval_shape_not_null NOT NULL,
     interval_element_count integer,
     interval_summary_bytes integer,
-    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying NOT NULL,
+    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying CONSTRAINT bayesian_model_fits_diagnostic_status_not_null NOT NULL,
     diagnostic_failure_reason character varying(64),
     diagnostic_policy_version character varying(64),
     diagnostic_target_filter_version character varying(64),
@@ -2339,46 +3088,51 @@ WITH (fillfactor='90');
 
 ALTER TABLE ONLY public.bayesian_model_fits_p01 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_model_fits_p02; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_model_fits_p02 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    model_type character varying(64) NOT NULL,
-    model_version character varying(64) NOT NULL,
-    source_window_start timestamp with time zone NOT NULL,
-    source_window_end timestamp with time zone NOT NULL,
-    source_snapshot_hash character varying(64) NOT NULL,
-    status character varying(32) DEFAULT 'pending'::character varying NOT NULL,
-    eligibility_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    fallback_applied boolean DEFAULT false NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_model_fits_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_model_fits_tenant_id_not_null1 NOT NULL,
+    model_type character varying(64) CONSTRAINT bayesian_model_fits_model_type_not_null1 NOT NULL,
+    model_version character varying(64) CONSTRAINT bayesian_model_fits_model_version_not_null1 NOT NULL,
+    source_window_start timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_start_not_null1 NOT NULL,
+    source_window_end timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_end_not_null1 NOT NULL,
+    source_snapshot_hash character varying(64) CONSTRAINT bayesian_model_fits_source_snapshot_hash_not_null1 NOT NULL,
+    status character varying(32) DEFAULT 'pending'::character varying CONSTRAINT bayesian_model_fits_status_not_null1 NOT NULL,
+    eligibility_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_eligibility_status_not_null1 NOT NULL,
+    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_data_completeness_status_not_null1 NOT NULL,
+    fallback_applied boolean DEFAULT false CONSTRAINT bayesian_model_fits_fallback_applied_not_null1 NOT NULL,
     fallback_reason character varying(64),
     sampling_started_at timestamp with time zone,
     last_eligibility_check_at timestamp with time zone,
     last_fit_at timestamp with time zone,
     completed_at timestamp with time zone,
     runtime_seconds integer,
-    max_runtime_seconds integer DEFAULT 60 NOT NULL,
-    max_samples integer DEFAULT 0 NOT NULL,
-    max_cores integer DEFAULT 1 NOT NULL,
+    max_runtime_seconds integer DEFAULT 60 CONSTRAINT bayesian_model_fits_max_runtime_seconds_not_null1 NOT NULL,
+    max_samples integer DEFAULT 0 CONSTRAINT bayesian_model_fits_max_samples_not_null1 NOT NULL,
+    max_cores integer DEFAULT 1 CONSTRAINT bayesian_model_fits_max_cores_not_null1 NOT NULL,
     n_chains integer,
     n_samples_actual integer,
     r_hat_max double precision,
     ess_min double precision,
     divergence_count integer,
-    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying NOT NULL,
+    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying CONSTRAINT bayesian_model_fits_credible_interval_status_not_null1 NOT NULL,
     confidence_bucket character varying(32),
     confidence_bucket_reason character varying(255),
     confidence_policy_version character varying(64),
     artifact_ref character varying(255),
     artifact_hash character varying(64),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_created_at_not_null1 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_updated_at_not_null1 NOT NULL,
     hdi_lower double precision,
     hdi_upper double precision,
-    interval_shape jsonb DEFAULT '[]'::jsonb NOT NULL,
+    interval_shape jsonb DEFAULT '[]'::jsonb CONSTRAINT bayesian_model_fits_interval_shape_not_null NOT NULL,
     interval_element_count integer,
     interval_summary_bytes integer,
-    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying NOT NULL,
+    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying CONSTRAINT bayesian_model_fits_diagnostic_status_not_null NOT NULL,
     diagnostic_failure_reason character varying(64),
     diagnostic_policy_version character varying(64),
     diagnostic_target_filter_version character varying(64),
@@ -2420,46 +3174,51 @@ WITH (fillfactor='90');
 
 ALTER TABLE ONLY public.bayesian_model_fits_p02 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_model_fits_p03; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_model_fits_p03 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    model_type character varying(64) NOT NULL,
-    model_version character varying(64) NOT NULL,
-    source_window_start timestamp with time zone NOT NULL,
-    source_window_end timestamp with time zone NOT NULL,
-    source_snapshot_hash character varying(64) NOT NULL,
-    status character varying(32) DEFAULT 'pending'::character varying NOT NULL,
-    eligibility_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    fallback_applied boolean DEFAULT false NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_model_fits_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_model_fits_tenant_id_not_null1 NOT NULL,
+    model_type character varying(64) CONSTRAINT bayesian_model_fits_model_type_not_null1 NOT NULL,
+    model_version character varying(64) CONSTRAINT bayesian_model_fits_model_version_not_null1 NOT NULL,
+    source_window_start timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_start_not_null1 NOT NULL,
+    source_window_end timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_end_not_null1 NOT NULL,
+    source_snapshot_hash character varying(64) CONSTRAINT bayesian_model_fits_source_snapshot_hash_not_null1 NOT NULL,
+    status character varying(32) DEFAULT 'pending'::character varying CONSTRAINT bayesian_model_fits_status_not_null1 NOT NULL,
+    eligibility_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_eligibility_status_not_null1 NOT NULL,
+    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_data_completeness_status_not_null1 NOT NULL,
+    fallback_applied boolean DEFAULT false CONSTRAINT bayesian_model_fits_fallback_applied_not_null1 NOT NULL,
     fallback_reason character varying(64),
     sampling_started_at timestamp with time zone,
     last_eligibility_check_at timestamp with time zone,
     last_fit_at timestamp with time zone,
     completed_at timestamp with time zone,
     runtime_seconds integer,
-    max_runtime_seconds integer DEFAULT 60 NOT NULL,
-    max_samples integer DEFAULT 0 NOT NULL,
-    max_cores integer DEFAULT 1 NOT NULL,
+    max_runtime_seconds integer DEFAULT 60 CONSTRAINT bayesian_model_fits_max_runtime_seconds_not_null1 NOT NULL,
+    max_samples integer DEFAULT 0 CONSTRAINT bayesian_model_fits_max_samples_not_null1 NOT NULL,
+    max_cores integer DEFAULT 1 CONSTRAINT bayesian_model_fits_max_cores_not_null1 NOT NULL,
     n_chains integer,
     n_samples_actual integer,
     r_hat_max double precision,
     ess_min double precision,
     divergence_count integer,
-    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying NOT NULL,
+    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying CONSTRAINT bayesian_model_fits_credible_interval_status_not_null1 NOT NULL,
     confidence_bucket character varying(32),
     confidence_bucket_reason character varying(255),
     confidence_policy_version character varying(64),
     artifact_ref character varying(255),
     artifact_hash character varying(64),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_created_at_not_null1 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_updated_at_not_null1 NOT NULL,
     hdi_lower double precision,
     hdi_upper double precision,
-    interval_shape jsonb DEFAULT '[]'::jsonb NOT NULL,
+    interval_shape jsonb DEFAULT '[]'::jsonb CONSTRAINT bayesian_model_fits_interval_shape_not_null NOT NULL,
     interval_element_count integer,
     interval_summary_bytes integer,
-    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying NOT NULL,
+    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying CONSTRAINT bayesian_model_fits_diagnostic_status_not_null NOT NULL,
     diagnostic_failure_reason character varying(64),
     diagnostic_policy_version character varying(64),
     diagnostic_target_filter_version character varying(64),
@@ -2501,46 +3260,51 @@ WITH (fillfactor='90');
 
 ALTER TABLE ONLY public.bayesian_model_fits_p03 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_model_fits_p04; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_model_fits_p04 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    model_type character varying(64) NOT NULL,
-    model_version character varying(64) NOT NULL,
-    source_window_start timestamp with time zone NOT NULL,
-    source_window_end timestamp with time zone NOT NULL,
-    source_snapshot_hash character varying(64) NOT NULL,
-    status character varying(32) DEFAULT 'pending'::character varying NOT NULL,
-    eligibility_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    fallback_applied boolean DEFAULT false NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_model_fits_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_model_fits_tenant_id_not_null1 NOT NULL,
+    model_type character varying(64) CONSTRAINT bayesian_model_fits_model_type_not_null1 NOT NULL,
+    model_version character varying(64) CONSTRAINT bayesian_model_fits_model_version_not_null1 NOT NULL,
+    source_window_start timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_start_not_null1 NOT NULL,
+    source_window_end timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_end_not_null1 NOT NULL,
+    source_snapshot_hash character varying(64) CONSTRAINT bayesian_model_fits_source_snapshot_hash_not_null1 NOT NULL,
+    status character varying(32) DEFAULT 'pending'::character varying CONSTRAINT bayesian_model_fits_status_not_null1 NOT NULL,
+    eligibility_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_eligibility_status_not_null1 NOT NULL,
+    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_data_completeness_status_not_null1 NOT NULL,
+    fallback_applied boolean DEFAULT false CONSTRAINT bayesian_model_fits_fallback_applied_not_null1 NOT NULL,
     fallback_reason character varying(64),
     sampling_started_at timestamp with time zone,
     last_eligibility_check_at timestamp with time zone,
     last_fit_at timestamp with time zone,
     completed_at timestamp with time zone,
     runtime_seconds integer,
-    max_runtime_seconds integer DEFAULT 60 NOT NULL,
-    max_samples integer DEFAULT 0 NOT NULL,
-    max_cores integer DEFAULT 1 NOT NULL,
+    max_runtime_seconds integer DEFAULT 60 CONSTRAINT bayesian_model_fits_max_runtime_seconds_not_null1 NOT NULL,
+    max_samples integer DEFAULT 0 CONSTRAINT bayesian_model_fits_max_samples_not_null1 NOT NULL,
+    max_cores integer DEFAULT 1 CONSTRAINT bayesian_model_fits_max_cores_not_null1 NOT NULL,
     n_chains integer,
     n_samples_actual integer,
     r_hat_max double precision,
     ess_min double precision,
     divergence_count integer,
-    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying NOT NULL,
+    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying CONSTRAINT bayesian_model_fits_credible_interval_status_not_null1 NOT NULL,
     confidence_bucket character varying(32),
     confidence_bucket_reason character varying(255),
     confidence_policy_version character varying(64),
     artifact_ref character varying(255),
     artifact_hash character varying(64),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_created_at_not_null1 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_updated_at_not_null1 NOT NULL,
     hdi_lower double precision,
     hdi_upper double precision,
-    interval_shape jsonb DEFAULT '[]'::jsonb NOT NULL,
+    interval_shape jsonb DEFAULT '[]'::jsonb CONSTRAINT bayesian_model_fits_interval_shape_not_null NOT NULL,
     interval_element_count integer,
     interval_summary_bytes integer,
-    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying NOT NULL,
+    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying CONSTRAINT bayesian_model_fits_diagnostic_status_not_null NOT NULL,
     diagnostic_failure_reason character varying(64),
     diagnostic_policy_version character varying(64),
     diagnostic_target_filter_version character varying(64),
@@ -2582,46 +3346,51 @@ WITH (fillfactor='90');
 
 ALTER TABLE ONLY public.bayesian_model_fits_p04 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_model_fits_p05; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_model_fits_p05 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    model_type character varying(64) NOT NULL,
-    model_version character varying(64) NOT NULL,
-    source_window_start timestamp with time zone NOT NULL,
-    source_window_end timestamp with time zone NOT NULL,
-    source_snapshot_hash character varying(64) NOT NULL,
-    status character varying(32) DEFAULT 'pending'::character varying NOT NULL,
-    eligibility_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    fallback_applied boolean DEFAULT false NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_model_fits_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_model_fits_tenant_id_not_null1 NOT NULL,
+    model_type character varying(64) CONSTRAINT bayesian_model_fits_model_type_not_null1 NOT NULL,
+    model_version character varying(64) CONSTRAINT bayesian_model_fits_model_version_not_null1 NOT NULL,
+    source_window_start timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_start_not_null1 NOT NULL,
+    source_window_end timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_end_not_null1 NOT NULL,
+    source_snapshot_hash character varying(64) CONSTRAINT bayesian_model_fits_source_snapshot_hash_not_null1 NOT NULL,
+    status character varying(32) DEFAULT 'pending'::character varying CONSTRAINT bayesian_model_fits_status_not_null1 NOT NULL,
+    eligibility_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_eligibility_status_not_null1 NOT NULL,
+    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_data_completeness_status_not_null1 NOT NULL,
+    fallback_applied boolean DEFAULT false CONSTRAINT bayesian_model_fits_fallback_applied_not_null1 NOT NULL,
     fallback_reason character varying(64),
     sampling_started_at timestamp with time zone,
     last_eligibility_check_at timestamp with time zone,
     last_fit_at timestamp with time zone,
     completed_at timestamp with time zone,
     runtime_seconds integer,
-    max_runtime_seconds integer DEFAULT 60 NOT NULL,
-    max_samples integer DEFAULT 0 NOT NULL,
-    max_cores integer DEFAULT 1 NOT NULL,
+    max_runtime_seconds integer DEFAULT 60 CONSTRAINT bayesian_model_fits_max_runtime_seconds_not_null1 NOT NULL,
+    max_samples integer DEFAULT 0 CONSTRAINT bayesian_model_fits_max_samples_not_null1 NOT NULL,
+    max_cores integer DEFAULT 1 CONSTRAINT bayesian_model_fits_max_cores_not_null1 NOT NULL,
     n_chains integer,
     n_samples_actual integer,
     r_hat_max double precision,
     ess_min double precision,
     divergence_count integer,
-    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying NOT NULL,
+    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying CONSTRAINT bayesian_model_fits_credible_interval_status_not_null1 NOT NULL,
     confidence_bucket character varying(32),
     confidence_bucket_reason character varying(255),
     confidence_policy_version character varying(64),
     artifact_ref character varying(255),
     artifact_hash character varying(64),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_created_at_not_null1 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_updated_at_not_null1 NOT NULL,
     hdi_lower double precision,
     hdi_upper double precision,
-    interval_shape jsonb DEFAULT '[]'::jsonb NOT NULL,
+    interval_shape jsonb DEFAULT '[]'::jsonb CONSTRAINT bayesian_model_fits_interval_shape_not_null NOT NULL,
     interval_element_count integer,
     interval_summary_bytes integer,
-    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying NOT NULL,
+    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying CONSTRAINT bayesian_model_fits_diagnostic_status_not_null NOT NULL,
     diagnostic_failure_reason character varying(64),
     diagnostic_policy_version character varying(64),
     diagnostic_target_filter_version character varying(64),
@@ -2663,46 +3432,51 @@ WITH (fillfactor='90');
 
 ALTER TABLE ONLY public.bayesian_model_fits_p05 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_model_fits_p06; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_model_fits_p06 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    model_type character varying(64) NOT NULL,
-    model_version character varying(64) NOT NULL,
-    source_window_start timestamp with time zone NOT NULL,
-    source_window_end timestamp with time zone NOT NULL,
-    source_snapshot_hash character varying(64) NOT NULL,
-    status character varying(32) DEFAULT 'pending'::character varying NOT NULL,
-    eligibility_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    fallback_applied boolean DEFAULT false NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_model_fits_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_model_fits_tenant_id_not_null1 NOT NULL,
+    model_type character varying(64) CONSTRAINT bayesian_model_fits_model_type_not_null1 NOT NULL,
+    model_version character varying(64) CONSTRAINT bayesian_model_fits_model_version_not_null1 NOT NULL,
+    source_window_start timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_start_not_null1 NOT NULL,
+    source_window_end timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_end_not_null1 NOT NULL,
+    source_snapshot_hash character varying(64) CONSTRAINT bayesian_model_fits_source_snapshot_hash_not_null1 NOT NULL,
+    status character varying(32) DEFAULT 'pending'::character varying CONSTRAINT bayesian_model_fits_status_not_null1 NOT NULL,
+    eligibility_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_eligibility_status_not_null1 NOT NULL,
+    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_data_completeness_status_not_null1 NOT NULL,
+    fallback_applied boolean DEFAULT false CONSTRAINT bayesian_model_fits_fallback_applied_not_null1 NOT NULL,
     fallback_reason character varying(64),
     sampling_started_at timestamp with time zone,
     last_eligibility_check_at timestamp with time zone,
     last_fit_at timestamp with time zone,
     completed_at timestamp with time zone,
     runtime_seconds integer,
-    max_runtime_seconds integer DEFAULT 60 NOT NULL,
-    max_samples integer DEFAULT 0 NOT NULL,
-    max_cores integer DEFAULT 1 NOT NULL,
+    max_runtime_seconds integer DEFAULT 60 CONSTRAINT bayesian_model_fits_max_runtime_seconds_not_null1 NOT NULL,
+    max_samples integer DEFAULT 0 CONSTRAINT bayesian_model_fits_max_samples_not_null1 NOT NULL,
+    max_cores integer DEFAULT 1 CONSTRAINT bayesian_model_fits_max_cores_not_null1 NOT NULL,
     n_chains integer,
     n_samples_actual integer,
     r_hat_max double precision,
     ess_min double precision,
     divergence_count integer,
-    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying NOT NULL,
+    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying CONSTRAINT bayesian_model_fits_credible_interval_status_not_null1 NOT NULL,
     confidence_bucket character varying(32),
     confidence_bucket_reason character varying(255),
     confidence_policy_version character varying(64),
     artifact_ref character varying(255),
     artifact_hash character varying(64),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_created_at_not_null1 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_updated_at_not_null1 NOT NULL,
     hdi_lower double precision,
     hdi_upper double precision,
-    interval_shape jsonb DEFAULT '[]'::jsonb NOT NULL,
+    interval_shape jsonb DEFAULT '[]'::jsonb CONSTRAINT bayesian_model_fits_interval_shape_not_null NOT NULL,
     interval_element_count integer,
     interval_summary_bytes integer,
-    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying NOT NULL,
+    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying CONSTRAINT bayesian_model_fits_diagnostic_status_not_null NOT NULL,
     diagnostic_failure_reason character varying(64),
     diagnostic_policy_version character varying(64),
     diagnostic_target_filter_version character varying(64),
@@ -2744,46 +3518,51 @@ WITH (fillfactor='90');
 
 ALTER TABLE ONLY public.bayesian_model_fits_p06 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_model_fits_p07; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_model_fits_p07 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    model_type character varying(64) NOT NULL,
-    model_version character varying(64) NOT NULL,
-    source_window_start timestamp with time zone NOT NULL,
-    source_window_end timestamp with time zone NOT NULL,
-    source_snapshot_hash character varying(64) NOT NULL,
-    status character varying(32) DEFAULT 'pending'::character varying NOT NULL,
-    eligibility_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    fallback_applied boolean DEFAULT false NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_model_fits_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_model_fits_tenant_id_not_null1 NOT NULL,
+    model_type character varying(64) CONSTRAINT bayesian_model_fits_model_type_not_null1 NOT NULL,
+    model_version character varying(64) CONSTRAINT bayesian_model_fits_model_version_not_null1 NOT NULL,
+    source_window_start timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_start_not_null1 NOT NULL,
+    source_window_end timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_end_not_null1 NOT NULL,
+    source_snapshot_hash character varying(64) CONSTRAINT bayesian_model_fits_source_snapshot_hash_not_null1 NOT NULL,
+    status character varying(32) DEFAULT 'pending'::character varying CONSTRAINT bayesian_model_fits_status_not_null1 NOT NULL,
+    eligibility_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_eligibility_status_not_null1 NOT NULL,
+    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_data_completeness_status_not_null1 NOT NULL,
+    fallback_applied boolean DEFAULT false CONSTRAINT bayesian_model_fits_fallback_applied_not_null1 NOT NULL,
     fallback_reason character varying(64),
     sampling_started_at timestamp with time zone,
     last_eligibility_check_at timestamp with time zone,
     last_fit_at timestamp with time zone,
     completed_at timestamp with time zone,
     runtime_seconds integer,
-    max_runtime_seconds integer DEFAULT 60 NOT NULL,
-    max_samples integer DEFAULT 0 NOT NULL,
-    max_cores integer DEFAULT 1 NOT NULL,
+    max_runtime_seconds integer DEFAULT 60 CONSTRAINT bayesian_model_fits_max_runtime_seconds_not_null1 NOT NULL,
+    max_samples integer DEFAULT 0 CONSTRAINT bayesian_model_fits_max_samples_not_null1 NOT NULL,
+    max_cores integer DEFAULT 1 CONSTRAINT bayesian_model_fits_max_cores_not_null1 NOT NULL,
     n_chains integer,
     n_samples_actual integer,
     r_hat_max double precision,
     ess_min double precision,
     divergence_count integer,
-    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying NOT NULL,
+    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying CONSTRAINT bayesian_model_fits_credible_interval_status_not_null1 NOT NULL,
     confidence_bucket character varying(32),
     confidence_bucket_reason character varying(255),
     confidence_policy_version character varying(64),
     artifact_ref character varying(255),
     artifact_hash character varying(64),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_created_at_not_null1 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_updated_at_not_null1 NOT NULL,
     hdi_lower double precision,
     hdi_upper double precision,
-    interval_shape jsonb DEFAULT '[]'::jsonb NOT NULL,
+    interval_shape jsonb DEFAULT '[]'::jsonb CONSTRAINT bayesian_model_fits_interval_shape_not_null NOT NULL,
     interval_element_count integer,
     interval_summary_bytes integer,
-    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying NOT NULL,
+    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying CONSTRAINT bayesian_model_fits_diagnostic_status_not_null NOT NULL,
     diagnostic_failure_reason character varying(64),
     diagnostic_policy_version character varying(64),
     diagnostic_target_filter_version character varying(64),
@@ -2825,46 +3604,51 @@ WITH (fillfactor='90');
 
 ALTER TABLE ONLY public.bayesian_model_fits_p07 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_model_fits_p08; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_model_fits_p08 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    model_type character varying(64) NOT NULL,
-    model_version character varying(64) NOT NULL,
-    source_window_start timestamp with time zone NOT NULL,
-    source_window_end timestamp with time zone NOT NULL,
-    source_snapshot_hash character varying(64) NOT NULL,
-    status character varying(32) DEFAULT 'pending'::character varying NOT NULL,
-    eligibility_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    fallback_applied boolean DEFAULT false NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_model_fits_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_model_fits_tenant_id_not_null1 NOT NULL,
+    model_type character varying(64) CONSTRAINT bayesian_model_fits_model_type_not_null1 NOT NULL,
+    model_version character varying(64) CONSTRAINT bayesian_model_fits_model_version_not_null1 NOT NULL,
+    source_window_start timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_start_not_null1 NOT NULL,
+    source_window_end timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_end_not_null1 NOT NULL,
+    source_snapshot_hash character varying(64) CONSTRAINT bayesian_model_fits_source_snapshot_hash_not_null1 NOT NULL,
+    status character varying(32) DEFAULT 'pending'::character varying CONSTRAINT bayesian_model_fits_status_not_null1 NOT NULL,
+    eligibility_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_eligibility_status_not_null1 NOT NULL,
+    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_data_completeness_status_not_null1 NOT NULL,
+    fallback_applied boolean DEFAULT false CONSTRAINT bayesian_model_fits_fallback_applied_not_null1 NOT NULL,
     fallback_reason character varying(64),
     sampling_started_at timestamp with time zone,
     last_eligibility_check_at timestamp with time zone,
     last_fit_at timestamp with time zone,
     completed_at timestamp with time zone,
     runtime_seconds integer,
-    max_runtime_seconds integer DEFAULT 60 NOT NULL,
-    max_samples integer DEFAULT 0 NOT NULL,
-    max_cores integer DEFAULT 1 NOT NULL,
+    max_runtime_seconds integer DEFAULT 60 CONSTRAINT bayesian_model_fits_max_runtime_seconds_not_null1 NOT NULL,
+    max_samples integer DEFAULT 0 CONSTRAINT bayesian_model_fits_max_samples_not_null1 NOT NULL,
+    max_cores integer DEFAULT 1 CONSTRAINT bayesian_model_fits_max_cores_not_null1 NOT NULL,
     n_chains integer,
     n_samples_actual integer,
     r_hat_max double precision,
     ess_min double precision,
     divergence_count integer,
-    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying NOT NULL,
+    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying CONSTRAINT bayesian_model_fits_credible_interval_status_not_null1 NOT NULL,
     confidence_bucket character varying(32),
     confidence_bucket_reason character varying(255),
     confidence_policy_version character varying(64),
     artifact_ref character varying(255),
     artifact_hash character varying(64),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_created_at_not_null1 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_updated_at_not_null1 NOT NULL,
     hdi_lower double precision,
     hdi_upper double precision,
-    interval_shape jsonb DEFAULT '[]'::jsonb NOT NULL,
+    interval_shape jsonb DEFAULT '[]'::jsonb CONSTRAINT bayesian_model_fits_interval_shape_not_null NOT NULL,
     interval_element_count integer,
     interval_summary_bytes integer,
-    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying NOT NULL,
+    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying CONSTRAINT bayesian_model_fits_diagnostic_status_not_null NOT NULL,
     diagnostic_failure_reason character varying(64),
     diagnostic_policy_version character varying(64),
     diagnostic_target_filter_version character varying(64),
@@ -2906,46 +3690,51 @@ WITH (fillfactor='90');
 
 ALTER TABLE ONLY public.bayesian_model_fits_p08 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_model_fits_p09; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_model_fits_p09 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    model_type character varying(64) NOT NULL,
-    model_version character varying(64) NOT NULL,
-    source_window_start timestamp with time zone NOT NULL,
-    source_window_end timestamp with time zone NOT NULL,
-    source_snapshot_hash character varying(64) NOT NULL,
-    status character varying(32) DEFAULT 'pending'::character varying NOT NULL,
-    eligibility_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    fallback_applied boolean DEFAULT false NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_model_fits_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_model_fits_tenant_id_not_null1 NOT NULL,
+    model_type character varying(64) CONSTRAINT bayesian_model_fits_model_type_not_null1 NOT NULL,
+    model_version character varying(64) CONSTRAINT bayesian_model_fits_model_version_not_null1 NOT NULL,
+    source_window_start timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_start_not_null1 NOT NULL,
+    source_window_end timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_end_not_null1 NOT NULL,
+    source_snapshot_hash character varying(64) CONSTRAINT bayesian_model_fits_source_snapshot_hash_not_null1 NOT NULL,
+    status character varying(32) DEFAULT 'pending'::character varying CONSTRAINT bayesian_model_fits_status_not_null1 NOT NULL,
+    eligibility_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_eligibility_status_not_null1 NOT NULL,
+    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_data_completeness_status_not_null1 NOT NULL,
+    fallback_applied boolean DEFAULT false CONSTRAINT bayesian_model_fits_fallback_applied_not_null1 NOT NULL,
     fallback_reason character varying(64),
     sampling_started_at timestamp with time zone,
     last_eligibility_check_at timestamp with time zone,
     last_fit_at timestamp with time zone,
     completed_at timestamp with time zone,
     runtime_seconds integer,
-    max_runtime_seconds integer DEFAULT 60 NOT NULL,
-    max_samples integer DEFAULT 0 NOT NULL,
-    max_cores integer DEFAULT 1 NOT NULL,
+    max_runtime_seconds integer DEFAULT 60 CONSTRAINT bayesian_model_fits_max_runtime_seconds_not_null1 NOT NULL,
+    max_samples integer DEFAULT 0 CONSTRAINT bayesian_model_fits_max_samples_not_null1 NOT NULL,
+    max_cores integer DEFAULT 1 CONSTRAINT bayesian_model_fits_max_cores_not_null1 NOT NULL,
     n_chains integer,
     n_samples_actual integer,
     r_hat_max double precision,
     ess_min double precision,
     divergence_count integer,
-    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying NOT NULL,
+    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying CONSTRAINT bayesian_model_fits_credible_interval_status_not_null1 NOT NULL,
     confidence_bucket character varying(32),
     confidence_bucket_reason character varying(255),
     confidence_policy_version character varying(64),
     artifact_ref character varying(255),
     artifact_hash character varying(64),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_created_at_not_null1 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_updated_at_not_null1 NOT NULL,
     hdi_lower double precision,
     hdi_upper double precision,
-    interval_shape jsonb DEFAULT '[]'::jsonb NOT NULL,
+    interval_shape jsonb DEFAULT '[]'::jsonb CONSTRAINT bayesian_model_fits_interval_shape_not_null NOT NULL,
     interval_element_count integer,
     interval_summary_bytes integer,
-    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying NOT NULL,
+    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying CONSTRAINT bayesian_model_fits_diagnostic_status_not_null NOT NULL,
     diagnostic_failure_reason character varying(64),
     diagnostic_policy_version character varying(64),
     diagnostic_target_filter_version character varying(64),
@@ -2987,46 +3776,51 @@ WITH (fillfactor='90');
 
 ALTER TABLE ONLY public.bayesian_model_fits_p09 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_model_fits_p10; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_model_fits_p10 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    model_type character varying(64) NOT NULL,
-    model_version character varying(64) NOT NULL,
-    source_window_start timestamp with time zone NOT NULL,
-    source_window_end timestamp with time zone NOT NULL,
-    source_snapshot_hash character varying(64) NOT NULL,
-    status character varying(32) DEFAULT 'pending'::character varying NOT NULL,
-    eligibility_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    fallback_applied boolean DEFAULT false NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_model_fits_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_model_fits_tenant_id_not_null1 NOT NULL,
+    model_type character varying(64) CONSTRAINT bayesian_model_fits_model_type_not_null1 NOT NULL,
+    model_version character varying(64) CONSTRAINT bayesian_model_fits_model_version_not_null1 NOT NULL,
+    source_window_start timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_start_not_null1 NOT NULL,
+    source_window_end timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_end_not_null1 NOT NULL,
+    source_snapshot_hash character varying(64) CONSTRAINT bayesian_model_fits_source_snapshot_hash_not_null1 NOT NULL,
+    status character varying(32) DEFAULT 'pending'::character varying CONSTRAINT bayesian_model_fits_status_not_null1 NOT NULL,
+    eligibility_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_eligibility_status_not_null1 NOT NULL,
+    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_data_completeness_status_not_null1 NOT NULL,
+    fallback_applied boolean DEFAULT false CONSTRAINT bayesian_model_fits_fallback_applied_not_null1 NOT NULL,
     fallback_reason character varying(64),
     sampling_started_at timestamp with time zone,
     last_eligibility_check_at timestamp with time zone,
     last_fit_at timestamp with time zone,
     completed_at timestamp with time zone,
     runtime_seconds integer,
-    max_runtime_seconds integer DEFAULT 60 NOT NULL,
-    max_samples integer DEFAULT 0 NOT NULL,
-    max_cores integer DEFAULT 1 NOT NULL,
+    max_runtime_seconds integer DEFAULT 60 CONSTRAINT bayesian_model_fits_max_runtime_seconds_not_null1 NOT NULL,
+    max_samples integer DEFAULT 0 CONSTRAINT bayesian_model_fits_max_samples_not_null1 NOT NULL,
+    max_cores integer DEFAULT 1 CONSTRAINT bayesian_model_fits_max_cores_not_null1 NOT NULL,
     n_chains integer,
     n_samples_actual integer,
     r_hat_max double precision,
     ess_min double precision,
     divergence_count integer,
-    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying NOT NULL,
+    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying CONSTRAINT bayesian_model_fits_credible_interval_status_not_null1 NOT NULL,
     confidence_bucket character varying(32),
     confidence_bucket_reason character varying(255),
     confidence_policy_version character varying(64),
     artifact_ref character varying(255),
     artifact_hash character varying(64),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_created_at_not_null1 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_updated_at_not_null1 NOT NULL,
     hdi_lower double precision,
     hdi_upper double precision,
-    interval_shape jsonb DEFAULT '[]'::jsonb NOT NULL,
+    interval_shape jsonb DEFAULT '[]'::jsonb CONSTRAINT bayesian_model_fits_interval_shape_not_null NOT NULL,
     interval_element_count integer,
     interval_summary_bytes integer,
-    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying NOT NULL,
+    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying CONSTRAINT bayesian_model_fits_diagnostic_status_not_null NOT NULL,
     diagnostic_failure_reason character varying(64),
     diagnostic_policy_version character varying(64),
     diagnostic_target_filter_version character varying(64),
@@ -3068,46 +3862,51 @@ WITH (fillfactor='90');
 
 ALTER TABLE ONLY public.bayesian_model_fits_p10 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_model_fits_p11; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_model_fits_p11 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    model_type character varying(64) NOT NULL,
-    model_version character varying(64) NOT NULL,
-    source_window_start timestamp with time zone NOT NULL,
-    source_window_end timestamp with time zone NOT NULL,
-    source_snapshot_hash character varying(64) NOT NULL,
-    status character varying(32) DEFAULT 'pending'::character varying NOT NULL,
-    eligibility_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    fallback_applied boolean DEFAULT false NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_model_fits_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_model_fits_tenant_id_not_null1 NOT NULL,
+    model_type character varying(64) CONSTRAINT bayesian_model_fits_model_type_not_null1 NOT NULL,
+    model_version character varying(64) CONSTRAINT bayesian_model_fits_model_version_not_null1 NOT NULL,
+    source_window_start timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_start_not_null1 NOT NULL,
+    source_window_end timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_end_not_null1 NOT NULL,
+    source_snapshot_hash character varying(64) CONSTRAINT bayesian_model_fits_source_snapshot_hash_not_null1 NOT NULL,
+    status character varying(32) DEFAULT 'pending'::character varying CONSTRAINT bayesian_model_fits_status_not_null1 NOT NULL,
+    eligibility_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_eligibility_status_not_null1 NOT NULL,
+    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_data_completeness_status_not_null1 NOT NULL,
+    fallback_applied boolean DEFAULT false CONSTRAINT bayesian_model_fits_fallback_applied_not_null1 NOT NULL,
     fallback_reason character varying(64),
     sampling_started_at timestamp with time zone,
     last_eligibility_check_at timestamp with time zone,
     last_fit_at timestamp with time zone,
     completed_at timestamp with time zone,
     runtime_seconds integer,
-    max_runtime_seconds integer DEFAULT 60 NOT NULL,
-    max_samples integer DEFAULT 0 NOT NULL,
-    max_cores integer DEFAULT 1 NOT NULL,
+    max_runtime_seconds integer DEFAULT 60 CONSTRAINT bayesian_model_fits_max_runtime_seconds_not_null1 NOT NULL,
+    max_samples integer DEFAULT 0 CONSTRAINT bayesian_model_fits_max_samples_not_null1 NOT NULL,
+    max_cores integer DEFAULT 1 CONSTRAINT bayesian_model_fits_max_cores_not_null1 NOT NULL,
     n_chains integer,
     n_samples_actual integer,
     r_hat_max double precision,
     ess_min double precision,
     divergence_count integer,
-    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying NOT NULL,
+    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying CONSTRAINT bayesian_model_fits_credible_interval_status_not_null1 NOT NULL,
     confidence_bucket character varying(32),
     confidence_bucket_reason character varying(255),
     confidence_policy_version character varying(64),
     artifact_ref character varying(255),
     artifact_hash character varying(64),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_created_at_not_null1 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_updated_at_not_null1 NOT NULL,
     hdi_lower double precision,
     hdi_upper double precision,
-    interval_shape jsonb DEFAULT '[]'::jsonb NOT NULL,
+    interval_shape jsonb DEFAULT '[]'::jsonb CONSTRAINT bayesian_model_fits_interval_shape_not_null NOT NULL,
     interval_element_count integer,
     interval_summary_bytes integer,
-    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying NOT NULL,
+    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying CONSTRAINT bayesian_model_fits_diagnostic_status_not_null NOT NULL,
     diagnostic_failure_reason character varying(64),
     diagnostic_policy_version character varying(64),
     diagnostic_target_filter_version character varying(64),
@@ -3149,46 +3948,51 @@ WITH (fillfactor='90');
 
 ALTER TABLE ONLY public.bayesian_model_fits_p11 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_model_fits_p12; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_model_fits_p12 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    model_type character varying(64) NOT NULL,
-    model_version character varying(64) NOT NULL,
-    source_window_start timestamp with time zone NOT NULL,
-    source_window_end timestamp with time zone NOT NULL,
-    source_snapshot_hash character varying(64) NOT NULL,
-    status character varying(32) DEFAULT 'pending'::character varying NOT NULL,
-    eligibility_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    fallback_applied boolean DEFAULT false NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_model_fits_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_model_fits_tenant_id_not_null1 NOT NULL,
+    model_type character varying(64) CONSTRAINT bayesian_model_fits_model_type_not_null1 NOT NULL,
+    model_version character varying(64) CONSTRAINT bayesian_model_fits_model_version_not_null1 NOT NULL,
+    source_window_start timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_start_not_null1 NOT NULL,
+    source_window_end timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_end_not_null1 NOT NULL,
+    source_snapshot_hash character varying(64) CONSTRAINT bayesian_model_fits_source_snapshot_hash_not_null1 NOT NULL,
+    status character varying(32) DEFAULT 'pending'::character varying CONSTRAINT bayesian_model_fits_status_not_null1 NOT NULL,
+    eligibility_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_eligibility_status_not_null1 NOT NULL,
+    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_data_completeness_status_not_null1 NOT NULL,
+    fallback_applied boolean DEFAULT false CONSTRAINT bayesian_model_fits_fallback_applied_not_null1 NOT NULL,
     fallback_reason character varying(64),
     sampling_started_at timestamp with time zone,
     last_eligibility_check_at timestamp with time zone,
     last_fit_at timestamp with time zone,
     completed_at timestamp with time zone,
     runtime_seconds integer,
-    max_runtime_seconds integer DEFAULT 60 NOT NULL,
-    max_samples integer DEFAULT 0 NOT NULL,
-    max_cores integer DEFAULT 1 NOT NULL,
+    max_runtime_seconds integer DEFAULT 60 CONSTRAINT bayesian_model_fits_max_runtime_seconds_not_null1 NOT NULL,
+    max_samples integer DEFAULT 0 CONSTRAINT bayesian_model_fits_max_samples_not_null1 NOT NULL,
+    max_cores integer DEFAULT 1 CONSTRAINT bayesian_model_fits_max_cores_not_null1 NOT NULL,
     n_chains integer,
     n_samples_actual integer,
     r_hat_max double precision,
     ess_min double precision,
     divergence_count integer,
-    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying NOT NULL,
+    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying CONSTRAINT bayesian_model_fits_credible_interval_status_not_null1 NOT NULL,
     confidence_bucket character varying(32),
     confidence_bucket_reason character varying(255),
     confidence_policy_version character varying(64),
     artifact_ref character varying(255),
     artifact_hash character varying(64),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_created_at_not_null1 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_updated_at_not_null1 NOT NULL,
     hdi_lower double precision,
     hdi_upper double precision,
-    interval_shape jsonb DEFAULT '[]'::jsonb NOT NULL,
+    interval_shape jsonb DEFAULT '[]'::jsonb CONSTRAINT bayesian_model_fits_interval_shape_not_null NOT NULL,
     interval_element_count integer,
     interval_summary_bytes integer,
-    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying NOT NULL,
+    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying CONSTRAINT bayesian_model_fits_diagnostic_status_not_null NOT NULL,
     diagnostic_failure_reason character varying(64),
     diagnostic_policy_version character varying(64),
     diagnostic_target_filter_version character varying(64),
@@ -3230,46 +4034,51 @@ WITH (fillfactor='90');
 
 ALTER TABLE ONLY public.bayesian_model_fits_p12 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_model_fits_p13; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_model_fits_p13 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    model_type character varying(64) NOT NULL,
-    model_version character varying(64) NOT NULL,
-    source_window_start timestamp with time zone NOT NULL,
-    source_window_end timestamp with time zone NOT NULL,
-    source_snapshot_hash character varying(64) NOT NULL,
-    status character varying(32) DEFAULT 'pending'::character varying NOT NULL,
-    eligibility_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    fallback_applied boolean DEFAULT false NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_model_fits_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_model_fits_tenant_id_not_null1 NOT NULL,
+    model_type character varying(64) CONSTRAINT bayesian_model_fits_model_type_not_null1 NOT NULL,
+    model_version character varying(64) CONSTRAINT bayesian_model_fits_model_version_not_null1 NOT NULL,
+    source_window_start timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_start_not_null1 NOT NULL,
+    source_window_end timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_end_not_null1 NOT NULL,
+    source_snapshot_hash character varying(64) CONSTRAINT bayesian_model_fits_source_snapshot_hash_not_null1 NOT NULL,
+    status character varying(32) DEFAULT 'pending'::character varying CONSTRAINT bayesian_model_fits_status_not_null1 NOT NULL,
+    eligibility_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_eligibility_status_not_null1 NOT NULL,
+    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_data_completeness_status_not_null1 NOT NULL,
+    fallback_applied boolean DEFAULT false CONSTRAINT bayesian_model_fits_fallback_applied_not_null1 NOT NULL,
     fallback_reason character varying(64),
     sampling_started_at timestamp with time zone,
     last_eligibility_check_at timestamp with time zone,
     last_fit_at timestamp with time zone,
     completed_at timestamp with time zone,
     runtime_seconds integer,
-    max_runtime_seconds integer DEFAULT 60 NOT NULL,
-    max_samples integer DEFAULT 0 NOT NULL,
-    max_cores integer DEFAULT 1 NOT NULL,
+    max_runtime_seconds integer DEFAULT 60 CONSTRAINT bayesian_model_fits_max_runtime_seconds_not_null1 NOT NULL,
+    max_samples integer DEFAULT 0 CONSTRAINT bayesian_model_fits_max_samples_not_null1 NOT NULL,
+    max_cores integer DEFAULT 1 CONSTRAINT bayesian_model_fits_max_cores_not_null1 NOT NULL,
     n_chains integer,
     n_samples_actual integer,
     r_hat_max double precision,
     ess_min double precision,
     divergence_count integer,
-    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying NOT NULL,
+    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying CONSTRAINT bayesian_model_fits_credible_interval_status_not_null1 NOT NULL,
     confidence_bucket character varying(32),
     confidence_bucket_reason character varying(255),
     confidence_policy_version character varying(64),
     artifact_ref character varying(255),
     artifact_hash character varying(64),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_created_at_not_null1 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_updated_at_not_null1 NOT NULL,
     hdi_lower double precision,
     hdi_upper double precision,
-    interval_shape jsonb DEFAULT '[]'::jsonb NOT NULL,
+    interval_shape jsonb DEFAULT '[]'::jsonb CONSTRAINT bayesian_model_fits_interval_shape_not_null NOT NULL,
     interval_element_count integer,
     interval_summary_bytes integer,
-    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying NOT NULL,
+    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying CONSTRAINT bayesian_model_fits_diagnostic_status_not_null NOT NULL,
     diagnostic_failure_reason character varying(64),
     diagnostic_policy_version character varying(64),
     diagnostic_target_filter_version character varying(64),
@@ -3311,46 +4120,51 @@ WITH (fillfactor='90');
 
 ALTER TABLE ONLY public.bayesian_model_fits_p13 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_model_fits_p14; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_model_fits_p14 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    model_type character varying(64) NOT NULL,
-    model_version character varying(64) NOT NULL,
-    source_window_start timestamp with time zone NOT NULL,
-    source_window_end timestamp with time zone NOT NULL,
-    source_snapshot_hash character varying(64) NOT NULL,
-    status character varying(32) DEFAULT 'pending'::character varying NOT NULL,
-    eligibility_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    fallback_applied boolean DEFAULT false NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_model_fits_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_model_fits_tenant_id_not_null1 NOT NULL,
+    model_type character varying(64) CONSTRAINT bayesian_model_fits_model_type_not_null1 NOT NULL,
+    model_version character varying(64) CONSTRAINT bayesian_model_fits_model_version_not_null1 NOT NULL,
+    source_window_start timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_start_not_null1 NOT NULL,
+    source_window_end timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_end_not_null1 NOT NULL,
+    source_snapshot_hash character varying(64) CONSTRAINT bayesian_model_fits_source_snapshot_hash_not_null1 NOT NULL,
+    status character varying(32) DEFAULT 'pending'::character varying CONSTRAINT bayesian_model_fits_status_not_null1 NOT NULL,
+    eligibility_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_eligibility_status_not_null1 NOT NULL,
+    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_data_completeness_status_not_null1 NOT NULL,
+    fallback_applied boolean DEFAULT false CONSTRAINT bayesian_model_fits_fallback_applied_not_null1 NOT NULL,
     fallback_reason character varying(64),
     sampling_started_at timestamp with time zone,
     last_eligibility_check_at timestamp with time zone,
     last_fit_at timestamp with time zone,
     completed_at timestamp with time zone,
     runtime_seconds integer,
-    max_runtime_seconds integer DEFAULT 60 NOT NULL,
-    max_samples integer DEFAULT 0 NOT NULL,
-    max_cores integer DEFAULT 1 NOT NULL,
+    max_runtime_seconds integer DEFAULT 60 CONSTRAINT bayesian_model_fits_max_runtime_seconds_not_null1 NOT NULL,
+    max_samples integer DEFAULT 0 CONSTRAINT bayesian_model_fits_max_samples_not_null1 NOT NULL,
+    max_cores integer DEFAULT 1 CONSTRAINT bayesian_model_fits_max_cores_not_null1 NOT NULL,
     n_chains integer,
     n_samples_actual integer,
     r_hat_max double precision,
     ess_min double precision,
     divergence_count integer,
-    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying NOT NULL,
+    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying CONSTRAINT bayesian_model_fits_credible_interval_status_not_null1 NOT NULL,
     confidence_bucket character varying(32),
     confidence_bucket_reason character varying(255),
     confidence_policy_version character varying(64),
     artifact_ref character varying(255),
     artifact_hash character varying(64),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_created_at_not_null1 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_updated_at_not_null1 NOT NULL,
     hdi_lower double precision,
     hdi_upper double precision,
-    interval_shape jsonb DEFAULT '[]'::jsonb NOT NULL,
+    interval_shape jsonb DEFAULT '[]'::jsonb CONSTRAINT bayesian_model_fits_interval_shape_not_null NOT NULL,
     interval_element_count integer,
     interval_summary_bytes integer,
-    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying NOT NULL,
+    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying CONSTRAINT bayesian_model_fits_diagnostic_status_not_null NOT NULL,
     diagnostic_failure_reason character varying(64),
     diagnostic_policy_version character varying(64),
     diagnostic_target_filter_version character varying(64),
@@ -3392,46 +4206,51 @@ WITH (fillfactor='90');
 
 ALTER TABLE ONLY public.bayesian_model_fits_p14 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_model_fits_p15; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.bayesian_model_fits_p15 (
-    id uuid DEFAULT gen_random_uuid() NOT NULL,
-    tenant_id uuid NOT NULL,
-    model_type character varying(64) NOT NULL,
-    model_version character varying(64) NOT NULL,
-    source_window_start timestamp with time zone NOT NULL,
-    source_window_end timestamp with time zone NOT NULL,
-    source_snapshot_hash character varying(64) NOT NULL,
-    status character varying(32) DEFAULT 'pending'::character varying NOT NULL,
-    eligibility_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying NOT NULL,
-    fallback_applied boolean DEFAULT false NOT NULL,
+    id uuid DEFAULT gen_random_uuid() CONSTRAINT bayesian_model_fits_id_not_null1 NOT NULL,
+    tenant_id uuid CONSTRAINT bayesian_model_fits_tenant_id_not_null1 NOT NULL,
+    model_type character varying(64) CONSTRAINT bayesian_model_fits_model_type_not_null1 NOT NULL,
+    model_version character varying(64) CONSTRAINT bayesian_model_fits_model_version_not_null1 NOT NULL,
+    source_window_start timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_start_not_null1 NOT NULL,
+    source_window_end timestamp with time zone CONSTRAINT bayesian_model_fits_source_window_end_not_null1 NOT NULL,
+    source_snapshot_hash character varying(64) CONSTRAINT bayesian_model_fits_source_snapshot_hash_not_null1 NOT NULL,
+    status character varying(32) DEFAULT 'pending'::character varying CONSTRAINT bayesian_model_fits_status_not_null1 NOT NULL,
+    eligibility_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_eligibility_status_not_null1 NOT NULL,
+    data_completeness_status character varying(32) DEFAULT 'unknown'::character varying CONSTRAINT bayesian_model_fits_data_completeness_status_not_null1 NOT NULL,
+    fallback_applied boolean DEFAULT false CONSTRAINT bayesian_model_fits_fallback_applied_not_null1 NOT NULL,
     fallback_reason character varying(64),
     sampling_started_at timestamp with time zone,
     last_eligibility_check_at timestamp with time zone,
     last_fit_at timestamp with time zone,
     completed_at timestamp with time zone,
     runtime_seconds integer,
-    max_runtime_seconds integer DEFAULT 60 NOT NULL,
-    max_samples integer DEFAULT 0 NOT NULL,
-    max_cores integer DEFAULT 1 NOT NULL,
+    max_runtime_seconds integer DEFAULT 60 CONSTRAINT bayesian_model_fits_max_runtime_seconds_not_null1 NOT NULL,
+    max_samples integer DEFAULT 0 CONSTRAINT bayesian_model_fits_max_samples_not_null1 NOT NULL,
+    max_cores integer DEFAULT 1 CONSTRAINT bayesian_model_fits_max_cores_not_null1 NOT NULL,
     n_chains integer,
     n_samples_actual integer,
     r_hat_max double precision,
     ess_min double precision,
     divergence_count integer,
-    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying NOT NULL,
+    credible_interval_status character varying(32) DEFAULT 'not_available'::character varying CONSTRAINT bayesian_model_fits_credible_interval_status_not_null1 NOT NULL,
     confidence_bucket character varying(32),
     confidence_bucket_reason character varying(255),
     confidence_policy_version character varying(64),
     artifact_ref character varying(255),
     artifact_hash character varying(64),
-    created_at timestamp with time zone DEFAULT now() NOT NULL,
-    updated_at timestamp with time zone DEFAULT now() NOT NULL,
+    created_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_created_at_not_null1 NOT NULL,
+    updated_at timestamp with time zone DEFAULT now() CONSTRAINT bayesian_model_fits_updated_at_not_null1 NOT NULL,
     hdi_lower double precision,
     hdi_upper double precision,
-    interval_shape jsonb DEFAULT '[]'::jsonb NOT NULL,
+    interval_shape jsonb DEFAULT '[]'::jsonb CONSTRAINT bayesian_model_fits_interval_shape_not_null NOT NULL,
     interval_element_count integer,
     interval_summary_bytes integer,
-    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying NOT NULL,
+    diagnostic_status character varying(32) DEFAULT 'not_computed'::character varying CONSTRAINT bayesian_model_fits_diagnostic_status_not_null NOT NULL,
     diagnostic_failure_reason character varying(64),
     diagnostic_policy_version character varying(64),
     diagnostic_target_filter_version character varying(64),
@@ -3473,6 +4292,11 @@ WITH (fillfactor='90');
 
 ALTER TABLE ONLY public.bayesian_model_fits_p15 FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: budget_jobs; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.budget_jobs (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     tenant_id uuid NOT NULL,
@@ -3498,6 +4322,11 @@ CREATE TABLE public.budget_jobs (
 
 ALTER TABLE ONLY public.budget_jobs FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: budget_optimization_jobs; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.budget_optimization_jobs (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     tenant_id uuid NOT NULL,
@@ -3515,6 +4344,11 @@ CREATE TABLE public.budget_optimization_jobs (
 
 ALTER TABLE ONLY public.budget_optimization_jobs FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: celery_taskmeta; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.celery_taskmeta (
     id integer NOT NULL,
     task_id character varying(155) NOT NULL,
@@ -3529,6 +4363,11 @@ CREATE TABLE public.celery_taskmeta (
     retries integer
 );
 
+
+--
+-- Name: celery_taskmeta_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
 CREATE SEQUENCE public.celery_taskmeta_id_seq
     AS integer
     START WITH 1
@@ -3537,7 +4376,17 @@ CREATE SEQUENCE public.celery_taskmeta_id_seq
     NO MAXVALUE
     CACHE 1;
 
+
+--
+-- Name: celery_taskmeta_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
 ALTER SEQUENCE public.celery_taskmeta_id_seq OWNED BY public.celery_taskmeta.id;
+
+
+--
+-- Name: celery_tasksetmeta; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.celery_tasksetmeta (
     id integer NOT NULL,
@@ -3545,6 +4394,11 @@ CREATE TABLE public.celery_tasksetmeta (
     result bytea,
     date_done timestamp without time zone DEFAULT CURRENT_TIMESTAMP
 );
+
+
+--
+-- Name: celery_tasksetmeta_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
 
 CREATE SEQUENCE public.celery_tasksetmeta_id_seq
     AS integer
@@ -3554,7 +4408,17 @@ CREATE SEQUENCE public.celery_tasksetmeta_id_seq
     NO MAXVALUE
     CACHE 1;
 
+
+--
+-- Name: celery_tasksetmeta_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
 ALTER SEQUENCE public.celery_tasksetmeta_id_seq OWNED BY public.celery_tasksetmeta.id;
+
+
+--
+-- Name: channel_assignment_corrections; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.channel_assignment_corrections (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -3572,6 +4436,11 @@ CREATE TABLE public.channel_assignment_corrections (
 
 ALTER TABLE ONLY public.channel_assignment_corrections FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: channel_state_transitions; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.channel_state_transitions (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     channel_code character varying(50) NOT NULL,
@@ -3583,6 +4452,11 @@ CREATE TABLE public.channel_state_transitions (
     metadata jsonb
 );
 
+
+--
+-- Name: channel_taxonomy; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.channel_taxonomy (
     code text NOT NULL,
     family text NOT NULL,
@@ -3593,6 +4467,11 @@ CREATE TABLE public.channel_taxonomy (
     state character varying(50) DEFAULT 'active'::character varying NOT NULL,
     CONSTRAINT channel_taxonomy_state_check CHECK (((state)::text = ANY ((ARRAY['draft'::character varying, 'active'::character varying, 'deprecated'::character varying, 'archived'::character varying])::text[])))
 );
+
+
+--
+-- Name: compliance_audit_ledger; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.compliance_audit_ledger (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -3611,6 +4490,11 @@ CREATE TABLE public.compliance_audit_ledger (
 );
 
 ALTER TABLE ONLY public.compliance_audit_ledger FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: dead_events; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.dead_events (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -3638,6 +4522,11 @@ CREATE TABLE public.dead_events (
 
 ALTER TABLE ONLY public.dead_events FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: dead_events_quarantine; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.dead_events_quarantine (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     tenant_id uuid,
@@ -3655,6 +4544,11 @@ CREATE TABLE public.dead_events_quarantine (
 
 ALTER TABLE ONLY public.dead_events_quarantine FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: ephemeral_click_resolution; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.ephemeral_click_resolution (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     tenant_id uuid NOT NULL,
@@ -3670,6 +4564,11 @@ CREATE TABLE public.ephemeral_click_resolution (
 );
 
 ALTER TABLE ONLY public.ephemeral_click_resolution FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: ephemeral_order_resolution; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.ephemeral_order_resolution (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -3687,6 +4586,11 @@ CREATE TABLE public.ephemeral_order_resolution (
 
 ALTER TABLE ONLY public.ephemeral_order_resolution FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: explanation_cache; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.explanation_cache (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     tenant_id uuid NOT NULL,
@@ -3701,6 +4605,11 @@ CREATE TABLE public.explanation_cache (
 );
 
 ALTER TABLE ONLY public.explanation_cache FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: investigation_jobs; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.investigation_jobs (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -3731,6 +4640,11 @@ CREATE TABLE public.investigation_jobs (
 
 ALTER TABLE ONLY public.investigation_jobs FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: investigation_tool_calls; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.investigation_tool_calls (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     tenant_id uuid NOT NULL,
@@ -3742,6 +4656,11 @@ CREATE TABLE public.investigation_tool_calls (
 );
 
 ALTER TABLE ONLY public.investigation_tool_calls FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: investigations; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.investigations (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -3761,6 +4680,11 @@ CREATE TABLE public.investigations (
 
 ALTER TABLE ONLY public.investigations FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: jwt_verification_cache; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.jwt_verification_cache (
     singleton_id smallint NOT NULL,
     jwks_json text,
@@ -3774,6 +4698,11 @@ CREATE TABLE public.jwt_verification_cache (
     CONSTRAINT jwt_verification_cache_singleton_id_check CHECK ((singleton_id = 1))
 );
 
+
+--
+-- Name: kombu_message; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.kombu_message (
     id integer NOT NULL,
     visible boolean DEFAULT true NOT NULL,
@@ -3783,6 +4712,11 @@ CREATE TABLE public.kombu_message (
     queue_id integer NOT NULL
 );
 
+
+--
+-- Name: kombu_message_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
 CREATE SEQUENCE public.kombu_message_id_seq
     AS integer
     START WITH 1
@@ -3791,12 +4725,27 @@ CREATE SEQUENCE public.kombu_message_id_seq
     NO MAXVALUE
     CACHE 1;
 
+
+--
+-- Name: kombu_message_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
 ALTER SEQUENCE public.kombu_message_id_seq OWNED BY public.kombu_message.id;
+
+
+--
+-- Name: kombu_queue; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.kombu_queue (
     id integer NOT NULL,
     name character varying(200) NOT NULL
 );
+
+
+--
+-- Name: kombu_queue_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
 
 CREATE SEQUENCE public.kombu_queue_id_seq
     AS integer
@@ -3806,7 +4755,17 @@ CREATE SEQUENCE public.kombu_queue_id_seq
     NO MAXVALUE
     CACHE 1;
 
+
+--
+-- Name: kombu_queue_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
 ALTER SEQUENCE public.kombu_queue_id_seq OWNED BY public.kombu_queue.id;
+
+
+--
+-- Name: llm_api_calls; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.llm_api_calls (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -3860,6 +4819,11 @@ CREATE TABLE public.llm_api_calls (
 
 ALTER TABLE ONLY public.llm_api_calls FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: llm_breaker_state; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.llm_breaker_state (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     tenant_id uuid NOT NULL,
@@ -3875,6 +4839,11 @@ CREATE TABLE public.llm_breaker_state (
 );
 
 ALTER TABLE ONLY public.llm_breaker_state FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: llm_budget_reservations; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.llm_budget_reservations (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -3894,6 +4863,11 @@ CREATE TABLE public.llm_budget_reservations (
 );
 
 ALTER TABLE ONLY public.llm_budget_reservations FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: llm_call_audit; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.llm_call_audit (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -3916,6 +4890,11 @@ CREATE TABLE public.llm_call_audit (
 
 ALTER TABLE ONLY public.llm_call_audit FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: llm_hourly_shutoff_state; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.llm_hourly_shutoff_state (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     tenant_id uuid NOT NULL,
@@ -3935,6 +4914,11 @@ CREATE TABLE public.llm_hourly_shutoff_state (
 
 ALTER TABLE ONLY public.llm_hourly_shutoff_state FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: llm_monthly_budget_state; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.llm_monthly_budget_state (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     tenant_id uuid NOT NULL,
@@ -3951,6 +4935,11 @@ CREATE TABLE public.llm_monthly_budget_state (
 
 ALTER TABLE ONLY public.llm_monthly_budget_state FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: llm_monthly_costs; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.llm_monthly_costs (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     tenant_id uuid NOT NULL,
@@ -3965,6 +4954,11 @@ CREATE TABLE public.llm_monthly_costs (
 );
 
 ALTER TABLE ONLY public.llm_monthly_costs FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: llm_semantic_cache; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.llm_semantic_cache (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -3992,6 +4986,11 @@ CREATE TABLE public.llm_semantic_cache (
 
 ALTER TABLE ONLY public.llm_semantic_cache FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: llm_validation_failures; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.llm_validation_failures (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     tenant_id uuid NOT NULL,
@@ -4004,6 +5003,11 @@ CREATE TABLE public.llm_validation_failures (
 
 ALTER TABLE ONLY public.llm_validation_failures FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: message_id_sequence; Type: SEQUENCE; Schema: public; Owner: -
+--
+
 CREATE SEQUENCE public.message_id_sequence
     START WITH 1
     INCREMENT BY 1
@@ -4011,28 +5015,43 @@ CREATE SEQUENCE public.message_id_sequence
     NO MAXVALUE
     CACHE 1;
 
+
+--
+-- Name: message_id_sequence; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
 ALTER SEQUENCE public.message_id_sequence OWNED BY public.kombu_message.id;
 
-CREATE MATERIALIZED VIEW mv_allocation_summary AS
- SELECT tenant_id,
-    event_id,
-    model_version,
-    sum(allocated_revenue_cents) AS total_allocated_cents,
-    revenue_cents AS event_revenue_cents,
+
+--
+-- Name: mv_allocation_summary; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.mv_allocation_summary AS
+ SELECT aa.tenant_id,
+    aa.event_id,
+    aa.model_version,
+    sum(aa.allocated_revenue_cents) AS total_allocated_cents,
+    e.revenue_cents AS event_revenue_cents,
         CASE
-            WHEN (revenue_cents IS NULL) THEN NULL::boolean
-            ELSE (sum(allocated_revenue_cents) = revenue_cents)
+            WHEN (e.revenue_cents IS NULL) THEN NULL::boolean
+            ELSE (sum(aa.allocated_revenue_cents) = e.revenue_cents)
         END AS is_balanced,
         CASE
-            WHEN (revenue_cents IS NULL) THEN NULL::bigint
-            ELSE abs((sum(allocated_revenue_cents) - revenue_cents))
+            WHEN (e.revenue_cents IS NULL) THEN NULL::bigint
+            ELSE abs((sum(aa.allocated_revenue_cents) - e.revenue_cents))
         END AS drift_cents
-   FROM (attribution_allocations aa
-     LEFT JOIN attribution_events e ON ((event_id = id)))
-  GROUP BY tenant_id, event_id, model_version, revenue_cents
+   FROM (public.attribution_allocations aa
+     LEFT JOIN public.attribution_events e ON ((aa.event_id = e.id)))
+  GROUP BY aa.tenant_id, aa.event_id, aa.model_version, e.revenue_cents
   WITH NO DATA;
 
-CREATE MATERIALIZED VIEW mv_channel_performance AS
+
+--
+-- Name: mv_channel_performance; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.mv_channel_performance AS
  SELECT tenant_id,
     channel_code,
     date_trunc('day'::text, created_at) AS allocation_date,
@@ -4040,10 +5059,15 @@ CREATE MATERIALIZED VIEW mv_channel_performance AS
     sum(allocated_revenue_cents) AS total_revenue_cents,
     avg(confidence_score) AS avg_confidence_score,
     count(*) AS total_allocations
-   FROM attribution_allocations
+   FROM public.attribution_allocations
   WHERE (created_at >= (CURRENT_DATE - '90 days'::interval))
   GROUP BY tenant_id, channel_code, (date_trunc('day'::text, created_at))
   WITH NO DATA;
+
+
+--
+-- Name: revenue_ledger; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.revenue_ledger (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -4081,26 +5105,41 @@ CREATE TABLE public.revenue_ledger (
 
 ALTER TABLE ONLY public.revenue_ledger FORCE ROW LEVEL SECURITY;
 
-CREATE MATERIALIZED VIEW mv_daily_revenue_summary AS
+
+--
+-- Name: mv_daily_revenue_summary; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.mv_daily_revenue_summary AS
  SELECT tenant_id,
     date_trunc('day'::text, verification_timestamp) AS revenue_date,
     state,
     currency,
     sum(amount_cents) AS total_amount_cents,
     count(*) AS transaction_count
-   FROM revenue_ledger
+   FROM public.revenue_ledger
   WHERE ((state)::text = ANY ((ARRAY['captured'::character varying, 'refunded'::character varying, 'chargeback'::character varying])::text[]))
   GROUP BY tenant_id, (date_trunc('day'::text, verification_timestamp)), state, currency
   WITH NO DATA;
 
-CREATE MATERIALIZED VIEW mv_realtime_revenue AS
+
+--
+-- Name: mv_realtime_revenue; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.mv_realtime_revenue AS
  SELECT tenant_id,
     ((COALESCE(sum(COALESCE(amount_cents, revenue_cents)), (0)::bigint))::numeric / 100.0) AS total_revenue,
     bool_or(COALESCE(is_verified, false)) AS verified,
     (EXTRACT(epoch FROM (now() - max(updated_at))))::integer AS data_freshness_seconds
-   FROM revenue_ledger rl
+   FROM public.revenue_ledger rl
   GROUP BY tenant_id
   WITH NO DATA;
+
+
+--
+-- Name: reconciliation_runs; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.reconciliation_runs (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -4117,17 +5156,27 @@ CREATE TABLE public.reconciliation_runs (
 
 ALTER TABLE ONLY public.reconciliation_runs FORCE ROW LEVEL SECURITY;
 
-CREATE MATERIALIZED VIEW mv_reconciliation_status AS
- SELECT tenant_id,
-    state,
-    last_run_at,
-    id AS reconciliation_run_id
-   FROM (reconciliation_runs rr
-     JOIN ( SELECT tenant_id,
-            max(last_run_at) AS max_last_run_at
-           FROM reconciliation_runs
-          GROUP BY tenant_id) latest ON (((tenant_id = tenant_id) AND (last_run_at = max_last_run_at))))
+
+--
+-- Name: mv_reconciliation_status; Type: MATERIALIZED VIEW; Schema: public; Owner: -
+--
+
+CREATE MATERIALIZED VIEW public.mv_reconciliation_status AS
+ SELECT rr.tenant_id,
+    rr.state,
+    rr.last_run_at,
+    rr.id AS reconciliation_run_id
+   FROM (public.reconciliation_runs rr
+     JOIN ( SELECT reconciliation_runs.tenant_id,
+            max(reconciliation_runs.last_run_at) AS max_last_run_at
+           FROM public.reconciliation_runs
+          GROUP BY reconciliation_runs.tenant_id) latest ON (((rr.tenant_id = latest.tenant_id) AND (rr.last_run_at = latest.max_last_run_at))))
   WITH NO DATA;
+
+
+--
+-- Name: oauth_handshake_sessions; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.oauth_handshake_sessions (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -4157,6 +5206,11 @@ CREATE TABLE public.oauth_handshake_sessions (
 
 ALTER TABLE ONLY public.oauth_handshake_sessions FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: pii_audit_findings; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.pii_audit_findings (
     id bigint NOT NULL,
     table_name text NOT NULL,
@@ -4167,6 +5221,11 @@ CREATE TABLE public.pii_audit_findings (
     detected_at timestamp with time zone DEFAULT now() NOT NULL
 );
 
+
+--
+-- Name: pii_audit_findings_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
 CREATE SEQUENCE public.pii_audit_findings_id_seq
     START WITH 1
     INCREMENT BY 1
@@ -4174,7 +5233,17 @@ CREATE SEQUENCE public.pii_audit_findings_id_seq
     NO MAXVALUE
     CACHE 1;
 
+
+--
+-- Name: pii_audit_findings_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
 ALTER SEQUENCE public.pii_audit_findings_id_seq OWNED BY public.pii_audit_findings.id;
+
+
+--
+-- Name: platform_connections; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.platform_connections (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -4189,6 +5258,11 @@ CREATE TABLE public.platform_connections (
 );
 
 ALTER TABLE ONLY public.platform_connections FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: platform_credentials; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.platform_credentials (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -4218,6 +5292,11 @@ CREATE TABLE public.platform_credentials (
 
 ALTER TABLE ONLY public.platform_credentials FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: queue_id_sequence; Type: SEQUENCE; Schema: public; Owner: -
+--
+
 CREATE SEQUENCE public.queue_id_sequence
     START WITH 1
     INCREMENT BY 1
@@ -4225,7 +5304,17 @@ CREATE SEQUENCE public.queue_id_sequence
     NO MAXVALUE
     CACHE 1;
 
+
+--
+-- Name: queue_id_sequence; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
 ALTER SEQUENCE public.queue_id_sequence OWNED BY public.kombu_queue.id;
+
+
+--
+-- Name: r4_crash_barriers; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.r4_crash_barriers (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -4240,11 +5329,21 @@ CREATE TABLE public.r4_crash_barriers (
 
 ALTER TABLE ONLY public.r4_crash_barriers FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: r4_recovery_exclusions; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.r4_recovery_exclusions (
     scenario text NOT NULL,
     task_id text NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL
 );
+
+
+--
+-- Name: r4_task_attempts; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.r4_task_attempts (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -4258,6 +5357,11 @@ CREATE TABLE public.r4_task_attempts (
 );
 
 ALTER TABLE ONLY public.r4_task_attempts FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: raw_event_payloads; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.raw_event_payloads (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -4275,6 +5379,11 @@ CREATE TABLE public.raw_event_payloads (
 
 ALTER TABLE ONLY public.raw_event_payloads FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: revenue_cache_entries; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.revenue_cache_entries (
     tenant_id uuid NOT NULL,
     cache_key text NOT NULL,
@@ -4291,6 +5400,11 @@ CREATE TABLE public.revenue_cache_entries (
 
 ALTER TABLE ONLY public.revenue_cache_entries FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: revenue_state_transitions; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.revenue_state_transitions (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     ledger_id uuid NOT NULL,
@@ -4303,6 +5417,11 @@ CREATE TABLE public.revenue_state_transitions (
 
 ALTER TABLE ONLY public.revenue_state_transitions FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: roles; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.roles (
     code text NOT NULL,
     description text NOT NULL,
@@ -4310,6 +5429,11 @@ CREATE TABLE public.roles (
     CONSTRAINT ck_roles_code_lowercase CHECK ((code = lower(code))),
     CONSTRAINT ck_roles_code_not_empty CHECK ((length(TRIM(BOTH FROM code)) > 0))
 );
+
+
+--
+-- Name: session_authority; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.session_authority (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -4330,6 +5454,11 @@ CREATE TABLE public.session_authority (
 
 ALTER TABLE ONLY public.session_authority FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: task_id_sequence; Type: SEQUENCE; Schema: public; Owner: -
+--
+
 CREATE SEQUENCE public.task_id_sequence
     START WITH 1
     INCREMENT BY 1
@@ -4337,7 +5466,17 @@ CREATE SEQUENCE public.task_id_sequence
     NO MAXVALUE
     CACHE 1;
 
+
+--
+-- Name: task_id_sequence; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
 ALTER SEQUENCE public.task_id_sequence OWNED BY public.celery_taskmeta.id;
+
+
+--
+-- Name: taskset_id_sequence; Type: SEQUENCE; Schema: public; Owner: -
+--
 
 CREATE SEQUENCE public.taskset_id_sequence
     START WITH 1
@@ -4346,7 +5485,17 @@ CREATE SEQUENCE public.taskset_id_sequence
     NO MAXVALUE
     CACHE 1;
 
+
+--
+-- Name: taskset_id_sequence; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
 ALTER SEQUENCE public.taskset_id_sequence OWNED BY public.celery_tasksetmeta.id;
+
+
+--
+-- Name: tenant_membership_roles; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.tenant_membership_roles (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -4359,6 +5508,11 @@ CREATE TABLE public.tenant_membership_roles (
 
 ALTER TABLE ONLY public.tenant_membership_roles FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: tenant_memberships; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.tenant_memberships (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     tenant_id uuid NOT NULL,
@@ -4370,6 +5524,11 @@ CREATE TABLE public.tenant_memberships (
 );
 
 ALTER TABLE ONLY public.tenant_memberships FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: tenants; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.tenants (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -4389,6 +5548,11 @@ CREATE TABLE public.tenants (
     CONSTRAINT ck_tenants_name_not_empty CHECK ((length(TRIM(BOTH FROM name)) > 0))
 );
 
+
+--
+-- Name: users; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.users (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     login_identifier_hash text NOT NULL,
@@ -4404,21 +5568,26 @@ CREATE TABLE public.users (
 
 ALTER TABLE ONLY public.users FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: webhook_ingress_identities; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.webhook_ingress_identities (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     tenant_id uuid NOT NULL,
     event_id uuid NOT NULL,
     provider character varying(32) NOT NULL,
-    provider_native_event_reference character varying(255) NOT NULL,
-    provider_native_commerce_reference character varying(255) NOT NULL,
-    normalized_commerce_reference_kind character varying(64) NOT NULL,
-    normalized_commerce_reference_value character varying(255) NOT NULL,
+    provider_native_event_reference character varying(255) CONSTRAINT webhook_ingress_identities_provider_native_event_refer_not_null NOT NULL,
+    provider_native_commerce_reference character varying(255) CONSTRAINT webhook_ingress_identities_provider_native_commerce_re_not_null NOT NULL,
+    normalized_commerce_reference_kind character varying(64) CONSTRAINT webhook_ingress_identities_normalized_commerce_referen_not_null NOT NULL,
+    normalized_commerce_reference_value character varying(255) CONSTRAINT webhook_ingress_identities_normalized_commerce_refere_not_null1 NOT NULL,
     verified_amount_minor integer NOT NULL,
     verified_amount_currency character(3) NOT NULL,
     verified_amount_scale integer DEFAULT 2 NOT NULL,
     event_timestamp timestamp with time zone NOT NULL,
     idempotency_key character varying(255) NOT NULL,
-    verified_commerce_ingress_state character varying(64) NOT NULL,
+    verified_commerce_ingress_state character varying(64) CONSTRAINT webhook_ingress_identities_verified_commerce_ingress_s_not_null NOT NULL,
     verified_at timestamp with time zone DEFAULT now() NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
@@ -4428,31 +5597,41 @@ CREATE TABLE public.webhook_ingress_identities (
 
 ALTER TABLE ONLY public.webhook_ingress_identities FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: worker_failed_jobs; Type: TABLE; Schema: public; Owner: -
+--
+
 CREATE TABLE public.worker_failed_jobs (
-    id uuid NOT NULL,
-    task_id character varying(155) NOT NULL,
-    task_name character varying(255) NOT NULL,
+    id uuid CONSTRAINT celery_task_failures_id_not_null NOT NULL,
+    task_id character varying(155) CONSTRAINT celery_task_failures_task_id_not_null NOT NULL,
+    task_name character varying(255) CONSTRAINT celery_task_failures_task_name_not_null NOT NULL,
     queue character varying(100),
     worker character varying(255),
     task_args jsonb,
     task_kwargs jsonb,
     tenant_id uuid,
-    error_type character varying(100) NOT NULL,
-    exception_class character varying(255) NOT NULL,
-    error_message text NOT NULL,
+    error_type character varying(100) CONSTRAINT celery_task_failures_error_type_not_null NOT NULL,
+    exception_class character varying(255) CONSTRAINT celery_task_failures_exception_class_not_null NOT NULL,
+    error_message text CONSTRAINT celery_task_failures_error_message_not_null NOT NULL,
     traceback text,
-    retry_count integer DEFAULT 0 NOT NULL,
+    retry_count integer DEFAULT 0 CONSTRAINT celery_task_failures_retry_count_not_null NOT NULL,
     last_retry_at timestamp with time zone,
-    status character varying(50) DEFAULT '''pending'''::character varying NOT NULL,
+    status character varying(50) DEFAULT '''pending'''::character varying CONSTRAINT celery_task_failures_status_not_null NOT NULL,
     remediation_notes text,
     resolved_at timestamp with time zone,
     correlation_id uuid,
-    failed_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    failed_at timestamp with time zone DEFAULT CURRENT_TIMESTAMP CONSTRAINT celery_task_failures_failed_at_not_null NOT NULL,
     CONSTRAINT ck_worker_failed_jobs_retry_count_positive CHECK ((retry_count >= 0)),
     CONSTRAINT ck_worker_failed_jobs_status_valid CHECK (((status)::text = ANY ((ARRAY['pending'::character varying, 'in_progress'::character varying, 'resolved'::character varying, 'abandoned'::character varying])::text[])))
 );
 
 ALTER TABLE ONLY public.worker_failed_jobs FORCE ROW LEVEL SECURITY;
+
+
+--
+-- Name: worker_side_effects; Type: TABLE; Schema: public; Owner: -
+--
 
 CREATE TABLE public.worker_side_effects (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
@@ -4465,2513 +5644,8146 @@ CREATE TABLE public.worker_side_effects (
 
 ALTER TABLE ONLY public.worker_side_effects FORCE ROW LEVEL SECURITY;
 
+
+--
+-- Name: bayesian_artifacts_p00; Type: TABLE ATTACH; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts ATTACH PARTITION public.bayesian_artifacts_p00 FOR VALUES WITH (modulus 16, remainder 0);
+
+
+--
+-- Name: bayesian_artifacts_p01; Type: TABLE ATTACH; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts ATTACH PARTITION public.bayesian_artifacts_p01 FOR VALUES WITH (modulus 16, remainder 1);
 
+
+--
+-- Name: bayesian_artifacts_p02; Type: TABLE ATTACH; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts ATTACH PARTITION public.bayesian_artifacts_p02 FOR VALUES WITH (modulus 16, remainder 2);
+
+
+--
+-- Name: bayesian_artifacts_p03; Type: TABLE ATTACH; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts ATTACH PARTITION public.bayesian_artifacts_p03 FOR VALUES WITH (modulus 16, remainder 3);
 
+
+--
+-- Name: bayesian_artifacts_p04; Type: TABLE ATTACH; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts ATTACH PARTITION public.bayesian_artifacts_p04 FOR VALUES WITH (modulus 16, remainder 4);
+
+
+--
+-- Name: bayesian_artifacts_p05; Type: TABLE ATTACH; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts ATTACH PARTITION public.bayesian_artifacts_p05 FOR VALUES WITH (modulus 16, remainder 5);
 
+
+--
+-- Name: bayesian_artifacts_p06; Type: TABLE ATTACH; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts ATTACH PARTITION public.bayesian_artifacts_p06 FOR VALUES WITH (modulus 16, remainder 6);
+
+
+--
+-- Name: bayesian_artifacts_p07; Type: TABLE ATTACH; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts ATTACH PARTITION public.bayesian_artifacts_p07 FOR VALUES WITH (modulus 16, remainder 7);
 
+
+--
+-- Name: bayesian_artifacts_p08; Type: TABLE ATTACH; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts ATTACH PARTITION public.bayesian_artifacts_p08 FOR VALUES WITH (modulus 16, remainder 8);
+
+
+--
+-- Name: bayesian_artifacts_p09; Type: TABLE ATTACH; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts ATTACH PARTITION public.bayesian_artifacts_p09 FOR VALUES WITH (modulus 16, remainder 9);
 
+
+--
+-- Name: bayesian_artifacts_p10; Type: TABLE ATTACH; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts ATTACH PARTITION public.bayesian_artifacts_p10 FOR VALUES WITH (modulus 16, remainder 10);
+
+
+--
+-- Name: bayesian_artifacts_p11; Type: TABLE ATTACH; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts ATTACH PARTITION public.bayesian_artifacts_p11 FOR VALUES WITH (modulus 16, remainder 11);
 
+
+--
+-- Name: bayesian_artifacts_p12; Type: TABLE ATTACH; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts ATTACH PARTITION public.bayesian_artifacts_p12 FOR VALUES WITH (modulus 16, remainder 12);
+
+
+--
+-- Name: bayesian_artifacts_p13; Type: TABLE ATTACH; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts ATTACH PARTITION public.bayesian_artifacts_p13 FOR VALUES WITH (modulus 16, remainder 13);
 
+
+--
+-- Name: bayesian_artifacts_p14; Type: TABLE ATTACH; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts ATTACH PARTITION public.bayesian_artifacts_p14 FOR VALUES WITH (modulus 16, remainder 14);
+
+
+--
+-- Name: bayesian_artifacts_p15; Type: TABLE ATTACH; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts ATTACH PARTITION public.bayesian_artifacts_p15 FOR VALUES WITH (modulus 16, remainder 15);
 
+
+--
+-- Name: bayesian_model_fits_p00; Type: TABLE ATTACH; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits ATTACH PARTITION public.bayesian_model_fits_p00 FOR VALUES WITH (modulus 16, remainder 0);
+
+
+--
+-- Name: bayesian_model_fits_p01; Type: TABLE ATTACH; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits ATTACH PARTITION public.bayesian_model_fits_p01 FOR VALUES WITH (modulus 16, remainder 1);
 
+
+--
+-- Name: bayesian_model_fits_p02; Type: TABLE ATTACH; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits ATTACH PARTITION public.bayesian_model_fits_p02 FOR VALUES WITH (modulus 16, remainder 2);
+
+
+--
+-- Name: bayesian_model_fits_p03; Type: TABLE ATTACH; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits ATTACH PARTITION public.bayesian_model_fits_p03 FOR VALUES WITH (modulus 16, remainder 3);
 
+
+--
+-- Name: bayesian_model_fits_p04; Type: TABLE ATTACH; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits ATTACH PARTITION public.bayesian_model_fits_p04 FOR VALUES WITH (modulus 16, remainder 4);
+
+
+--
+-- Name: bayesian_model_fits_p05; Type: TABLE ATTACH; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits ATTACH PARTITION public.bayesian_model_fits_p05 FOR VALUES WITH (modulus 16, remainder 5);
 
+
+--
+-- Name: bayesian_model_fits_p06; Type: TABLE ATTACH; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits ATTACH PARTITION public.bayesian_model_fits_p06 FOR VALUES WITH (modulus 16, remainder 6);
+
+
+--
+-- Name: bayesian_model_fits_p07; Type: TABLE ATTACH; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits ATTACH PARTITION public.bayesian_model_fits_p07 FOR VALUES WITH (modulus 16, remainder 7);
 
+
+--
+-- Name: bayesian_model_fits_p08; Type: TABLE ATTACH; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits ATTACH PARTITION public.bayesian_model_fits_p08 FOR VALUES WITH (modulus 16, remainder 8);
+
+
+--
+-- Name: bayesian_model_fits_p09; Type: TABLE ATTACH; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits ATTACH PARTITION public.bayesian_model_fits_p09 FOR VALUES WITH (modulus 16, remainder 9);
 
+
+--
+-- Name: bayesian_model_fits_p10; Type: TABLE ATTACH; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits ATTACH PARTITION public.bayesian_model_fits_p10 FOR VALUES WITH (modulus 16, remainder 10);
+
+
+--
+-- Name: bayesian_model_fits_p11; Type: TABLE ATTACH; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits ATTACH PARTITION public.bayesian_model_fits_p11 FOR VALUES WITH (modulus 16, remainder 11);
 
+
+--
+-- Name: bayesian_model_fits_p12; Type: TABLE ATTACH; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits ATTACH PARTITION public.bayesian_model_fits_p12 FOR VALUES WITH (modulus 16, remainder 12);
+
+
+--
+-- Name: bayesian_model_fits_p13; Type: TABLE ATTACH; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits ATTACH PARTITION public.bayesian_model_fits_p13 FOR VALUES WITH (modulus 16, remainder 13);
 
+
+--
+-- Name: bayesian_model_fits_p14; Type: TABLE ATTACH; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits ATTACH PARTITION public.bayesian_model_fits_p14 FOR VALUES WITH (modulus 16, remainder 14);
+
+
+--
+-- Name: bayesian_model_fits_p15; Type: TABLE ATTACH; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits ATTACH PARTITION public.bayesian_model_fits_p15 FOR VALUES WITH (modulus 16, remainder 15);
 
+
+--
+-- Name: celery_taskmeta id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.celery_taskmeta ALTER COLUMN id SET DEFAULT nextval('public.task_id_sequence'::regclass);
+
+
+--
+-- Name: celery_tasksetmeta id; Type: DEFAULT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.celery_tasksetmeta ALTER COLUMN id SET DEFAULT nextval('public.taskset_id_sequence'::regclass);
 
+
+--
+-- Name: kombu_message id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.kombu_message ALTER COLUMN id SET DEFAULT nextval('public.message_id_sequence'::regclass);
+
+
+--
+-- Name: kombu_queue id; Type: DEFAULT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.kombu_queue ALTER COLUMN id SET DEFAULT nextval('public.queue_id_sequence'::regclass);
 
+
+--
+-- Name: pii_audit_findings id; Type: DEFAULT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.pii_audit_findings ALTER COLUMN id SET DEFAULT nextval('public.pii_audit_findings_id_seq'::regclass);
+
+
+--
+-- Name: alembic_version alembic_version_pkc; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.alembic_version
     ADD CONSTRAINT alembic_version_pkc PRIMARY KEY (version_num);
 
+
+--
+-- Name: attribution_allocations attribution_allocations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.attribution_allocations
     ADD CONSTRAINT attribution_allocations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: attribution_commerce_identities attribution_commerce_identities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.attribution_commerce_identities
     ADD CONSTRAINT attribution_commerce_identities_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: attribution_events attribution_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.attribution_events
     ADD CONSTRAINT attribution_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: attribution_recompute_jobs attribution_recompute_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.attribution_recompute_jobs
     ADD CONSTRAINT attribution_recompute_jobs_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: auth_refresh_tokens auth_refresh_tokens_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.auth_refresh_tokens
     ADD CONSTRAINT auth_refresh_tokens_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: b23_exception_records b23_exception_records_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.b23_exception_records
     ADD CONSTRAINT b23_exception_records_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: b23_match_task_dispatches b23_match_task_dispatches_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.b23_match_task_dispatches
     ADD CONSTRAINT b23_match_task_dispatches_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: b23_match_verdicts b23_match_verdicts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.b23_match_verdicts
     ADD CONSTRAINT b23_match_verdicts_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: b23_revenue_events b23_revenue_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.b23_revenue_events
     ADD CONSTRAINT b23_revenue_events_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: b23_webhook_ingestion_logs b23_webhook_ingestion_logs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.b23_webhook_ingestion_logs
     ADD CONSTRAINT b23_webhook_ingestion_logs_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: b24_active_execution_leases b24_active_execution_leases_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.b24_active_execution_leases
     ADD CONSTRAINT b24_active_execution_leases_pkey PRIMARY KEY (tenant_id, model_type, model_version, source_window_start, source_window_end);
+
+
+--
+-- Name: b24_dirty_events b24_dirty_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.b24_dirty_events
     ADD CONSTRAINT b24_dirty_events_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: b24_feature_authority_build_outbox b24_feature_authority_build_outbox_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.b24_feature_authority_build_outbox
     ADD CONSTRAINT b24_feature_authority_build_outbox_pkey PRIMARY KEY (tenant_id, id);
+
+
+--
+-- Name: b24_feature_authority_build_requests b24_feature_authority_build_requests_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.b24_feature_authority_build_requests
     ADD CONSTRAINT b24_feature_authority_build_requests_pkey PRIMARY KEY (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash);
 
+
+--
+-- Name: b24_fit_dispatch_outbox b24_fit_dispatch_outbox_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.b24_fit_dispatch_outbox
     ADD CONSTRAINT b24_fit_dispatch_outbox_pkey PRIMARY KEY (tenant_id, id);
+
+
+--
+-- Name: b24_fit_recovery_outbox b24_fit_recovery_outbox_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.b24_fit_recovery_outbox
+    ADD CONSTRAINT b24_fit_recovery_outbox_pkey PRIMARY KEY (tenant_id, id);
+
+
+--
+-- Name: b24_source_window_feature_authority b24_source_window_feature_authority_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.b24_source_window_feature_authority
     ADD CONSTRAINT b24_source_window_feature_authority_pkey PRIMARY KEY (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash);
 
+
+--
+-- Name: bayesian_artifact_storage_quotas bayesian_artifact_storage_quotas_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifact_storage_quotas
     ADD CONSTRAINT bayesian_artifact_storage_quotas_pkey PRIMARY KEY (tenant_id);
+
+
+--
+-- Name: bayesian_artifacts bayesian_artifacts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts
     ADD CONSTRAINT bayesian_artifacts_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_artifacts_p00 bayesian_artifacts_p00_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts_p00
     ADD CONSTRAINT bayesian_artifacts_p00_pkey PRIMARY KEY (tenant_id, id);
+
+
+--
+-- Name: bayesian_artifacts uq_bayesian_artifacts_tenant_artifact_ref; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts
     ADD CONSTRAINT uq_bayesian_artifacts_tenant_artifact_ref UNIQUE (tenant_id, artifact_ref);
 
+
+--
+-- Name: bayesian_artifacts_p00 bayesian_artifacts_p00_tenant_id_artifact_ref_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts_p00
     ADD CONSTRAINT bayesian_artifacts_p00_tenant_id_artifact_ref_key UNIQUE (tenant_id, artifact_ref);
+
+
+--
+-- Name: bayesian_artifacts_p01 bayesian_artifacts_p01_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts_p01
     ADD CONSTRAINT bayesian_artifacts_p01_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_artifacts_p01 bayesian_artifacts_p01_tenant_id_artifact_ref_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts_p01
     ADD CONSTRAINT bayesian_artifacts_p01_tenant_id_artifact_ref_key UNIQUE (tenant_id, artifact_ref);
+
+
+--
+-- Name: bayesian_artifacts_p02 bayesian_artifacts_p02_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts_p02
     ADD CONSTRAINT bayesian_artifacts_p02_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_artifacts_p02 bayesian_artifacts_p02_tenant_id_artifact_ref_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts_p02
     ADD CONSTRAINT bayesian_artifacts_p02_tenant_id_artifact_ref_key UNIQUE (tenant_id, artifact_ref);
+
+
+--
+-- Name: bayesian_artifacts_p03 bayesian_artifacts_p03_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts_p03
     ADD CONSTRAINT bayesian_artifacts_p03_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_artifacts_p03 bayesian_artifacts_p03_tenant_id_artifact_ref_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts_p03
     ADD CONSTRAINT bayesian_artifacts_p03_tenant_id_artifact_ref_key UNIQUE (tenant_id, artifact_ref);
+
+
+--
+-- Name: bayesian_artifacts_p04 bayesian_artifacts_p04_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts_p04
     ADD CONSTRAINT bayesian_artifacts_p04_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_artifacts_p04 bayesian_artifacts_p04_tenant_id_artifact_ref_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts_p04
     ADD CONSTRAINT bayesian_artifacts_p04_tenant_id_artifact_ref_key UNIQUE (tenant_id, artifact_ref);
+
+
+--
+-- Name: bayesian_artifacts_p05 bayesian_artifacts_p05_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts_p05
     ADD CONSTRAINT bayesian_artifacts_p05_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_artifacts_p05 bayesian_artifacts_p05_tenant_id_artifact_ref_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts_p05
     ADD CONSTRAINT bayesian_artifacts_p05_tenant_id_artifact_ref_key UNIQUE (tenant_id, artifact_ref);
+
+
+--
+-- Name: bayesian_artifacts_p06 bayesian_artifacts_p06_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts_p06
     ADD CONSTRAINT bayesian_artifacts_p06_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_artifacts_p06 bayesian_artifacts_p06_tenant_id_artifact_ref_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts_p06
     ADD CONSTRAINT bayesian_artifacts_p06_tenant_id_artifact_ref_key UNIQUE (tenant_id, artifact_ref);
+
+
+--
+-- Name: bayesian_artifacts_p07 bayesian_artifacts_p07_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts_p07
     ADD CONSTRAINT bayesian_artifacts_p07_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_artifacts_p07 bayesian_artifacts_p07_tenant_id_artifact_ref_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts_p07
     ADD CONSTRAINT bayesian_artifacts_p07_tenant_id_artifact_ref_key UNIQUE (tenant_id, artifact_ref);
+
+
+--
+-- Name: bayesian_artifacts_p08 bayesian_artifacts_p08_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts_p08
     ADD CONSTRAINT bayesian_artifacts_p08_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_artifacts_p08 bayesian_artifacts_p08_tenant_id_artifact_ref_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts_p08
     ADD CONSTRAINT bayesian_artifacts_p08_tenant_id_artifact_ref_key UNIQUE (tenant_id, artifact_ref);
+
+
+--
+-- Name: bayesian_artifacts_p09 bayesian_artifacts_p09_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts_p09
     ADD CONSTRAINT bayesian_artifacts_p09_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_artifacts_p09 bayesian_artifacts_p09_tenant_id_artifact_ref_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts_p09
     ADD CONSTRAINT bayesian_artifacts_p09_tenant_id_artifact_ref_key UNIQUE (tenant_id, artifact_ref);
+
+
+--
+-- Name: bayesian_artifacts_p10 bayesian_artifacts_p10_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts_p10
     ADD CONSTRAINT bayesian_artifacts_p10_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_artifacts_p10 bayesian_artifacts_p10_tenant_id_artifact_ref_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts_p10
     ADD CONSTRAINT bayesian_artifacts_p10_tenant_id_artifact_ref_key UNIQUE (tenant_id, artifact_ref);
+
+
+--
+-- Name: bayesian_artifacts_p11 bayesian_artifacts_p11_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts_p11
     ADD CONSTRAINT bayesian_artifacts_p11_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_artifacts_p11 bayesian_artifacts_p11_tenant_id_artifact_ref_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts_p11
     ADD CONSTRAINT bayesian_artifacts_p11_tenant_id_artifact_ref_key UNIQUE (tenant_id, artifact_ref);
+
+
+--
+-- Name: bayesian_artifacts_p12 bayesian_artifacts_p12_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts_p12
     ADD CONSTRAINT bayesian_artifacts_p12_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_artifacts_p12 bayesian_artifacts_p12_tenant_id_artifact_ref_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts_p12
     ADD CONSTRAINT bayesian_artifacts_p12_tenant_id_artifact_ref_key UNIQUE (tenant_id, artifact_ref);
+
+
+--
+-- Name: bayesian_artifacts_p13 bayesian_artifacts_p13_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts_p13
     ADD CONSTRAINT bayesian_artifacts_p13_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_artifacts_p13 bayesian_artifacts_p13_tenant_id_artifact_ref_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts_p13
     ADD CONSTRAINT bayesian_artifacts_p13_tenant_id_artifact_ref_key UNIQUE (tenant_id, artifact_ref);
+
+
+--
+-- Name: bayesian_artifacts_p14 bayesian_artifacts_p14_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts_p14
     ADD CONSTRAINT bayesian_artifacts_p14_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_artifacts_p14 bayesian_artifacts_p14_tenant_id_artifact_ref_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts_p14
     ADD CONSTRAINT bayesian_artifacts_p14_tenant_id_artifact_ref_key UNIQUE (tenant_id, artifact_ref);
+
+
+--
+-- Name: bayesian_artifacts_p15 bayesian_artifacts_p15_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifacts_p15
     ADD CONSTRAINT bayesian_artifacts_p15_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_artifacts_p15 bayesian_artifacts_p15_tenant_id_artifact_ref_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_artifacts_p15
     ADD CONSTRAINT bayesian_artifacts_p15_tenant_id_artifact_ref_key UNIQUE (tenant_id, artifact_ref);
+
+
+--
+-- Name: bayesian_model_fits bayesian_model_fits_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits
     ADD CONSTRAINT bayesian_model_fits_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_model_fits_p00 bayesian_model_fits_p00_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits_p00
     ADD CONSTRAINT bayesian_model_fits_p00_pkey PRIMARY KEY (tenant_id, id);
+
+
+--
+-- Name: bayesian_model_fits uq_bayesian_model_fits_tenant_model_window_snapshot; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits
     ADD CONSTRAINT uq_bayesian_model_fits_tenant_model_window_snapshot UNIQUE (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash);
 
+
+--
+-- Name: bayesian_model_fits_p00 bayesian_model_fits_p00_tenant_id_model_type_model_version__key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits_p00
     ADD CONSTRAINT bayesian_model_fits_p00_tenant_id_model_type_model_version__key UNIQUE (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p01 bayesian_model_fits_p01_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits_p01
     ADD CONSTRAINT bayesian_model_fits_p01_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_model_fits_p01 bayesian_model_fits_p01_tenant_id_model_type_model_version__key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits_p01
     ADD CONSTRAINT bayesian_model_fits_p01_tenant_id_model_type_model_version__key UNIQUE (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p02 bayesian_model_fits_p02_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits_p02
     ADD CONSTRAINT bayesian_model_fits_p02_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_model_fits_p02 bayesian_model_fits_p02_tenant_id_model_type_model_version__key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits_p02
     ADD CONSTRAINT bayesian_model_fits_p02_tenant_id_model_type_model_version__key UNIQUE (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p03 bayesian_model_fits_p03_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits_p03
     ADD CONSTRAINT bayesian_model_fits_p03_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_model_fits_p03 bayesian_model_fits_p03_tenant_id_model_type_model_version__key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits_p03
     ADD CONSTRAINT bayesian_model_fits_p03_tenant_id_model_type_model_version__key UNIQUE (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p04 bayesian_model_fits_p04_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits_p04
     ADD CONSTRAINT bayesian_model_fits_p04_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_model_fits_p04 bayesian_model_fits_p04_tenant_id_model_type_model_version__key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits_p04
     ADD CONSTRAINT bayesian_model_fits_p04_tenant_id_model_type_model_version__key UNIQUE (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p05 bayesian_model_fits_p05_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits_p05
     ADD CONSTRAINT bayesian_model_fits_p05_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_model_fits_p05 bayesian_model_fits_p05_tenant_id_model_type_model_version__key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits_p05
     ADD CONSTRAINT bayesian_model_fits_p05_tenant_id_model_type_model_version__key UNIQUE (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p06 bayesian_model_fits_p06_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits_p06
     ADD CONSTRAINT bayesian_model_fits_p06_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_model_fits_p06 bayesian_model_fits_p06_tenant_id_model_type_model_version__key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits_p06
     ADD CONSTRAINT bayesian_model_fits_p06_tenant_id_model_type_model_version__key UNIQUE (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p07 bayesian_model_fits_p07_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits_p07
     ADD CONSTRAINT bayesian_model_fits_p07_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_model_fits_p07 bayesian_model_fits_p07_tenant_id_model_type_model_version__key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits_p07
     ADD CONSTRAINT bayesian_model_fits_p07_tenant_id_model_type_model_version__key UNIQUE (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p08 bayesian_model_fits_p08_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits_p08
     ADD CONSTRAINT bayesian_model_fits_p08_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_model_fits_p08 bayesian_model_fits_p08_tenant_id_model_type_model_version__key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits_p08
     ADD CONSTRAINT bayesian_model_fits_p08_tenant_id_model_type_model_version__key UNIQUE (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p09 bayesian_model_fits_p09_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits_p09
     ADD CONSTRAINT bayesian_model_fits_p09_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_model_fits_p09 bayesian_model_fits_p09_tenant_id_model_type_model_version__key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits_p09
     ADD CONSTRAINT bayesian_model_fits_p09_tenant_id_model_type_model_version__key UNIQUE (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p10 bayesian_model_fits_p10_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits_p10
     ADD CONSTRAINT bayesian_model_fits_p10_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_model_fits_p10 bayesian_model_fits_p10_tenant_id_model_type_model_version__key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits_p10
     ADD CONSTRAINT bayesian_model_fits_p10_tenant_id_model_type_model_version__key UNIQUE (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p11 bayesian_model_fits_p11_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits_p11
     ADD CONSTRAINT bayesian_model_fits_p11_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_model_fits_p11 bayesian_model_fits_p11_tenant_id_model_type_model_version__key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits_p11
     ADD CONSTRAINT bayesian_model_fits_p11_tenant_id_model_type_model_version__key UNIQUE (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p12 bayesian_model_fits_p12_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits_p12
     ADD CONSTRAINT bayesian_model_fits_p12_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_model_fits_p12 bayesian_model_fits_p12_tenant_id_model_type_model_version__key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits_p12
     ADD CONSTRAINT bayesian_model_fits_p12_tenant_id_model_type_model_version__key UNIQUE (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p13 bayesian_model_fits_p13_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits_p13
     ADD CONSTRAINT bayesian_model_fits_p13_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_model_fits_p13 bayesian_model_fits_p13_tenant_id_model_type_model_version__key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits_p13
     ADD CONSTRAINT bayesian_model_fits_p13_tenant_id_model_type_model_version__key UNIQUE (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p14 bayesian_model_fits_p14_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits_p14
     ADD CONSTRAINT bayesian_model_fits_p14_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_model_fits_p14 bayesian_model_fits_p14_tenant_id_model_type_model_version__key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits_p14
     ADD CONSTRAINT bayesian_model_fits_p14_tenant_id_model_type_model_version__key UNIQUE (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p15 bayesian_model_fits_p15_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_model_fits_p15
     ADD CONSTRAINT bayesian_model_fits_p15_pkey PRIMARY KEY (tenant_id, id);
 
+
+--
+-- Name: bayesian_model_fits_p15 bayesian_model_fits_p15_tenant_id_model_type_model_version__key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.bayesian_model_fits_p15
     ADD CONSTRAINT bayesian_model_fits_p15_tenant_id_model_type_model_version__key UNIQUE (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash);
+
+
+--
+-- Name: budget_jobs budget_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.budget_jobs
     ADD CONSTRAINT budget_jobs_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: budget_optimization_jobs budget_optimization_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.budget_optimization_jobs
     ADD CONSTRAINT budget_optimization_jobs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: worker_failed_jobs celery_task_failures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.worker_failed_jobs
     ADD CONSTRAINT celery_task_failures_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: celery_taskmeta celery_taskmeta_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.celery_taskmeta
     ADD CONSTRAINT celery_taskmeta_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: celery_taskmeta celery_taskmeta_task_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.celery_taskmeta
     ADD CONSTRAINT celery_taskmeta_task_id_key UNIQUE (task_id);
 
+
+--
+-- Name: celery_tasksetmeta celery_tasksetmeta_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.celery_tasksetmeta
     ADD CONSTRAINT celery_tasksetmeta_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: celery_tasksetmeta celery_tasksetmeta_taskset_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.celery_tasksetmeta
     ADD CONSTRAINT celery_tasksetmeta_taskset_id_key UNIQUE (taskset_id);
 
+
+--
+-- Name: channel_assignment_corrections channel_assignment_corrections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.channel_assignment_corrections
     ADD CONSTRAINT channel_assignment_corrections_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: channel_state_transitions channel_state_transitions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.channel_state_transitions
     ADD CONSTRAINT channel_state_transitions_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: channel_taxonomy channel_taxonomy_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.channel_taxonomy
     ADD CONSTRAINT channel_taxonomy_pkey PRIMARY KEY (code);
+
+
+--
+-- Name: b23_match_verdicts ck_b23_match_verdicts_matched_requires_attribution_event; Type: CHECK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE public.b23_match_verdicts
     ADD CONSTRAINT ck_b23_match_verdicts_matched_requires_attribution_event CHECK ((((status)::text <> ALL ((ARRAY['matched_provisional'::character varying, 'matched_confirmed'::character varying, 'adjusted'::character varying])::text[])) OR (attribution_event_id IS NOT NULL))) NOT VALID;
 
+
+--
+-- Name: compliance_audit_ledger compliance_audit_ledger_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.compliance_audit_ledger
     ADD CONSTRAINT compliance_audit_ledger_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: dead_events dead_events_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.dead_events
     ADD CONSTRAINT dead_events_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: dead_events_quarantine dead_events_quarantine_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.dead_events_quarantine
     ADD CONSTRAINT dead_events_quarantine_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: ephemeral_click_resolution ephemeral_click_resolution_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.ephemeral_click_resolution
     ADD CONSTRAINT ephemeral_click_resolution_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: ephemeral_order_resolution ephemeral_order_resolution_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.ephemeral_order_resolution
     ADD CONSTRAINT ephemeral_order_resolution_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: explanation_cache explanation_cache_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.explanation_cache
     ADD CONSTRAINT explanation_cache_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: explanation_cache explanation_cache_tenant_id_entity_type_entity_id_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.explanation_cache
     ADD CONSTRAINT explanation_cache_tenant_id_entity_type_entity_id_key UNIQUE (tenant_id, entity_type, entity_id);
+
+
+--
+-- Name: investigation_jobs investigation_jobs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.investigation_jobs
     ADD CONSTRAINT investigation_jobs_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: investigation_tool_calls investigation_tool_calls_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.investigation_tool_calls
     ADD CONSTRAINT investigation_tool_calls_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: investigations investigations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.investigations
     ADD CONSTRAINT investigations_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: jwt_verification_cache jwt_verification_cache_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.jwt_verification_cache
     ADD CONSTRAINT jwt_verification_cache_pkey PRIMARY KEY (singleton_id);
+
+
+--
+-- Name: kombu_message kombu_message_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.kombu_message
     ADD CONSTRAINT kombu_message_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: kombu_queue kombu_queue_name_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.kombu_queue
     ADD CONSTRAINT kombu_queue_name_key UNIQUE (name);
+
+
+--
+-- Name: kombu_queue kombu_queue_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.kombu_queue
     ADD CONSTRAINT kombu_queue_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: llm_api_calls llm_api_calls_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.llm_api_calls
     ADD CONSTRAINT llm_api_calls_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: llm_breaker_state llm_breaker_state_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.llm_breaker_state
     ADD CONSTRAINT llm_breaker_state_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: llm_breaker_state llm_breaker_state_tenant_id_user_id_breaker_key_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.llm_breaker_state
     ADD CONSTRAINT llm_breaker_state_tenant_id_user_id_breaker_key_key UNIQUE (tenant_id, user_id, breaker_key);
+
+
+--
+-- Name: llm_budget_reservations llm_budget_reservations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.llm_budget_reservations
     ADD CONSTRAINT llm_budget_reservations_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: llm_budget_reservations llm_budget_reservations_tenant_id_user_id_endpoint_request__key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.llm_budget_reservations
     ADD CONSTRAINT llm_budget_reservations_tenant_id_user_id_endpoint_request__key UNIQUE (tenant_id, user_id, endpoint, request_id);
+
+
+--
+-- Name: llm_call_audit llm_call_audit_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.llm_call_audit
     ADD CONSTRAINT llm_call_audit_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: llm_hourly_shutoff_state llm_hourly_shutoff_state_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.llm_hourly_shutoff_state
     ADD CONSTRAINT llm_hourly_shutoff_state_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: llm_hourly_shutoff_state llm_hourly_shutoff_state_tenant_id_user_id_hour_start_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.llm_hourly_shutoff_state
     ADD CONSTRAINT llm_hourly_shutoff_state_tenant_id_user_id_hour_start_key UNIQUE (tenant_id, user_id, hour_start);
 
+
+--
+-- Name: llm_monthly_budget_state llm_monthly_budget_state_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.llm_monthly_budget_state
     ADD CONSTRAINT llm_monthly_budget_state_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: llm_monthly_budget_state llm_monthly_budget_state_tenant_id_user_id_month_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.llm_monthly_budget_state
     ADD CONSTRAINT llm_monthly_budget_state_tenant_id_user_id_month_key UNIQUE (tenant_id, user_id, month);
 
+
+--
+-- Name: llm_monthly_costs llm_monthly_costs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.llm_monthly_costs
     ADD CONSTRAINT llm_monthly_costs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: llm_semantic_cache llm_semantic_cache_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.llm_semantic_cache
     ADD CONSTRAINT llm_semantic_cache_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: llm_semantic_cache llm_semantic_cache_tenant_id_user_id_endpoint_cache_key_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.llm_semantic_cache
     ADD CONSTRAINT llm_semantic_cache_tenant_id_user_id_endpoint_cache_key_key UNIQUE (tenant_id, user_id, endpoint, cache_key);
+
+
+--
+-- Name: llm_validation_failures llm_validation_failures_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.llm_validation_failures
     ADD CONSTRAINT llm_validation_failures_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: oauth_handshake_sessions oauth_handshake_sessions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.oauth_handshake_sessions
     ADD CONSTRAINT oauth_handshake_sessions_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: pii_audit_findings pii_audit_findings_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.pii_audit_findings
     ADD CONSTRAINT pii_audit_findings_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: auth_access_token_denylist pk_auth_access_token_denylist; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.auth_access_token_denylist
     ADD CONSTRAINT pk_auth_access_token_denylist PRIMARY KEY (tenant_id, user_id, jti);
+
+
+--
+-- Name: auth_user_token_cutoffs pk_auth_user_token_cutoffs; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.auth_user_token_cutoffs
     ADD CONSTRAINT pk_auth_user_token_cutoffs PRIMARY KEY (tenant_id, user_id);
 
+
+--
+-- Name: platform_connections platform_connections_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.platform_connections
     ADD CONSTRAINT platform_connections_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: platform_credentials platform_credentials_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.platform_credentials
     ADD CONSTRAINT platform_credentials_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: r4_crash_barriers r4_crash_barriers_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.r4_crash_barriers
     ADD CONSTRAINT r4_crash_barriers_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: r4_recovery_exclusions r4_recovery_exclusions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.r4_recovery_exclusions
     ADD CONSTRAINT r4_recovery_exclusions_pkey PRIMARY KEY (scenario, task_id);
 
+
+--
+-- Name: r4_task_attempts r4_task_attempts_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.r4_task_attempts
     ADD CONSTRAINT r4_task_attempts_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: raw_event_payloads raw_event_payloads_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.raw_event_payloads
     ADD CONSTRAINT raw_event_payloads_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: reconciliation_runs reconciliation_runs_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.reconciliation_runs
     ADD CONSTRAINT reconciliation_runs_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: revenue_cache_entries revenue_cache_entries_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.revenue_cache_entries
     ADD CONSTRAINT revenue_cache_entries_pkey PRIMARY KEY (tenant_id, cache_key);
 
+
+--
+-- Name: revenue_ledger revenue_ledger_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.revenue_ledger
     ADD CONSTRAINT revenue_ledger_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: revenue_state_transitions revenue_state_transitions_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.revenue_state_transitions
     ADD CONSTRAINT revenue_state_transitions_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: roles roles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.roles
     ADD CONSTRAINT roles_pkey PRIMARY KEY (code);
+
+
+--
+-- Name: session_authority session_authority_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.session_authority
     ADD CONSTRAINT session_authority_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: tenant_membership_roles tenant_membership_roles_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.tenant_membership_roles
     ADD CONSTRAINT tenant_membership_roles_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: tenant_memberships tenant_memberships_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.tenant_memberships
     ADD CONSTRAINT tenant_memberships_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: tenants tenants_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.tenants
     ADD CONSTRAINT tenants_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: attribution_commerce_identities uq_attr_commerce_identity_tenant_event; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.attribution_commerce_identities
     ADD CONSTRAINT uq_attr_commerce_identity_tenant_event UNIQUE (tenant_id, attribution_event_id);
 
+
+--
+-- Name: attribution_commerce_identities uq_attr_commerce_identity_tenant_provider_reference; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.attribution_commerce_identities
     ADD CONSTRAINT uq_attr_commerce_identity_tenant_provider_reference UNIQUE (tenant_id, provider, canonical_commerce_reference);
+
+
+--
+-- Name: attribution_events uq_attribution_events_tenant_idempotency_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.attribution_events
     ADD CONSTRAINT uq_attribution_events_tenant_idempotency_key UNIQUE (tenant_id, idempotency_key);
 
+
+--
+-- Name: b23_match_task_dispatches uq_b23_match_task_dispatches_task_id; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.b23_match_task_dispatches
     ADD CONSTRAINT uq_b23_match_task_dispatches_task_id UNIQUE (task_id);
+
+
+--
+-- Name: b23_match_task_dispatches uq_b23_match_task_dispatches_tenant_ingress; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.b23_match_task_dispatches
     ADD CONSTRAINT uq_b23_match_task_dispatches_tenant_ingress UNIQUE (tenant_id, webhook_ingress_identity_id);
 
+
+--
+-- Name: b23_match_verdicts uq_b23_match_verdicts_tenant_provider_event_ref; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.b23_match_verdicts
     ADD CONSTRAINT uq_b23_match_verdicts_tenant_provider_event_ref UNIQUE (tenant_id, provider, provider_native_event_reference);
+
+
+--
+-- Name: b23_revenue_events uq_b23_revenue_events_tenant_provider_event_ref; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.b23_revenue_events
     ADD CONSTRAINT uq_b23_revenue_events_tenant_provider_event_ref UNIQUE (tenant_id, provider, provider_native_event_reference);
 
+
+--
+-- Name: b24_feature_authority_build_outbox uq_b24_feature_authority_build_outbox_candidate; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.b24_feature_authority_build_outbox
     ADD CONSTRAINT uq_b24_feature_authority_build_outbox_candidate UNIQUE (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash);
+
+
+--
+-- Name: b24_feature_authority_build_outbox uq_b24_feature_authority_build_outbox_dispatch_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.b24_feature_authority_build_outbox
     ADD CONSTRAINT uq_b24_feature_authority_build_outbox_dispatch_key UNIQUE (tenant_id, dispatch_key);
 
+
+--
+-- Name: b24_fit_dispatch_outbox uq_b24_fit_dispatch_outbox_dispatch_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.b24_fit_dispatch_outbox
     ADD CONSTRAINT uq_b24_fit_dispatch_outbox_dispatch_key UNIQUE (tenant_id, dispatch_key);
+
+
+--
+-- Name: b24_fit_dispatch_outbox uq_b24_fit_dispatch_outbox_fit; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.b24_fit_dispatch_outbox
     ADD CONSTRAINT uq_b24_fit_dispatch_outbox_fit UNIQUE (tenant_id, fit_id);
 
+
+--
+-- Name: b24_fit_recovery_outbox uq_b24_fit_recovery_outbox_generation; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.b24_fit_recovery_outbox
+    ADD CONSTRAINT uq_b24_fit_recovery_outbox_generation UNIQUE (tenant_id, dispatch_id, recovery_generation);
+
+
+--
+-- Name: budget_jobs uq_budget_jobs_tenant_request_id; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.budget_jobs
     ADD CONSTRAINT uq_budget_jobs_tenant_request_id UNIQUE (tenant_id, request_id);
+
+
+--
+-- Name: budget_optimization_jobs uq_budget_optimization_jobs_tenant_request_id; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.budget_optimization_jobs
     ADD CONSTRAINT uq_budget_optimization_jobs_tenant_request_id UNIQUE (tenant_id, request_id);
 
+
+--
+-- Name: compliance_audit_ledger uq_compliance_audit_ledger_tenant_idempotency_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.compliance_audit_ledger
     ADD CONSTRAINT uq_compliance_audit_ledger_tenant_idempotency_key UNIQUE (tenant_id, idempotency_key);
+
+
+--
+-- Name: ephemeral_click_resolution uq_ephemeral_click_resolution_tenant_click; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.ephemeral_click_resolution
     ADD CONSTRAINT uq_ephemeral_click_resolution_tenant_click UNIQUE (tenant_id, click_id);
 
+
+--
+-- Name: ephemeral_order_resolution uq_ephemeral_order_resolution_tenant_order; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.ephemeral_order_resolution
     ADD CONSTRAINT uq_ephemeral_order_resolution_tenant_order UNIQUE (tenant_id, order_id);
+
+
+--
+-- Name: investigation_jobs uq_investigation_jobs_tenant_request_id; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.investigation_jobs
     ADD CONSTRAINT uq_investigation_jobs_tenant_request_id UNIQUE (tenant_id, request_id);
 
+
+--
+-- Name: investigations uq_investigations_tenant_request_id; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.investigations
     ADD CONSTRAINT uq_investigations_tenant_request_id UNIQUE (tenant_id, request_id);
+
+
+--
+-- Name: llm_api_calls uq_llm_api_calls_tenant_request_endpoint; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.llm_api_calls
     ADD CONSTRAINT uq_llm_api_calls_tenant_request_endpoint UNIQUE (tenant_id, request_id, endpoint);
 
+
+--
+-- Name: llm_monthly_costs uq_llm_monthly_costs_tenant_user_month; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.llm_monthly_costs
     ADD CONSTRAINT uq_llm_monthly_costs_tenant_user_month UNIQUE (tenant_id, user_id, month);
+
+
+--
+-- Name: oauth_handshake_sessions uq_oauth_handshake_sessions_tenant_state_hash; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.oauth_handshake_sessions
     ADD CONSTRAINT uq_oauth_handshake_sessions_tenant_state_hash UNIQUE (tenant_id, state_nonce_hash);
 
+
+--
+-- Name: raw_event_payloads uq_raw_event_payloads_tenant_event; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.raw_event_payloads
     ADD CONSTRAINT uq_raw_event_payloads_tenant_event UNIQUE (tenant_id, event_id);
+
+
+--
+-- Name: session_authority uq_session_authority_tenant_session_id; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.session_authority
     ADD CONSTRAINT uq_session_authority_tenant_session_id UNIQUE (tenant_id, session_id);
 
+
+--
+-- Name: tenant_membership_roles uq_tenant_membership_roles_membership_role; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.tenant_membership_roles
     ADD CONSTRAINT uq_tenant_membership_roles_membership_role UNIQUE (membership_id, role_code);
+
+
+--
+-- Name: tenant_memberships uq_tenant_memberships_id_tenant; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.tenant_memberships
     ADD CONSTRAINT uq_tenant_memberships_id_tenant UNIQUE (id, tenant_id);
 
+
+--
+-- Name: tenant_memberships uq_tenant_memberships_tenant_user; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.tenant_memberships
     ADD CONSTRAINT uq_tenant_memberships_tenant_user UNIQUE (tenant_id, user_id);
+
+
+--
+-- Name: webhook_ingress_identities uq_webhook_ingress_identities_event_id; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.webhook_ingress_identities
     ADD CONSTRAINT uq_webhook_ingress_identities_event_id UNIQUE (event_id);
 
+
+--
+-- Name: webhook_ingress_identities uq_webhook_ingress_identities_tenant_event; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.webhook_ingress_identities
     ADD CONSTRAINT uq_webhook_ingress_identities_tenant_event UNIQUE (tenant_id, event_id);
+
+
+--
+-- Name: webhook_ingress_identities uq_webhook_ingress_identities_tenant_idempotency; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.webhook_ingress_identities
     ADD CONSTRAINT uq_webhook_ingress_identities_tenant_idempotency UNIQUE (tenant_id, idempotency_key);
 
+
+--
+-- Name: users users_login_identifier_hash_key; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_login_identifier_hash_key UNIQUE (login_identifier_hash);
+
+
+--
+-- Name: users users_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.users
     ADD CONSTRAINT users_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: webhook_ingress_identities webhook_ingress_identities_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.webhook_ingress_identities
     ADD CONSTRAINT webhook_ingress_identities_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: worker_side_effects worker_side_effects_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.worker_side_effects
     ADD CONSTRAINT worker_side_effects_pkey PRIMARY KEY (id);
 
+
+--
+-- Name: idx_bayesian_artifacts_tenant_artifact_hash; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_bayesian_artifacts_tenant_artifact_hash ON ONLY public.bayesian_artifacts USING btree (tenant_id, artifact_hash);
+
+
+--
+-- Name: bayesian_artifacts_p00_tenant_id_artifact_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p00_tenant_id_artifact_hash_idx ON public.bayesian_artifacts_p00 USING btree (tenant_id, artifact_hash);
 
+
+--
+-- Name: idx_bayesian_artifacts_tenant_artifact_ref; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_bayesian_artifacts_tenant_artifact_ref ON ONLY public.bayesian_artifacts USING btree (tenant_id, artifact_ref);
+
+
+--
+-- Name: bayesian_artifacts_p00_tenant_id_artifact_ref_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p00_tenant_id_artifact_ref_idx ON public.bayesian_artifacts_p00 USING btree (tenant_id, artifact_ref);
 
+
+--
+-- Name: idx_bayesian_artifacts_tenant_fit; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_bayesian_artifacts_tenant_fit ON ONLY public.bayesian_artifacts USING btree (tenant_id, fit_id);
+
+
+--
+-- Name: bayesian_artifacts_p00_tenant_id_fit_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p00_tenant_id_fit_id_idx ON public.bayesian_artifacts_p00 USING btree (tenant_id, fit_id);
 
+
+--
+-- Name: idx_bayesian_artifacts_tenant_id; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_bayesian_artifacts_tenant_id ON ONLY public.bayesian_artifacts USING btree (tenant_id);
+
+
+--
+-- Name: bayesian_artifacts_p00_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p00_tenant_id_idx ON public.bayesian_artifacts_p00 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_artifacts_p01_tenant_id_artifact_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p01_tenant_id_artifact_hash_idx ON public.bayesian_artifacts_p01 USING btree (tenant_id, artifact_hash);
+
+
+--
+-- Name: bayesian_artifacts_p01_tenant_id_artifact_ref_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p01_tenant_id_artifact_ref_idx ON public.bayesian_artifacts_p01 USING btree (tenant_id, artifact_ref);
 
+
+--
+-- Name: bayesian_artifacts_p01_tenant_id_fit_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p01_tenant_id_fit_id_idx ON public.bayesian_artifacts_p01 USING btree (tenant_id, fit_id);
+
+
+--
+-- Name: bayesian_artifacts_p01_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p01_tenant_id_idx ON public.bayesian_artifacts_p01 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_artifacts_p02_tenant_id_artifact_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p02_tenant_id_artifact_hash_idx ON public.bayesian_artifacts_p02 USING btree (tenant_id, artifact_hash);
+
+
+--
+-- Name: bayesian_artifacts_p02_tenant_id_artifact_ref_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p02_tenant_id_artifact_ref_idx ON public.bayesian_artifacts_p02 USING btree (tenant_id, artifact_ref);
 
+
+--
+-- Name: bayesian_artifacts_p02_tenant_id_fit_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p02_tenant_id_fit_id_idx ON public.bayesian_artifacts_p02 USING btree (tenant_id, fit_id);
+
+
+--
+-- Name: bayesian_artifacts_p02_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p02_tenant_id_idx ON public.bayesian_artifacts_p02 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_artifacts_p03_tenant_id_artifact_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p03_tenant_id_artifact_hash_idx ON public.bayesian_artifacts_p03 USING btree (tenant_id, artifact_hash);
+
+
+--
+-- Name: bayesian_artifacts_p03_tenant_id_artifact_ref_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p03_tenant_id_artifact_ref_idx ON public.bayesian_artifacts_p03 USING btree (tenant_id, artifact_ref);
 
+
+--
+-- Name: bayesian_artifacts_p03_tenant_id_fit_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p03_tenant_id_fit_id_idx ON public.bayesian_artifacts_p03 USING btree (tenant_id, fit_id);
+
+
+--
+-- Name: bayesian_artifacts_p03_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p03_tenant_id_idx ON public.bayesian_artifacts_p03 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_artifacts_p04_tenant_id_artifact_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p04_tenant_id_artifact_hash_idx ON public.bayesian_artifacts_p04 USING btree (tenant_id, artifact_hash);
+
+
+--
+-- Name: bayesian_artifacts_p04_tenant_id_artifact_ref_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p04_tenant_id_artifact_ref_idx ON public.bayesian_artifacts_p04 USING btree (tenant_id, artifact_ref);
 
+
+--
+-- Name: bayesian_artifacts_p04_tenant_id_fit_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p04_tenant_id_fit_id_idx ON public.bayesian_artifacts_p04 USING btree (tenant_id, fit_id);
+
+
+--
+-- Name: bayesian_artifacts_p04_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p04_tenant_id_idx ON public.bayesian_artifacts_p04 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_artifacts_p05_tenant_id_artifact_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p05_tenant_id_artifact_hash_idx ON public.bayesian_artifacts_p05 USING btree (tenant_id, artifact_hash);
+
+
+--
+-- Name: bayesian_artifacts_p05_tenant_id_artifact_ref_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p05_tenant_id_artifact_ref_idx ON public.bayesian_artifacts_p05 USING btree (tenant_id, artifact_ref);
 
+
+--
+-- Name: bayesian_artifacts_p05_tenant_id_fit_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p05_tenant_id_fit_id_idx ON public.bayesian_artifacts_p05 USING btree (tenant_id, fit_id);
+
+
+--
+-- Name: bayesian_artifacts_p05_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p05_tenant_id_idx ON public.bayesian_artifacts_p05 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_artifacts_p06_tenant_id_artifact_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p06_tenant_id_artifact_hash_idx ON public.bayesian_artifacts_p06 USING btree (tenant_id, artifact_hash);
+
+
+--
+-- Name: bayesian_artifacts_p06_tenant_id_artifact_ref_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p06_tenant_id_artifact_ref_idx ON public.bayesian_artifacts_p06 USING btree (tenant_id, artifact_ref);
 
+
+--
+-- Name: bayesian_artifacts_p06_tenant_id_fit_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p06_tenant_id_fit_id_idx ON public.bayesian_artifacts_p06 USING btree (tenant_id, fit_id);
+
+
+--
+-- Name: bayesian_artifacts_p06_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p06_tenant_id_idx ON public.bayesian_artifacts_p06 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_artifacts_p07_tenant_id_artifact_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p07_tenant_id_artifact_hash_idx ON public.bayesian_artifacts_p07 USING btree (tenant_id, artifact_hash);
+
+
+--
+-- Name: bayesian_artifacts_p07_tenant_id_artifact_ref_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p07_tenant_id_artifact_ref_idx ON public.bayesian_artifacts_p07 USING btree (tenant_id, artifact_ref);
 
+
+--
+-- Name: bayesian_artifacts_p07_tenant_id_fit_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p07_tenant_id_fit_id_idx ON public.bayesian_artifacts_p07 USING btree (tenant_id, fit_id);
+
+
+--
+-- Name: bayesian_artifacts_p07_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p07_tenant_id_idx ON public.bayesian_artifacts_p07 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_artifacts_p08_tenant_id_artifact_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p08_tenant_id_artifact_hash_idx ON public.bayesian_artifacts_p08 USING btree (tenant_id, artifact_hash);
+
+
+--
+-- Name: bayesian_artifacts_p08_tenant_id_artifact_ref_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p08_tenant_id_artifact_ref_idx ON public.bayesian_artifacts_p08 USING btree (tenant_id, artifact_ref);
 
+
+--
+-- Name: bayesian_artifacts_p08_tenant_id_fit_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p08_tenant_id_fit_id_idx ON public.bayesian_artifacts_p08 USING btree (tenant_id, fit_id);
+
+
+--
+-- Name: bayesian_artifacts_p08_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p08_tenant_id_idx ON public.bayesian_artifacts_p08 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_artifacts_p09_tenant_id_artifact_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p09_tenant_id_artifact_hash_idx ON public.bayesian_artifacts_p09 USING btree (tenant_id, artifact_hash);
+
+
+--
+-- Name: bayesian_artifacts_p09_tenant_id_artifact_ref_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p09_tenant_id_artifact_ref_idx ON public.bayesian_artifacts_p09 USING btree (tenant_id, artifact_ref);
 
+
+--
+-- Name: bayesian_artifacts_p09_tenant_id_fit_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p09_tenant_id_fit_id_idx ON public.bayesian_artifacts_p09 USING btree (tenant_id, fit_id);
+
+
+--
+-- Name: bayesian_artifacts_p09_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p09_tenant_id_idx ON public.bayesian_artifacts_p09 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_artifacts_p10_tenant_id_artifact_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p10_tenant_id_artifact_hash_idx ON public.bayesian_artifacts_p10 USING btree (tenant_id, artifact_hash);
+
+
+--
+-- Name: bayesian_artifacts_p10_tenant_id_artifact_ref_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p10_tenant_id_artifact_ref_idx ON public.bayesian_artifacts_p10 USING btree (tenant_id, artifact_ref);
 
+
+--
+-- Name: bayesian_artifacts_p10_tenant_id_fit_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p10_tenant_id_fit_id_idx ON public.bayesian_artifacts_p10 USING btree (tenant_id, fit_id);
+
+
+--
+-- Name: bayesian_artifacts_p10_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p10_tenant_id_idx ON public.bayesian_artifacts_p10 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_artifacts_p11_tenant_id_artifact_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p11_tenant_id_artifact_hash_idx ON public.bayesian_artifacts_p11 USING btree (tenant_id, artifact_hash);
+
+
+--
+-- Name: bayesian_artifacts_p11_tenant_id_artifact_ref_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p11_tenant_id_artifact_ref_idx ON public.bayesian_artifacts_p11 USING btree (tenant_id, artifact_ref);
 
+
+--
+-- Name: bayesian_artifacts_p11_tenant_id_fit_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p11_tenant_id_fit_id_idx ON public.bayesian_artifacts_p11 USING btree (tenant_id, fit_id);
+
+
+--
+-- Name: bayesian_artifacts_p11_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p11_tenant_id_idx ON public.bayesian_artifacts_p11 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_artifacts_p12_tenant_id_artifact_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p12_tenant_id_artifact_hash_idx ON public.bayesian_artifacts_p12 USING btree (tenant_id, artifact_hash);
+
+
+--
+-- Name: bayesian_artifacts_p12_tenant_id_artifact_ref_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p12_tenant_id_artifact_ref_idx ON public.bayesian_artifacts_p12 USING btree (tenant_id, artifact_ref);
 
+
+--
+-- Name: bayesian_artifacts_p12_tenant_id_fit_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p12_tenant_id_fit_id_idx ON public.bayesian_artifacts_p12 USING btree (tenant_id, fit_id);
+
+
+--
+-- Name: bayesian_artifacts_p12_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p12_tenant_id_idx ON public.bayesian_artifacts_p12 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_artifacts_p13_tenant_id_artifact_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p13_tenant_id_artifact_hash_idx ON public.bayesian_artifacts_p13 USING btree (tenant_id, artifact_hash);
+
+
+--
+-- Name: bayesian_artifacts_p13_tenant_id_artifact_ref_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p13_tenant_id_artifact_ref_idx ON public.bayesian_artifacts_p13 USING btree (tenant_id, artifact_ref);
 
+
+--
+-- Name: bayesian_artifacts_p13_tenant_id_fit_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p13_tenant_id_fit_id_idx ON public.bayesian_artifacts_p13 USING btree (tenant_id, fit_id);
+
+
+--
+-- Name: bayesian_artifacts_p13_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p13_tenant_id_idx ON public.bayesian_artifacts_p13 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_artifacts_p14_tenant_id_artifact_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p14_tenant_id_artifact_hash_idx ON public.bayesian_artifacts_p14 USING btree (tenant_id, artifact_hash);
+
+
+--
+-- Name: bayesian_artifacts_p14_tenant_id_artifact_ref_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p14_tenant_id_artifact_ref_idx ON public.bayesian_artifacts_p14 USING btree (tenant_id, artifact_ref);
 
+
+--
+-- Name: bayesian_artifacts_p14_tenant_id_fit_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p14_tenant_id_fit_id_idx ON public.bayesian_artifacts_p14 USING btree (tenant_id, fit_id);
+
+
+--
+-- Name: bayesian_artifacts_p14_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p14_tenant_id_idx ON public.bayesian_artifacts_p14 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_artifacts_p15_tenant_id_artifact_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p15_tenant_id_artifact_hash_idx ON public.bayesian_artifacts_p15 USING btree (tenant_id, artifact_hash);
+
+
+--
+-- Name: bayesian_artifacts_p15_tenant_id_artifact_ref_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p15_tenant_id_artifact_ref_idx ON public.bayesian_artifacts_p15 USING btree (tenant_id, artifact_ref);
 
+
+--
+-- Name: bayesian_artifacts_p15_tenant_id_fit_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_artifacts_p15_tenant_id_fit_id_idx ON public.bayesian_artifacts_p15 USING btree (tenant_id, fit_id);
+
+
+--
+-- Name: bayesian_artifacts_p15_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_artifacts_p15_tenant_id_idx ON public.bayesian_artifacts_p15 USING btree (tenant_id);
 
+
+--
+-- Name: idx_bayesian_model_fits_tenant_id; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_bayesian_model_fits_tenant_id ON ONLY public.bayesian_model_fits USING btree (tenant_id);
+
+
+--
+-- Name: bayesian_model_fits_p00_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p00_tenant_id_idx ON public.bayesian_model_fits_p00 USING btree (tenant_id);
 
+
+--
+-- Name: idx_bayesian_model_fits_tenant_model_eligibility; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_bayesian_model_fits_tenant_model_eligibility ON ONLY public.bayesian_model_fits USING btree (tenant_id, model_type, eligibility_status, last_eligibility_check_at DESC);
+
+
+--
+-- Name: bayesian_model_fits_p00_tenant_id_model_type_eligibility_st_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p00_tenant_id_model_type_eligibility_st_idx ON public.bayesian_model_fits_p00 USING btree (tenant_id, model_type, eligibility_status, last_eligibility_check_at DESC);
 
+
+--
+-- Name: idx_bayesian_model_fits_tenant_model_fallback; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_bayesian_model_fits_tenant_model_fallback ON ONLY public.bayesian_model_fits USING btree (tenant_id, model_type, fallback_reason, last_eligibility_check_at DESC) WHERE (fallback_applied = true);
+
+
+--
+-- Name: bayesian_model_fits_p00_tenant_id_model_type_fallback_reaso_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p00_tenant_id_model_type_fallback_reaso_idx ON public.bayesian_model_fits_p00 USING btree (tenant_id, model_type, fallback_reason, last_eligibility_check_at DESC) WHERE (fallback_applied = true);
 
+
+--
+-- Name: idx_bayesian_model_fits_tenant_model_window; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_bayesian_model_fits_tenant_model_window ON ONLY public.bayesian_model_fits USING btree (tenant_id, model_type, source_window_start, source_window_end);
+
+
+--
+-- Name: bayesian_model_fits_p00_tenant_id_model_type_source_window__idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p00_tenant_id_model_type_source_window__idx ON public.bayesian_model_fits_p00 USING btree (tenant_id, model_type, source_window_start, source_window_end);
 
+
+--
+-- Name: idx_bayesian_model_fits_tenant_model_window_latest; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_bayesian_model_fits_tenant_model_window_latest ON ONLY public.bayesian_model_fits USING btree (tenant_id, model_type, source_window_start, source_window_end, created_at DESC);
+
+
+--
+-- Name: bayesian_model_fits_p00_tenant_id_model_type_source_window_idx1; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p00_tenant_id_model_type_source_window_idx1 ON public.bayesian_model_fits_p00 USING btree (tenant_id, model_type, source_window_start, source_window_end, created_at DESC);
 
+
+--
+-- Name: idx_bayesian_model_fits_tenant_source_snapshot_hash; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_bayesian_model_fits_tenant_source_snapshot_hash ON ONLY public.bayesian_model_fits USING btree (tenant_id, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p00_tenant_id_source_snapshot_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p00_tenant_id_source_snapshot_hash_idx ON public.bayesian_model_fits_p00 USING btree (tenant_id, source_snapshot_hash);
 
+
+--
+-- Name: idx_bayesian_model_fits_tenant_status; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_bayesian_model_fits_tenant_status ON ONLY public.bayesian_model_fits USING btree (tenant_id, status);
+
+
+--
+-- Name: bayesian_model_fits_p00_tenant_id_status_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p00_tenant_id_status_idx ON public.bayesian_model_fits_p00 USING btree (tenant_id, status);
 
+
+--
+-- Name: bayesian_model_fits_p01_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p01_tenant_id_idx ON public.bayesian_model_fits_p01 USING btree (tenant_id);
+
+
+--
+-- Name: bayesian_model_fits_p01_tenant_id_model_type_eligibility_st_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p01_tenant_id_model_type_eligibility_st_idx ON public.bayesian_model_fits_p01 USING btree (tenant_id, model_type, eligibility_status, last_eligibility_check_at DESC);
 
+
+--
+-- Name: bayesian_model_fits_p01_tenant_id_model_type_fallback_reaso_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p01_tenant_id_model_type_fallback_reaso_idx ON public.bayesian_model_fits_p01 USING btree (tenant_id, model_type, fallback_reason, last_eligibility_check_at DESC) WHERE (fallback_applied = true);
+
+
+--
+-- Name: bayesian_model_fits_p01_tenant_id_model_type_source_window__idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p01_tenant_id_model_type_source_window__idx ON public.bayesian_model_fits_p01 USING btree (tenant_id, model_type, source_window_start, source_window_end);
 
+
+--
+-- Name: bayesian_model_fits_p01_tenant_id_model_type_source_window_idx1; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p01_tenant_id_model_type_source_window_idx1 ON public.bayesian_model_fits_p01 USING btree (tenant_id, model_type, source_window_start, source_window_end, created_at DESC);
+
+
+--
+-- Name: bayesian_model_fits_p01_tenant_id_source_snapshot_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p01_tenant_id_source_snapshot_hash_idx ON public.bayesian_model_fits_p01 USING btree (tenant_id, source_snapshot_hash);
 
+
+--
+-- Name: bayesian_model_fits_p01_tenant_id_status_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p01_tenant_id_status_idx ON public.bayesian_model_fits_p01 USING btree (tenant_id, status);
+
+
+--
+-- Name: bayesian_model_fits_p02_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p02_tenant_id_idx ON public.bayesian_model_fits_p02 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_model_fits_p02_tenant_id_model_type_eligibility_st_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p02_tenant_id_model_type_eligibility_st_idx ON public.bayesian_model_fits_p02 USING btree (tenant_id, model_type, eligibility_status, last_eligibility_check_at DESC);
+
+
+--
+-- Name: bayesian_model_fits_p02_tenant_id_model_type_fallback_reaso_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p02_tenant_id_model_type_fallback_reaso_idx ON public.bayesian_model_fits_p02 USING btree (tenant_id, model_type, fallback_reason, last_eligibility_check_at DESC) WHERE (fallback_applied = true);
 
+
+--
+-- Name: bayesian_model_fits_p02_tenant_id_model_type_source_window__idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p02_tenant_id_model_type_source_window__idx ON public.bayesian_model_fits_p02 USING btree (tenant_id, model_type, source_window_start, source_window_end);
+
+
+--
+-- Name: bayesian_model_fits_p02_tenant_id_model_type_source_window_idx1; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p02_tenant_id_model_type_source_window_idx1 ON public.bayesian_model_fits_p02 USING btree (tenant_id, model_type, source_window_start, source_window_end, created_at DESC);
 
+
+--
+-- Name: bayesian_model_fits_p02_tenant_id_source_snapshot_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p02_tenant_id_source_snapshot_hash_idx ON public.bayesian_model_fits_p02 USING btree (tenant_id, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p02_tenant_id_status_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p02_tenant_id_status_idx ON public.bayesian_model_fits_p02 USING btree (tenant_id, status);
 
+
+--
+-- Name: bayesian_model_fits_p03_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p03_tenant_id_idx ON public.bayesian_model_fits_p03 USING btree (tenant_id);
+
+
+--
+-- Name: bayesian_model_fits_p03_tenant_id_model_type_eligibility_st_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p03_tenant_id_model_type_eligibility_st_idx ON public.bayesian_model_fits_p03 USING btree (tenant_id, model_type, eligibility_status, last_eligibility_check_at DESC);
 
+
+--
+-- Name: bayesian_model_fits_p03_tenant_id_model_type_fallback_reaso_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p03_tenant_id_model_type_fallback_reaso_idx ON public.bayesian_model_fits_p03 USING btree (tenant_id, model_type, fallback_reason, last_eligibility_check_at DESC) WHERE (fallback_applied = true);
+
+
+--
+-- Name: bayesian_model_fits_p03_tenant_id_model_type_source_window__idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p03_tenant_id_model_type_source_window__idx ON public.bayesian_model_fits_p03 USING btree (tenant_id, model_type, source_window_start, source_window_end);
 
+
+--
+-- Name: bayesian_model_fits_p03_tenant_id_model_type_source_window_idx1; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p03_tenant_id_model_type_source_window_idx1 ON public.bayesian_model_fits_p03 USING btree (tenant_id, model_type, source_window_start, source_window_end, created_at DESC);
+
+
+--
+-- Name: bayesian_model_fits_p03_tenant_id_source_snapshot_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p03_tenant_id_source_snapshot_hash_idx ON public.bayesian_model_fits_p03 USING btree (tenant_id, source_snapshot_hash);
 
+
+--
+-- Name: bayesian_model_fits_p03_tenant_id_status_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p03_tenant_id_status_idx ON public.bayesian_model_fits_p03 USING btree (tenant_id, status);
+
+
+--
+-- Name: bayesian_model_fits_p04_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p04_tenant_id_idx ON public.bayesian_model_fits_p04 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_model_fits_p04_tenant_id_model_type_eligibility_st_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p04_tenant_id_model_type_eligibility_st_idx ON public.bayesian_model_fits_p04 USING btree (tenant_id, model_type, eligibility_status, last_eligibility_check_at DESC);
+
+
+--
+-- Name: bayesian_model_fits_p04_tenant_id_model_type_fallback_reaso_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p04_tenant_id_model_type_fallback_reaso_idx ON public.bayesian_model_fits_p04 USING btree (tenant_id, model_type, fallback_reason, last_eligibility_check_at DESC) WHERE (fallback_applied = true);
 
+
+--
+-- Name: bayesian_model_fits_p04_tenant_id_model_type_source_window__idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p04_tenant_id_model_type_source_window__idx ON public.bayesian_model_fits_p04 USING btree (tenant_id, model_type, source_window_start, source_window_end);
+
+
+--
+-- Name: bayesian_model_fits_p04_tenant_id_model_type_source_window_idx1; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p04_tenant_id_model_type_source_window_idx1 ON public.bayesian_model_fits_p04 USING btree (tenant_id, model_type, source_window_start, source_window_end, created_at DESC);
 
+
+--
+-- Name: bayesian_model_fits_p04_tenant_id_source_snapshot_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p04_tenant_id_source_snapshot_hash_idx ON public.bayesian_model_fits_p04 USING btree (tenant_id, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p04_tenant_id_status_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p04_tenant_id_status_idx ON public.bayesian_model_fits_p04 USING btree (tenant_id, status);
 
+
+--
+-- Name: bayesian_model_fits_p05_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p05_tenant_id_idx ON public.bayesian_model_fits_p05 USING btree (tenant_id);
+
+
+--
+-- Name: bayesian_model_fits_p05_tenant_id_model_type_eligibility_st_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p05_tenant_id_model_type_eligibility_st_idx ON public.bayesian_model_fits_p05 USING btree (tenant_id, model_type, eligibility_status, last_eligibility_check_at DESC);
 
+
+--
+-- Name: bayesian_model_fits_p05_tenant_id_model_type_fallback_reaso_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p05_tenant_id_model_type_fallback_reaso_idx ON public.bayesian_model_fits_p05 USING btree (tenant_id, model_type, fallback_reason, last_eligibility_check_at DESC) WHERE (fallback_applied = true);
+
+
+--
+-- Name: bayesian_model_fits_p05_tenant_id_model_type_source_window__idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p05_tenant_id_model_type_source_window__idx ON public.bayesian_model_fits_p05 USING btree (tenant_id, model_type, source_window_start, source_window_end);
 
+
+--
+-- Name: bayesian_model_fits_p05_tenant_id_model_type_source_window_idx1; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p05_tenant_id_model_type_source_window_idx1 ON public.bayesian_model_fits_p05 USING btree (tenant_id, model_type, source_window_start, source_window_end, created_at DESC);
+
+
+--
+-- Name: bayesian_model_fits_p05_tenant_id_source_snapshot_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p05_tenant_id_source_snapshot_hash_idx ON public.bayesian_model_fits_p05 USING btree (tenant_id, source_snapshot_hash);
 
+
+--
+-- Name: bayesian_model_fits_p05_tenant_id_status_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p05_tenant_id_status_idx ON public.bayesian_model_fits_p05 USING btree (tenant_id, status);
+
+
+--
+-- Name: bayesian_model_fits_p06_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p06_tenant_id_idx ON public.bayesian_model_fits_p06 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_model_fits_p06_tenant_id_model_type_eligibility_st_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p06_tenant_id_model_type_eligibility_st_idx ON public.bayesian_model_fits_p06 USING btree (tenant_id, model_type, eligibility_status, last_eligibility_check_at DESC);
+
+
+--
+-- Name: bayesian_model_fits_p06_tenant_id_model_type_fallback_reaso_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p06_tenant_id_model_type_fallback_reaso_idx ON public.bayesian_model_fits_p06 USING btree (tenant_id, model_type, fallback_reason, last_eligibility_check_at DESC) WHERE (fallback_applied = true);
 
+
+--
+-- Name: bayesian_model_fits_p06_tenant_id_model_type_source_window__idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p06_tenant_id_model_type_source_window__idx ON public.bayesian_model_fits_p06 USING btree (tenant_id, model_type, source_window_start, source_window_end);
+
+
+--
+-- Name: bayesian_model_fits_p06_tenant_id_model_type_source_window_idx1; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p06_tenant_id_model_type_source_window_idx1 ON public.bayesian_model_fits_p06 USING btree (tenant_id, model_type, source_window_start, source_window_end, created_at DESC);
 
+
+--
+-- Name: bayesian_model_fits_p06_tenant_id_source_snapshot_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p06_tenant_id_source_snapshot_hash_idx ON public.bayesian_model_fits_p06 USING btree (tenant_id, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p06_tenant_id_status_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p06_tenant_id_status_idx ON public.bayesian_model_fits_p06 USING btree (tenant_id, status);
 
+
+--
+-- Name: bayesian_model_fits_p07_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p07_tenant_id_idx ON public.bayesian_model_fits_p07 USING btree (tenant_id);
+
+
+--
+-- Name: bayesian_model_fits_p07_tenant_id_model_type_eligibility_st_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p07_tenant_id_model_type_eligibility_st_idx ON public.bayesian_model_fits_p07 USING btree (tenant_id, model_type, eligibility_status, last_eligibility_check_at DESC);
 
+
+--
+-- Name: bayesian_model_fits_p07_tenant_id_model_type_fallback_reaso_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p07_tenant_id_model_type_fallback_reaso_idx ON public.bayesian_model_fits_p07 USING btree (tenant_id, model_type, fallback_reason, last_eligibility_check_at DESC) WHERE (fallback_applied = true);
+
+
+--
+-- Name: bayesian_model_fits_p07_tenant_id_model_type_source_window__idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p07_tenant_id_model_type_source_window__idx ON public.bayesian_model_fits_p07 USING btree (tenant_id, model_type, source_window_start, source_window_end);
 
+
+--
+-- Name: bayesian_model_fits_p07_tenant_id_model_type_source_window_idx1; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p07_tenant_id_model_type_source_window_idx1 ON public.bayesian_model_fits_p07 USING btree (tenant_id, model_type, source_window_start, source_window_end, created_at DESC);
+
+
+--
+-- Name: bayesian_model_fits_p07_tenant_id_source_snapshot_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p07_tenant_id_source_snapshot_hash_idx ON public.bayesian_model_fits_p07 USING btree (tenant_id, source_snapshot_hash);
 
+
+--
+-- Name: bayesian_model_fits_p07_tenant_id_status_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p07_tenant_id_status_idx ON public.bayesian_model_fits_p07 USING btree (tenant_id, status);
+
+
+--
+-- Name: bayesian_model_fits_p08_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p08_tenant_id_idx ON public.bayesian_model_fits_p08 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_model_fits_p08_tenant_id_model_type_eligibility_st_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p08_tenant_id_model_type_eligibility_st_idx ON public.bayesian_model_fits_p08 USING btree (tenant_id, model_type, eligibility_status, last_eligibility_check_at DESC);
+
+
+--
+-- Name: bayesian_model_fits_p08_tenant_id_model_type_fallback_reaso_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p08_tenant_id_model_type_fallback_reaso_idx ON public.bayesian_model_fits_p08 USING btree (tenant_id, model_type, fallback_reason, last_eligibility_check_at DESC) WHERE (fallback_applied = true);
 
+
+--
+-- Name: bayesian_model_fits_p08_tenant_id_model_type_source_window__idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p08_tenant_id_model_type_source_window__idx ON public.bayesian_model_fits_p08 USING btree (tenant_id, model_type, source_window_start, source_window_end);
+
+
+--
+-- Name: bayesian_model_fits_p08_tenant_id_model_type_source_window_idx1; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p08_tenant_id_model_type_source_window_idx1 ON public.bayesian_model_fits_p08 USING btree (tenant_id, model_type, source_window_start, source_window_end, created_at DESC);
 
+
+--
+-- Name: bayesian_model_fits_p08_tenant_id_source_snapshot_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p08_tenant_id_source_snapshot_hash_idx ON public.bayesian_model_fits_p08 USING btree (tenant_id, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p08_tenant_id_status_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p08_tenant_id_status_idx ON public.bayesian_model_fits_p08 USING btree (tenant_id, status);
 
+
+--
+-- Name: bayesian_model_fits_p09_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p09_tenant_id_idx ON public.bayesian_model_fits_p09 USING btree (tenant_id);
+
+
+--
+-- Name: bayesian_model_fits_p09_tenant_id_model_type_eligibility_st_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p09_tenant_id_model_type_eligibility_st_idx ON public.bayesian_model_fits_p09 USING btree (tenant_id, model_type, eligibility_status, last_eligibility_check_at DESC);
 
+
+--
+-- Name: bayesian_model_fits_p09_tenant_id_model_type_fallback_reaso_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p09_tenant_id_model_type_fallback_reaso_idx ON public.bayesian_model_fits_p09 USING btree (tenant_id, model_type, fallback_reason, last_eligibility_check_at DESC) WHERE (fallback_applied = true);
+
+
+--
+-- Name: bayesian_model_fits_p09_tenant_id_model_type_source_window__idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p09_tenant_id_model_type_source_window__idx ON public.bayesian_model_fits_p09 USING btree (tenant_id, model_type, source_window_start, source_window_end);
 
+
+--
+-- Name: bayesian_model_fits_p09_tenant_id_model_type_source_window_idx1; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p09_tenant_id_model_type_source_window_idx1 ON public.bayesian_model_fits_p09 USING btree (tenant_id, model_type, source_window_start, source_window_end, created_at DESC);
+
+
+--
+-- Name: bayesian_model_fits_p09_tenant_id_source_snapshot_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p09_tenant_id_source_snapshot_hash_idx ON public.bayesian_model_fits_p09 USING btree (tenant_id, source_snapshot_hash);
 
+
+--
+-- Name: bayesian_model_fits_p09_tenant_id_status_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p09_tenant_id_status_idx ON public.bayesian_model_fits_p09 USING btree (tenant_id, status);
+
+
+--
+-- Name: bayesian_model_fits_p10_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p10_tenant_id_idx ON public.bayesian_model_fits_p10 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_model_fits_p10_tenant_id_model_type_eligibility_st_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p10_tenant_id_model_type_eligibility_st_idx ON public.bayesian_model_fits_p10 USING btree (tenant_id, model_type, eligibility_status, last_eligibility_check_at DESC);
+
+
+--
+-- Name: bayesian_model_fits_p10_tenant_id_model_type_fallback_reaso_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p10_tenant_id_model_type_fallback_reaso_idx ON public.bayesian_model_fits_p10 USING btree (tenant_id, model_type, fallback_reason, last_eligibility_check_at DESC) WHERE (fallback_applied = true);
 
+
+--
+-- Name: bayesian_model_fits_p10_tenant_id_model_type_source_window__idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p10_tenant_id_model_type_source_window__idx ON public.bayesian_model_fits_p10 USING btree (tenant_id, model_type, source_window_start, source_window_end);
+
+
+--
+-- Name: bayesian_model_fits_p10_tenant_id_model_type_source_window_idx1; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p10_tenant_id_model_type_source_window_idx1 ON public.bayesian_model_fits_p10 USING btree (tenant_id, model_type, source_window_start, source_window_end, created_at DESC);
 
+
+--
+-- Name: bayesian_model_fits_p10_tenant_id_source_snapshot_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p10_tenant_id_source_snapshot_hash_idx ON public.bayesian_model_fits_p10 USING btree (tenant_id, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p10_tenant_id_status_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p10_tenant_id_status_idx ON public.bayesian_model_fits_p10 USING btree (tenant_id, status);
 
+
+--
+-- Name: bayesian_model_fits_p11_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p11_tenant_id_idx ON public.bayesian_model_fits_p11 USING btree (tenant_id);
+
+
+--
+-- Name: bayesian_model_fits_p11_tenant_id_model_type_eligibility_st_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p11_tenant_id_model_type_eligibility_st_idx ON public.bayesian_model_fits_p11 USING btree (tenant_id, model_type, eligibility_status, last_eligibility_check_at DESC);
 
+
+--
+-- Name: bayesian_model_fits_p11_tenant_id_model_type_fallback_reaso_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p11_tenant_id_model_type_fallback_reaso_idx ON public.bayesian_model_fits_p11 USING btree (tenant_id, model_type, fallback_reason, last_eligibility_check_at DESC) WHERE (fallback_applied = true);
+
+
+--
+-- Name: bayesian_model_fits_p11_tenant_id_model_type_source_window__idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p11_tenant_id_model_type_source_window__idx ON public.bayesian_model_fits_p11 USING btree (tenant_id, model_type, source_window_start, source_window_end);
 
+
+--
+-- Name: bayesian_model_fits_p11_tenant_id_model_type_source_window_idx1; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p11_tenant_id_model_type_source_window_idx1 ON public.bayesian_model_fits_p11 USING btree (tenant_id, model_type, source_window_start, source_window_end, created_at DESC);
+
+
+--
+-- Name: bayesian_model_fits_p11_tenant_id_source_snapshot_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p11_tenant_id_source_snapshot_hash_idx ON public.bayesian_model_fits_p11 USING btree (tenant_id, source_snapshot_hash);
 
+
+--
+-- Name: bayesian_model_fits_p11_tenant_id_status_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p11_tenant_id_status_idx ON public.bayesian_model_fits_p11 USING btree (tenant_id, status);
+
+
+--
+-- Name: bayesian_model_fits_p12_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p12_tenant_id_idx ON public.bayesian_model_fits_p12 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_model_fits_p12_tenant_id_model_type_eligibility_st_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p12_tenant_id_model_type_eligibility_st_idx ON public.bayesian_model_fits_p12 USING btree (tenant_id, model_type, eligibility_status, last_eligibility_check_at DESC);
+
+
+--
+-- Name: bayesian_model_fits_p12_tenant_id_model_type_fallback_reaso_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p12_tenant_id_model_type_fallback_reaso_idx ON public.bayesian_model_fits_p12 USING btree (tenant_id, model_type, fallback_reason, last_eligibility_check_at DESC) WHERE (fallback_applied = true);
 
+
+--
+-- Name: bayesian_model_fits_p12_tenant_id_model_type_source_window__idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p12_tenant_id_model_type_source_window__idx ON public.bayesian_model_fits_p12 USING btree (tenant_id, model_type, source_window_start, source_window_end);
+
+
+--
+-- Name: bayesian_model_fits_p12_tenant_id_model_type_source_window_idx1; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p12_tenant_id_model_type_source_window_idx1 ON public.bayesian_model_fits_p12 USING btree (tenant_id, model_type, source_window_start, source_window_end, created_at DESC);
 
+
+--
+-- Name: bayesian_model_fits_p12_tenant_id_source_snapshot_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p12_tenant_id_source_snapshot_hash_idx ON public.bayesian_model_fits_p12 USING btree (tenant_id, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p12_tenant_id_status_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p12_tenant_id_status_idx ON public.bayesian_model_fits_p12 USING btree (tenant_id, status);
 
+
+--
+-- Name: bayesian_model_fits_p13_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p13_tenant_id_idx ON public.bayesian_model_fits_p13 USING btree (tenant_id);
+
+
+--
+-- Name: bayesian_model_fits_p13_tenant_id_model_type_eligibility_st_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p13_tenant_id_model_type_eligibility_st_idx ON public.bayesian_model_fits_p13 USING btree (tenant_id, model_type, eligibility_status, last_eligibility_check_at DESC);
 
+
+--
+-- Name: bayesian_model_fits_p13_tenant_id_model_type_fallback_reaso_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p13_tenant_id_model_type_fallback_reaso_idx ON public.bayesian_model_fits_p13 USING btree (tenant_id, model_type, fallback_reason, last_eligibility_check_at DESC) WHERE (fallback_applied = true);
+
+
+--
+-- Name: bayesian_model_fits_p13_tenant_id_model_type_source_window__idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p13_tenant_id_model_type_source_window__idx ON public.bayesian_model_fits_p13 USING btree (tenant_id, model_type, source_window_start, source_window_end);
 
+
+--
+-- Name: bayesian_model_fits_p13_tenant_id_model_type_source_window_idx1; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p13_tenant_id_model_type_source_window_idx1 ON public.bayesian_model_fits_p13 USING btree (tenant_id, model_type, source_window_start, source_window_end, created_at DESC);
+
+
+--
+-- Name: bayesian_model_fits_p13_tenant_id_source_snapshot_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p13_tenant_id_source_snapshot_hash_idx ON public.bayesian_model_fits_p13 USING btree (tenant_id, source_snapshot_hash);
 
+
+--
+-- Name: bayesian_model_fits_p13_tenant_id_status_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p13_tenant_id_status_idx ON public.bayesian_model_fits_p13 USING btree (tenant_id, status);
+
+
+--
+-- Name: bayesian_model_fits_p14_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p14_tenant_id_idx ON public.bayesian_model_fits_p14 USING btree (tenant_id);
 
+
+--
+-- Name: bayesian_model_fits_p14_tenant_id_model_type_eligibility_st_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p14_tenant_id_model_type_eligibility_st_idx ON public.bayesian_model_fits_p14 USING btree (tenant_id, model_type, eligibility_status, last_eligibility_check_at DESC);
+
+
+--
+-- Name: bayesian_model_fits_p14_tenant_id_model_type_fallback_reaso_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p14_tenant_id_model_type_fallback_reaso_idx ON public.bayesian_model_fits_p14 USING btree (tenant_id, model_type, fallback_reason, last_eligibility_check_at DESC) WHERE (fallback_applied = true);
 
+
+--
+-- Name: bayesian_model_fits_p14_tenant_id_model_type_source_window__idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p14_tenant_id_model_type_source_window__idx ON public.bayesian_model_fits_p14 USING btree (tenant_id, model_type, source_window_start, source_window_end);
+
+
+--
+-- Name: bayesian_model_fits_p14_tenant_id_model_type_source_window_idx1; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p14_tenant_id_model_type_source_window_idx1 ON public.bayesian_model_fits_p14 USING btree (tenant_id, model_type, source_window_start, source_window_end, created_at DESC);
 
+
+--
+-- Name: bayesian_model_fits_p14_tenant_id_source_snapshot_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p14_tenant_id_source_snapshot_hash_idx ON public.bayesian_model_fits_p14 USING btree (tenant_id, source_snapshot_hash);
+
+
+--
+-- Name: bayesian_model_fits_p14_tenant_id_status_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p14_tenant_id_status_idx ON public.bayesian_model_fits_p14 USING btree (tenant_id, status);
 
+
+--
+-- Name: bayesian_model_fits_p15_tenant_id_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p15_tenant_id_idx ON public.bayesian_model_fits_p15 USING btree (tenant_id);
+
+
+--
+-- Name: bayesian_model_fits_p15_tenant_id_model_type_eligibility_st_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p15_tenant_id_model_type_eligibility_st_idx ON public.bayesian_model_fits_p15 USING btree (tenant_id, model_type, eligibility_status, last_eligibility_check_at DESC);
 
+
+--
+-- Name: bayesian_model_fits_p15_tenant_id_model_type_fallback_reaso_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p15_tenant_id_model_type_fallback_reaso_idx ON public.bayesian_model_fits_p15 USING btree (tenant_id, model_type, fallback_reason, last_eligibility_check_at DESC) WHERE (fallback_applied = true);
+
+
+--
+-- Name: bayesian_model_fits_p15_tenant_id_model_type_source_window__idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p15_tenant_id_model_type_source_window__idx ON public.bayesian_model_fits_p15 USING btree (tenant_id, model_type, source_window_start, source_window_end);
 
+
+--
+-- Name: bayesian_model_fits_p15_tenant_id_model_type_source_window_idx1; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p15_tenant_id_model_type_source_window_idx1 ON public.bayesian_model_fits_p15 USING btree (tenant_id, model_type, source_window_start, source_window_end, created_at DESC);
+
+
+--
+-- Name: bayesian_model_fits_p15_tenant_id_source_snapshot_hash_idx; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX bayesian_model_fits_p15_tenant_id_source_snapshot_hash_idx ON public.bayesian_model_fits_p15 USING btree (tenant_id, source_snapshot_hash);
 
+
+--
+-- Name: bayesian_model_fits_p15_tenant_id_status_idx; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX bayesian_model_fits_p15_tenant_id_status_idx ON public.bayesian_model_fits_p15 USING btree (tenant_id, status);
+
+
+--
+-- Name: idx_allocations_channel_performance; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_allocations_channel_performance ON public.attribution_allocations USING btree (tenant_id, channel_code, created_at DESC) INCLUDE (allocated_revenue_cents, confidence_score);
 
+
+--
+-- Name: idx_allocations_tenant_projection_channel; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_allocations_tenant_projection_channel ON public.attribution_allocations USING btree (tenant_id, recompute_job_id, model_type, channel_code);
+
+
+--
+-- Name: idx_attr_commerce_identity_last_observed; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_attr_commerce_identity_last_observed ON public.attribution_commerce_identities USING btree (last_observed_at);
 
+
+--
+-- Name: idx_attr_commerce_identity_tenant_last_observed; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_attr_commerce_identity_tenant_last_observed ON public.attribution_commerce_identities USING btree (tenant_id, last_observed_at DESC);
+
+
+--
+-- Name: idx_attr_commerce_identity_tenant_provider_reference; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_attr_commerce_identity_tenant_provider_reference ON public.attribution_commerce_identities USING btree (tenant_id, provider, canonical_commerce_reference);
 
+
+--
+-- Name: idx_attribution_allocations_channel; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_attribution_allocations_channel ON public.attribution_allocations USING btree (channel_code);
+
+
+--
+-- Name: idx_attribution_allocations_event_id; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_attribution_allocations_event_id ON public.attribution_allocations USING btree (event_id);
 
+
+--
+-- Name: idx_attribution_allocations_tenant_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_attribution_allocations_tenant_created_at ON public.attribution_allocations USING btree (tenant_id, created_at DESC);
+
+
+--
+-- Name: idx_attribution_allocations_tenant_event_model; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_attribution_allocations_tenant_event_model ON public.attribution_allocations USING btree (tenant_id, event_id, model_version);
 
+
+--
+-- Name: idx_attribution_allocations_tenant_event_model_channel; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE UNIQUE INDEX idx_attribution_allocations_tenant_event_model_channel ON public.attribution_allocations USING btree (tenant_id, event_id, model_version, channel_code) WHERE ((model_version IS NOT NULL) AND (recompute_job_id IS NULL));
+
+
+--
+-- Name: idx_attribution_allocations_tenant_event_projection; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_attribution_allocations_tenant_event_projection ON public.attribution_allocations USING btree (tenant_id, event_id, recompute_job_id) WHERE (recompute_job_id IS NOT NULL);
 
+
+--
+-- Name: idx_attribution_allocations_tenant_event_projection_channel; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE UNIQUE INDEX idx_attribution_allocations_tenant_event_projection_channel ON public.attribution_allocations USING btree (tenant_id, event_id, recompute_job_id, channel_code) WHERE (recompute_job_id IS NOT NULL);
+
+
+--
+-- Name: idx_attribution_allocations_tenant_model_version; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_attribution_allocations_tenant_model_version ON public.attribution_allocations USING btree (tenant_id, model_version);
 
+
+--
+-- Name: idx_attribution_events_session_id; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_attribution_events_session_id ON public.attribution_events USING btree (session_id) WHERE (session_id IS NOT NULL);
+
+
+--
+-- Name: idx_attribution_events_tenant_occurred_at; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_attribution_events_tenant_occurred_at ON public.attribution_events USING btree (tenant_id, occurred_at DESC);
 
+
+--
+-- Name: idx_attribution_recompute_jobs_tenant_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_attribution_recompute_jobs_tenant_created_at ON public.attribution_recompute_jobs USING btree (tenant_id, created_at DESC);
+
+
+--
+-- Name: idx_attribution_recompute_jobs_tenant_status; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_attribution_recompute_jobs_tenant_status ON public.attribution_recompute_jobs USING btree (tenant_id, status);
 
+
+--
+-- Name: idx_attribution_recompute_jobs_window_identity; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE UNIQUE INDEX idx_attribution_recompute_jobs_window_identity ON public.attribution_recompute_jobs USING btree (tenant_id, window_start, window_end, model_version);
+
+
+--
+-- Name: idx_auth_access_token_denylist_expires_at; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_auth_access_token_denylist_expires_at ON public.auth_access_token_denylist USING btree (expires_at DESC);
 
+
+--
+-- Name: idx_auth_access_token_denylist_jti; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_auth_access_token_denylist_jti ON public.auth_access_token_denylist USING btree (jti);
+
+
+--
+-- Name: idx_auth_access_token_denylist_tenant_user_revoked_at; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_auth_access_token_denylist_tenant_user_revoked_at ON public.auth_access_token_denylist USING btree (tenant_id, user_id, revoked_at DESC);
 
+
+--
+-- Name: idx_auth_refresh_tokens_family_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_auth_refresh_tokens_family_created_at ON public.auth_refresh_tokens USING btree (family_id, created_at DESC);
+
+
+--
+-- Name: idx_auth_refresh_tokens_tenant_created_at; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_auth_refresh_tokens_tenant_created_at ON public.auth_refresh_tokens USING btree (tenant_id, created_at DESC);
 
+
+--
+-- Name: idx_auth_refresh_tokens_tenant_user_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_auth_refresh_tokens_tenant_user_created_at ON public.auth_refresh_tokens USING btree (tenant_id, user_id, created_at DESC);
+
+
+--
+-- Name: idx_auth_user_token_cutoffs_tenant_user; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_auth_user_token_cutoffs_tenant_user ON public.auth_user_token_cutoffs USING btree (tenant_id, user_id);
 
+
+--
+-- Name: idx_b23_exception_records_tenant_provider_reference; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b23_exception_records_tenant_provider_reference ON public.b23_exception_records USING btree (tenant_id, provider, canonical_commerce_reference);
+
+
+--
+-- Name: idx_b23_exception_records_tenant_status_severity; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b23_exception_records_tenant_status_severity ON public.b23_exception_records USING btree (tenant_id, status, severity, raised_at DESC);
 
+
+--
+-- Name: idx_b23_match_task_dispatches_ingress; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b23_match_task_dispatches_ingress ON public.b23_match_task_dispatches USING btree (webhook_ingress_identity_id);
+
+
+--
+-- Name: idx_b23_match_task_dispatches_tenant_reference; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b23_match_task_dispatches_tenant_reference ON public.b23_match_task_dispatches USING btree (tenant_id, provider, provider_native_event_reference, normalized_commerce_reference_value);
 
+
+--
+-- Name: idx_b23_match_verdicts_tenant_discrepancy_band; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b23_match_verdicts_tenant_discrepancy_band ON public.b23_match_verdicts USING btree (tenant_id, discrepancy_band, last_transition_at DESC);
+
+
+--
+-- Name: idx_b23_match_verdicts_tenant_discrepancy_ratio_bps; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b23_match_verdicts_tenant_discrepancy_ratio_bps ON public.b23_match_verdicts USING btree (tenant_id, discrepancy_ratio_bps, last_transition_at DESC);
 
+
+--
+-- Name: idx_b23_match_verdicts_tenant_provider_commerce_native; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b23_match_verdicts_tenant_provider_commerce_native ON public.b23_match_verdicts USING btree (tenant_id, provider, provider_native_commerce_reference);
+
+
+--
+-- Name: idx_b23_match_verdicts_tenant_provider_reference; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b23_match_verdicts_tenant_provider_reference ON public.b23_match_verdicts USING btree (tenant_id, provider, canonical_commerce_reference);
 
+
+--
+-- Name: idx_b23_match_verdicts_tenant_state_timestamps; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b23_match_verdicts_tenant_state_timestamps ON public.b23_match_verdicts USING btree (tenant_id, pending_since, provisional_expires_at, confirmed_at, unmatched_marked_at, adjusted_at);
+
+
+--
+-- Name: idx_b23_match_verdicts_tenant_status_transition; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b23_match_verdicts_tenant_status_transition ON public.b23_match_verdicts USING btree (tenant_id, status, last_transition_at DESC);
 
+
+--
+-- Name: idx_b23_p4_attribution_event_tenant_id; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b23_p4_attribution_event_tenant_id ON public.attribution_events USING btree (tenant_id, id);
+
+
+--
+-- Name: idx_b23_p4_attribution_order_ref_expr; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b23_p4_attribution_order_ref_expr ON public.attribution_events USING btree (tenant_id, ((raw_payload ->> 'order_id'::text)), occurred_at DESC) WHERE (raw_payload ? 'order_id'::text);
 
+
+--
+-- Name: idx_b23_p4_match_rate_tenant_transition_status; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b23_p4_match_rate_tenant_transition_status ON public.b23_match_verdicts USING btree (tenant_id, last_transition_at DESC, status) WHERE ((status)::text = ANY ((ARRAY['matched_provisional'::character varying, 'matched_confirmed'::character varying, 'adjusted'::character varying, 'unmatched'::character varying])::text[]));
+
+
+--
+-- Name: idx_b23_p4_verdict_webhook_identity; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b23_p4_verdict_webhook_identity ON public.b23_match_verdicts USING btree (tenant_id, webhook_ingress_identity_id) WHERE (webhook_ingress_identity_id IS NOT NULL);
 
+
+--
+-- Name: idx_b23_p4_webhook_failure_tenant_platform_time; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b23_p4_webhook_failure_tenant_platform_time ON public.b23_webhook_ingestion_logs USING btree (tenant_id, provider, received_at DESC) WHERE ((ingestion_status)::text = 'failed'::text);
+
+
+--
+-- Name: idx_b23_p4_webhook_identity_claim; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b23_p4_webhook_identity_claim ON public.webhook_ingress_identities USING btree (tenant_id, verified_commerce_ingress_state, event_timestamp, id) WHERE ((verified_commerce_ingress_state)::text = 'authenticity_verified'::text);
 
+
+--
+-- Name: idx_b23_p4_worker_dlq_open_status_failed_at; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b23_p4_worker_dlq_open_status_failed_at ON public.worker_failed_jobs USING btree (status, tenant_id, failed_at DESC) WHERE ((status)::text = ANY ((ARRAY['pending'::character varying, 'in_progress'::character varying])::text[]));
+
+
+--
+-- Name: idx_b23_revenue_events_tenant_event_effect_sign; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b23_revenue_events_tenant_event_effect_sign ON public.b23_revenue_events USING btree (tenant_id, event_type, net_effect_sign, event_occurred_at DESC);
 
+
+--
+-- Name: idx_b23_revenue_events_tenant_event_type_recorded; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b23_revenue_events_tenant_event_type_recorded ON public.b23_revenue_events USING btree (tenant_id, event_type, recorded_at DESC);
+
+
+--
+-- Name: idx_b23_revenue_events_tenant_gross_capture_correction; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b23_revenue_events_tenant_gross_capture_correction ON public.b23_revenue_events USING btree (tenant_id, match_verdict_id, is_gross_capture_correction, event_occurred_at DESC);
 
+
+--
+-- Name: idx_b23_revenue_events_tenant_provider_commerce_native; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b23_revenue_events_tenant_provider_commerce_native ON public.b23_revenue_events USING btree (tenant_id, provider, provider_native_commerce_reference);
+
+
+--
+-- Name: idx_b23_revenue_events_tenant_provider_reference; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b23_revenue_events_tenant_provider_reference ON public.b23_revenue_events USING btree (tenant_id, provider, canonical_commerce_reference, event_occurred_at DESC);
 
+
+--
+-- Name: idx_b23_webhook_ingestion_logs_tenant_provider_received; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b23_webhook_ingestion_logs_tenant_provider_received ON public.b23_webhook_ingestion_logs USING btree (tenant_id, provider, received_at DESC);
+
+
+--
+-- Name: idx_b23_webhook_ingestion_logs_tenant_status_received; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b23_webhook_ingestion_logs_tenant_status_received ON public.b23_webhook_ingestion_logs USING btree (tenant_id, ingestion_status, received_at DESC);
 
+
+--
+-- Name: idx_b24_active_execution_canonical_profiling; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b24_active_execution_canonical_profiling ON public.b24_active_execution_leases USING btree (tenant_id, model_type, model_version, source_window_start, source_window_end, status, leased_until) WHERE ((status)::text = 'profiling'::text);
+
+
+--
+-- Name: idx_b24_active_execution_superseded; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b24_active_execution_superseded ON public.b24_active_execution_leases USING btree (tenant_id, model_type, model_version, source_window_start, source_window_end) WHERE (needs_refit_after_current = true);
 
+
+--
+-- Name: idx_b24_active_execution_tenant_fit; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b24_active_execution_tenant_fit ON public.b24_active_execution_leases USING btree (tenant_id, fit_id) WHERE (fit_id IS NOT NULL);
+
+
+--
+-- Name: idx_b24_active_execution_tenant_status_lease; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b24_active_execution_tenant_status_lease ON public.b24_active_execution_leases USING btree (tenant_id, status, leased_until);
 
+
+--
+-- Name: idx_b24_dirty_events_authority_retry_ready; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b24_dirty_events_authority_retry_ready ON public.b24_dirty_events USING btree (tenant_id, status, authority_retry_after_at, observed_at, id) WHERE ((status)::text = ANY ((ARRAY['authority_waiting'::character varying, 'authority_retry_ready'::character varying])::text[]));
+
+
+--
+-- Name: idx_b24_dirty_events_tenant_event_hash; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b24_dirty_events_tenant_event_hash ON public.b24_dirty_events USING btree (tenant_id, event_hash) WHERE (event_hash IS NOT NULL);
 
+
+--
+-- Name: idx_b24_dirty_events_tenant_model_window_pending; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b24_dirty_events_tenant_model_window_pending ON public.b24_dirty_events USING btree (tenant_id, model_type, model_version, source_window_start, source_window_end, observed_at, id) WHERE ((status)::text = ANY ((ARRAY['pending'::character varying, 'leased'::character varying])::text[]));
+
+
+--
+-- Name: idx_b24_dirty_events_tenant_status_observed; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b24_dirty_events_tenant_status_observed ON public.b24_dirty_events USING btree (tenant_id, status, observed_at, id);
 
+
+--
+-- Name: idx_b24_feature_authority_build_outbox_due; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b24_feature_authority_build_outbox_due ON public.b24_feature_authority_build_outbox USING btree (tenant_id, status, next_attempt_at, id) WHERE ((status)::text = ANY ((ARRAY['pending'::character varying, 'failed_retryable'::character varying, 'stale_recovered'::character varying])::text[]));
+
+
+--
+-- Name: idx_b24_feature_authority_build_requests_due; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b24_feature_authority_build_requests_due ON public.b24_feature_authority_build_requests USING btree (tenant_id, status, retry_after_at) WHERE ((status)::text = ANY ((ARRAY['authority_build_requested'::character varying, 'authority_waiting'::character varying, 'authority_retry_ready'::character varying])::text[]));
 
+
+--
+-- Name: idx_b24_feature_authority_tenant_model_window; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b24_feature_authority_tenant_model_window ON public.b24_source_window_feature_authority USING btree (tenant_id, model_type, model_version, source_window_start, source_window_end, computed_at DESC);
+
+
+--
+-- Name: idx_b24_fit_dispatch_outbox_dispatching; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b24_fit_dispatch_outbox_dispatching ON public.b24_fit_dispatch_outbox USING btree (tenant_id, dispatching_started_at) WHERE ((status)::text = 'dispatching'::text);
 
+
+--
+-- Name: idx_b24_fit_dispatch_outbox_due; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b24_fit_dispatch_outbox_due ON public.b24_fit_dispatch_outbox USING btree (tenant_id, status, next_attempt_at, id) WHERE ((status)::text = ANY ((ARRAY['pending'::character varying, 'failed_retryable'::character varying, 'stale_recovered'::character varying])::text[]));
+
+
+--
+-- Name: idx_b24_fit_dispatch_outbox_recoverable; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_b24_fit_dispatch_outbox_recoverable ON public.b24_fit_dispatch_outbox USING btree (status, next_recovery_at, lease_expires_at) WHERE ((status)::text = ANY ((ARRAY['dispatched'::character varying, 'leased'::character varying, 'running'::character varying, 'failed_retryable'::character varying, 'stale_recovered'::character varying])::text[]));
+
+
+--
+-- Name: idx_b24_fit_recovery_outbox_due; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE INDEX idx_b24_fit_recovery_outbox_due ON public.b24_fit_recovery_outbox USING btree (status, created_at, id) WHERE ((status)::text = ANY ((ARRAY['pending'::character varying, 'failed_retryable'::character varying])::text[]));
+
+
+--
+-- Name: idx_b24_p2_attribution_allocations_source_stream; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b24_p2_attribution_allocations_source_stream ON public.attribution_allocations USING btree (tenant_id, created_at, id) WHERE (verified = true);
 
+
+--
+-- Name: idx_b24_p2_attribution_events_source_stream; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b24_p2_attribution_events_source_stream ON public.attribution_events USING btree (tenant_id, occurred_at, id) WHERE (((processing_status)::text = 'processed'::text) AND ((event_type)::text = 'conversion'::text));
+
+
+--
+-- Name: idx_b24_p2_match_verdicts_source_stream; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b24_p2_match_verdicts_source_stream ON public.b23_match_verdicts USING btree (tenant_id, last_transition_at, id) WHERE ((status)::text = ANY ((ARRAY['matched_confirmed'::character varying, 'adjusted'::character varying])::text[]));
 
+
+--
+-- Name: idx_b24_p2_revenue_events_source_stream; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b24_p2_revenue_events_source_stream ON public.b23_revenue_events USING btree (tenant_id, event_occurred_at, id) WHERE ((event_type)::text = ANY ((ARRAY['payment_capture'::character varying, 'partial_refund'::character varying, 'full_refund'::character varying, 'chargeback_lost'::character varying, 'chargeback_won'::character varying, 'reversal'::character varying])::text[]));
+
+
+--
+-- Name: idx_b24_p3_attribution_allocations_source_stream_fallback; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b24_p3_attribution_allocations_source_stream_fallback ON public.attribution_allocations USING btree (tenant_id, created_at, id);
 
+
+--
+-- Name: idx_b24_p3_attribution_events_source_stream_fallback; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b24_p3_attribution_events_source_stream_fallback ON public.attribution_events USING btree (tenant_id, occurred_at, id);
+
+
+--
+-- Name: idx_b24_p3_match_verdicts_source_stream_fallback; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b24_p3_match_verdicts_source_stream_fallback ON public.b23_match_verdicts USING btree (tenant_id, last_transition_at, id);
 
+
+--
+-- Name: idx_b24_p3_revenue_events_source_stream_fallback; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b24_p3_revenue_events_source_stream_fallback ON public.b23_revenue_events USING btree (tenant_id, event_occurred_at, id);
+
+
+--
+-- Name: idx_b24_p4_attribution_events_campaign_cardinality; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b24_p4_attribution_events_campaign_cardinality ON public.attribution_events USING btree (tenant_id, campaign_id, occurred_at, id) WHERE (((processing_status)::text = 'processed'::text) AND ((event_type)::text = 'conversion'::text) AND (campaign_id IS NOT NULL));
 
+
+--
+-- Name: idx_b24_p4_attribution_events_campaign_early_stop; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b24_p4_attribution_events_campaign_early_stop ON public.attribution_events USING btree (tenant_id, campaign_id, occurred_at, id) WHERE (((processing_status)::text = 'processed'::text) AND ((event_type)::text = 'conversion'::text) AND (campaign_id IS NOT NULL) AND ((campaign_id)::text <> ''::text));
+
+
+--
+-- Name: idx_b24_p4_attribution_events_channel_early_stop; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b24_p4_attribution_events_channel_early_stop ON public.attribution_events USING btree (tenant_id, channel, occurred_at, id) WHERE (((processing_status)::text = 'processed'::text) AND ((event_type)::text = 'conversion'::text) AND (channel IS NOT NULL) AND ((channel)::text <> ''::text));
 
+
+--
+-- Name: idx_b24_p4_match_verdicts_provider_cardinality; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b24_p4_match_verdicts_provider_cardinality ON public.b23_match_verdicts USING btree (tenant_id, provider, last_transition_at, id) WHERE (((status)::text = ANY ((ARRAY['matched_confirmed'::character varying, 'adjusted'::character varying])::text[])) AND (provider IS NOT NULL));
+
+
+--
+-- Name: idx_b24_p4_match_verdicts_provider_early_stop; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b24_p4_match_verdicts_provider_early_stop ON public.b23_match_verdicts USING btree (tenant_id, provider, last_transition_at, id) WHERE (((status)::text = ANY ((ARRAY['matched_confirmed'::character varying, 'adjusted'::character varying])::text[])) AND (provider IS NOT NULL) AND ((provider)::text <> ''::text));
 
+
+--
+-- Name: idx_b24_p4_revenue_events_provider_cardinality; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_b24_p4_revenue_events_provider_cardinality ON public.b23_revenue_events USING btree (tenant_id, provider, event_occurred_at, id) WHERE (((event_type)::text = ANY ((ARRAY['payment_capture'::character varying, 'partial_refund'::character varying, 'full_refund'::character varying, 'chargeback_lost'::character varying, 'chargeback_won'::character varying, 'reversal'::character varying])::text[])) AND (provider IS NOT NULL));
+
+
+--
+-- Name: idx_b24_p4_revenue_events_provider_early_stop; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_b24_p4_revenue_events_provider_early_stop ON public.b23_revenue_events USING btree (tenant_id, provider, event_occurred_at, id) WHERE (((event_type)::text = ANY ((ARRAY['payment_capture'::character varying, 'partial_refund'::character varying, 'full_refund'::character varying, 'chargeback_lost'::character varying, 'chargeback_won'::character varying, 'reversal'::character varying])::text[])) AND (provider IS NOT NULL) AND ((provider)::text <> ''::text));
 
+
+--
+-- Name: idx_budget_jobs_tenant_status; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_budget_jobs_tenant_status ON public.budget_optimization_jobs USING btree (tenant_id, status, created_at DESC);
+
+
+--
+-- Name: idx_channel_assignment_corrections_channels; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_channel_assignment_corrections_channels ON public.channel_assignment_corrections USING btree (from_channel, to_channel, corrected_at DESC);
 
+
+--
+-- Name: idx_channel_assignment_corrections_entity; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_channel_assignment_corrections_entity ON public.channel_assignment_corrections USING btree (tenant_id, entity_type, entity_id, corrected_at DESC);
+
+
+--
+-- Name: idx_channel_assignment_corrections_tenant; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_channel_assignment_corrections_tenant ON public.channel_assignment_corrections USING btree (tenant_id, corrected_at DESC);
 
+
+--
+-- Name: idx_channel_state_transitions_channel_changed_at; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_channel_state_transitions_channel_changed_at ON public.channel_state_transitions USING btree (channel_code, changed_at DESC);
+
+
+--
+-- Name: idx_channel_state_transitions_to_state_changed_at; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_channel_state_transitions_to_state_changed_at ON public.channel_state_transitions USING btree (to_state, changed_at DESC);
 
+
+--
+-- Name: idx_compliance_audit_ledger_tenant_correlation; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_compliance_audit_ledger_tenant_correlation ON public.compliance_audit_ledger USING btree (tenant_id, correlation_id);
+
+
+--
+-- Name: idx_compliance_audit_ledger_tenant_created; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_compliance_audit_ledger_tenant_created ON public.compliance_audit_ledger USING btree (tenant_id, created_at DESC);
 
+
+--
+-- Name: idx_dead_events_error_code; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_dead_events_error_code ON public.dead_events USING btree (error_code);
+
+
+--
+-- Name: idx_dead_events_quarantine_null_lane; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_dead_events_quarantine_null_lane ON public.dead_events_quarantine USING btree (ingested_at DESC) WHERE (tenant_id IS NULL);
 
+
+--
+-- Name: idx_dead_events_quarantine_tenant_idempotency_key; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_dead_events_quarantine_tenant_idempotency_key ON public.dead_events_quarantine USING btree (tenant_id, idempotency_key) WHERE (idempotency_key IS NOT NULL);
+
+
+--
+-- Name: idx_dead_events_quarantine_tenant_ingested_at; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_dead_events_quarantine_tenant_ingested_at ON public.dead_events_quarantine USING btree (tenant_id, ingested_at DESC);
 
+
+--
+-- Name: idx_dead_events_remediation; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_dead_events_remediation ON public.dead_events USING btree (remediation_status, ingested_at DESC);
+
+
+--
+-- Name: idx_dead_events_source; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_dead_events_source ON public.dead_events USING btree (source);
 
+
+--
+-- Name: idx_dead_events_tenant_idempotency_key; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_dead_events_tenant_idempotency_key ON public.dead_events USING btree (tenant_id, idempotency_key) WHERE (idempotency_key IS NOT NULL);
+
+
+--
+-- Name: idx_dead_events_tenant_ingested_at; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_dead_events_tenant_ingested_at ON public.dead_events USING btree (tenant_id, ingested_at DESC);
 
+
+--
+-- Name: idx_ephemeral_click_resolution_tenant_click; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_ephemeral_click_resolution_tenant_click ON public.ephemeral_click_resolution USING btree (tenant_id, click_id);
+
+
+--
+-- Name: idx_ephemeral_click_resolution_tenant_expires; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_ephemeral_click_resolution_tenant_expires ON public.ephemeral_click_resolution USING btree (tenant_id, expires_at);
 
+
+--
+-- Name: idx_ephemeral_order_resolution_tenant_expires; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_ephemeral_order_resolution_tenant_expires ON public.ephemeral_order_resolution USING btree (tenant_id, expires_at);
+
+
+--
+-- Name: idx_ephemeral_order_resolution_tenant_order; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_ephemeral_order_resolution_tenant_order ON public.ephemeral_order_resolution USING btree (tenant_id, order_id);
 
+
+--
+-- Name: idx_events_processing_status; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_events_processing_status ON public.attribution_events USING btree (processing_status, processed_at) WHERE ((processing_status)::text = 'pending'::text);
+
+
+--
+-- Name: idx_events_tenant_timestamp; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_events_tenant_timestamp ON public.attribution_events USING btree (tenant_id, event_timestamp DESC);
 
+
+--
+-- Name: idx_explanation_cache_lookup; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_explanation_cache_lookup ON public.explanation_cache USING btree (tenant_id, entity_type, entity_id);
+
+
+--
+-- Name: idx_investigation_jobs_min_hold; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_investigation_jobs_min_hold ON public.investigation_jobs USING btree (min_hold_until) WHERE ((status)::text = 'PENDING'::text);
 
+
+--
+-- Name: idx_investigation_jobs_tenant_status; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_investigation_jobs_tenant_status ON public.investigation_jobs USING btree (tenant_id, status, created_at DESC);
+
+
+--
+-- Name: idx_investigations_tenant_status; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_investigations_tenant_status ON public.investigations USING btree (tenant_id, status, created_at DESC);
 
+
+--
+-- Name: idx_llm_api_calls_prompt_fingerprint; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_llm_api_calls_prompt_fingerprint ON public.llm_api_calls USING btree (tenant_id, prompt_fingerprint, created_at DESC);
+
+
+--
+-- Name: idx_llm_breaker_state_tenant_user_updated; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_llm_breaker_state_tenant_user_updated ON public.llm_breaker_state USING btree (tenant_id, user_id, updated_at DESC);
 
+
+--
+-- Name: idx_llm_budget_reservations_tenant_user_month; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_llm_budget_reservations_tenant_user_month ON public.llm_budget_reservations USING btree (tenant_id, user_id, month DESC);
+
+
+--
+-- Name: idx_llm_call_audit_decision; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_llm_call_audit_decision ON public.llm_call_audit USING btree (decision, created_at DESC);
 
+
+--
+-- Name: idx_llm_call_audit_prompt_fingerprint; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_llm_call_audit_prompt_fingerprint ON public.llm_call_audit USING btree (tenant_id, prompt_fingerprint, created_at DESC);
+
+
+--
+-- Name: idx_llm_call_audit_request_id; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_llm_call_audit_request_id ON public.llm_call_audit USING btree (request_id);
 
+
+--
+-- Name: idx_llm_call_audit_tenant_created; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_llm_call_audit_tenant_created ON public.llm_call_audit USING btree (tenant_id, created_at DESC);
+
+
+--
+-- Name: idx_llm_call_audit_tenant_user_created; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_llm_call_audit_tenant_user_created ON public.llm_call_audit USING btree (tenant_id, user_id, created_at DESC);
 
+
+--
+-- Name: idx_llm_calls_tenant_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_llm_calls_tenant_created_at ON public.llm_api_calls USING btree (tenant_id, created_at DESC);
+
+
+--
+-- Name: idx_llm_calls_tenant_endpoint; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_llm_calls_tenant_endpoint ON public.llm_api_calls USING btree (tenant_id, endpoint, created_at DESC);
 
+
+--
+-- Name: idx_llm_calls_tenant_user_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_llm_calls_tenant_user_created_at ON public.llm_api_calls USING btree (tenant_id, user_id, created_at DESC);
+
+
+--
+-- Name: idx_llm_failures_created_at; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_llm_failures_created_at ON public.llm_validation_failures USING btree (created_at DESC);
 
+
+--
+-- Name: idx_llm_failures_tenant_endpoint; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_llm_failures_tenant_endpoint ON public.llm_validation_failures USING btree (tenant_id, endpoint, created_at DESC);
+
+
+--
+-- Name: idx_llm_hourly_shutoff_disabled_until; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_llm_hourly_shutoff_disabled_until ON public.llm_hourly_shutoff_state USING btree (tenant_id, user_id, disabled_until DESC);
 
+
+--
+-- Name: idx_llm_hourly_shutoff_tenant_user_hour; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_llm_hourly_shutoff_tenant_user_hour ON public.llm_hourly_shutoff_state USING btree (tenant_id, user_id, hour_start DESC);
+
+
+--
+-- Name: idx_llm_monthly_budget_state_tenant_user_month; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_llm_monthly_budget_state_tenant_user_month ON public.llm_monthly_budget_state USING btree (tenant_id, user_id, month DESC);
 
+
+--
+-- Name: idx_llm_monthly_tenant_user_month; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_llm_monthly_tenant_user_month ON public.llm_monthly_costs USING btree (tenant_id, user_id, month DESC);
+
+
+--
+-- Name: idx_llm_semantic_cache_tenant_user_endpoint; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_llm_semantic_cache_tenant_user_endpoint ON public.llm_semantic_cache USING btree (tenant_id, user_id, endpoint, updated_at DESC);
 
+
+--
+-- Name: idx_mv_allocation_summary_key; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE UNIQUE INDEX idx_mv_allocation_summary_key ON public.mv_allocation_summary USING btree (tenant_id, event_id, model_version);
+
+
+--
+-- Name: idx_mv_channel_performance_unique; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE UNIQUE INDEX idx_mv_channel_performance_unique ON public.mv_channel_performance USING btree (tenant_id, channel_code, allocation_date);
 
+
+--
+-- Name: idx_mv_daily_revenue_summary_unique; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE UNIQUE INDEX idx_mv_daily_revenue_summary_unique ON public.mv_daily_revenue_summary USING btree (tenant_id, revenue_date, state, currency);
+
+
+--
+-- Name: idx_mv_realtime_revenue_tenant_id; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE UNIQUE INDEX idx_mv_realtime_revenue_tenant_id ON public.mv_realtime_revenue USING btree (tenant_id);
 
+
+--
+-- Name: idx_mv_reconciliation_status_tenant_id; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE UNIQUE INDEX idx_mv_reconciliation_status_tenant_id ON public.mv_reconciliation_status USING btree (tenant_id);
+
+
+--
+-- Name: idx_oauth_handshake_sessions_expires_at; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_oauth_handshake_sessions_expires_at ON public.oauth_handshake_sessions USING btree (expires_at DESC);
 
+
+--
+-- Name: idx_oauth_handshake_sessions_gc_after; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_oauth_handshake_sessions_gc_after ON public.oauth_handshake_sessions USING btree (gc_after);
+
+
+--
+-- Name: idx_oauth_handshake_sessions_tenant_platform_user_created; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_oauth_handshake_sessions_tenant_platform_user_created ON public.oauth_handshake_sessions USING btree (tenant_id, platform, user_id, created_at DESC);
 
+
+--
+-- Name: idx_oauth_handshake_sessions_tenant_state_lookup; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_oauth_handshake_sessions_tenant_state_lookup ON public.oauth_handshake_sessions USING btree (tenant_id, state_nonce_hash, status);
+
+
+--
+-- Name: idx_pii_audit_findings_detected_key; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_pii_audit_findings_detected_key ON public.pii_audit_findings USING btree (detected_key);
 
+
+--
+-- Name: idx_pii_audit_findings_table_detected_at; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_pii_audit_findings_table_detected_at ON public.pii_audit_findings USING btree (table_name, detected_at DESC);
+
+
+--
+-- Name: idx_platform_connections_tenant_platform_updated_at; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_platform_connections_tenant_platform_updated_at ON public.platform_connections USING btree (tenant_id, platform, updated_at DESC);
 
+
+--
+-- Name: idx_platform_credentials_refresh_due; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_platform_credentials_refresh_due ON public.platform_credentials USING btree (tenant_id, lifecycle_status, next_refresh_due_at) WHERE (next_refresh_due_at IS NOT NULL);
+
+
+--
+-- Name: idx_platform_credentials_tenant_lifecycle_updated; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_platform_credentials_tenant_lifecycle_updated ON public.platform_credentials USING btree (tenant_id, lifecycle_status, updated_at DESC);
 
+
+--
+-- Name: idx_platform_credentials_tenant_platform_updated_at; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_platform_credentials_tenant_platform_updated_at ON public.platform_credentials USING btree (tenant_id, platform, updated_at DESC);
+
+
+--
+-- Name: idx_platform_credentials_tenant_revoked_at; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_platform_credentials_tenant_revoked_at ON public.platform_credentials USING btree (tenant_id, revoked_at DESC) WHERE (revoked_at IS NOT NULL);
 
+
+--
+-- Name: idx_r4_crash_barriers_scenario_wrote_at; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_r4_crash_barriers_scenario_wrote_at ON public.r4_crash_barriers USING btree (scenario, wrote_at DESC);
+
+
+--
+-- Name: idx_r4_task_attempts_scenario_created_at; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_r4_task_attempts_scenario_created_at ON public.r4_task_attempts USING btree (scenario, created_at DESC);
 
+
+--
+-- Name: idx_r4_task_attempts_tenant_task; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_r4_task_attempts_tenant_task ON public.r4_task_attempts USING btree (tenant_id, task_id);
+
+
+--
+-- Name: idx_raw_event_payloads_event_id; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_raw_event_payloads_event_id ON public.raw_event_payloads USING btree (event_id);
 
+
+--
+-- Name: idx_raw_event_payloads_payload_json_gin; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_raw_event_payloads_payload_json_gin ON public.raw_event_payloads USING gin (payload_json jsonb_path_ops);
+
+
+--
+-- Name: idx_raw_event_payloads_tenant_created; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_raw_event_payloads_tenant_created ON public.raw_event_payloads USING btree (tenant_id, created_at DESC);
 
+
+--
+-- Name: idx_raw_event_payloads_tenant_lookup_hash; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_raw_event_payloads_tenant_lookup_hash ON public.raw_event_payloads USING btree (tenant_id, lookup_hash);
+
+
+--
+-- Name: idx_reconciliation_runs_state; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_reconciliation_runs_state ON public.reconciliation_runs USING btree (state);
 
+
+--
+-- Name: idx_reconciliation_runs_tenant_last_run_at; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_reconciliation_runs_tenant_last_run_at ON public.reconciliation_runs USING btree (tenant_id, last_run_at DESC);
+
+
+--
+-- Name: idx_revenue_cache_entries_error_cooldown; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_revenue_cache_entries_error_cooldown ON public.revenue_cache_entries USING btree (error_cooldown_until);
 
+
+--
+-- Name: idx_revenue_cache_entries_expires_at; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_revenue_cache_entries_expires_at ON public.revenue_cache_entries USING btree (expires_at);
+
+
+--
+-- Name: idx_revenue_ledger_is_verified; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_revenue_ledger_is_verified ON public.revenue_ledger USING btree (is_verified) WHERE (is_verified = true);
 
+
+--
+-- Name: idx_revenue_ledger_state; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_revenue_ledger_state ON public.revenue_ledger USING btree (state);
+
+
+--
+-- Name: idx_revenue_ledger_tenant_allocation_id; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE UNIQUE INDEX idx_revenue_ledger_tenant_allocation_id ON public.revenue_ledger USING btree (tenant_id, allocation_id) WHERE (allocation_id IS NOT NULL);
 
+
+--
+-- Name: idx_revenue_ledger_tenant_order_reconciliation; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_revenue_ledger_tenant_order_reconciliation ON public.revenue_ledger USING btree (tenant_id, order_id, created_at DESC) WHERE (order_id IS NOT NULL);
+
+
+--
+-- Name: idx_revenue_ledger_tenant_state; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_revenue_ledger_tenant_state ON public.revenue_ledger USING btree (tenant_id, state, created_at DESC);
 
+
+--
+-- Name: idx_revenue_ledger_tenant_updated_at; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_revenue_ledger_tenant_updated_at ON public.revenue_ledger USING btree (tenant_id, updated_at DESC);
+
+
+--
+-- Name: idx_revenue_ledger_transaction_id; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE UNIQUE INDEX idx_revenue_ledger_transaction_id ON public.revenue_ledger USING btree (transaction_id);
 
+
+--
+-- Name: idx_revenue_state_transitions_ledger_id; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_revenue_state_transitions_ledger_id ON public.revenue_state_transitions USING btree (ledger_id, transitioned_at DESC);
+
+
+--
+-- Name: idx_revenue_state_transitions_tenant_id; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_revenue_state_transitions_tenant_id ON public.revenue_state_transitions USING btree (tenant_id, transitioned_at DESC);
 
+
+--
+-- Name: idx_session_authority_active; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_session_authority_active ON public.session_authority USING btree (tenant_id, session_id, expires_at DESC) WHERE (invalidated_at IS NULL);
+
+
+--
+-- Name: idx_session_authority_tenant_expires; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_session_authority_tenant_expires ON public.session_authority USING btree (tenant_id, expires_at DESC);
 
+
+--
+-- Name: idx_session_authority_tenant_last_seen; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_session_authority_tenant_last_seen ON public.session_authority USING btree (tenant_id, last_seen_at DESC);
+
+
+--
+-- Name: idx_tenant_membership_roles_tenant_created_at; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_tenant_membership_roles_tenant_created_at ON public.tenant_membership_roles USING btree (tenant_id, created_at DESC);
 
+
+--
+-- Name: idx_tenant_memberships_tenant_created_at; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_tenant_memberships_tenant_created_at ON public.tenant_memberships USING btree (tenant_id, created_at DESC);
+
+
+--
+-- Name: idx_tenant_memberships_user_created_at; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_tenant_memberships_user_created_at ON public.tenant_memberships USING btree (user_id, created_at DESC);
 
+
+--
+-- Name: idx_tenants_api_key_hash; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE UNIQUE INDEX idx_tenants_api_key_hash ON public.tenants USING btree (api_key_hash);
+
+
+--
+-- Name: idx_tenants_name; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_tenants_name ON public.tenants USING btree (name);
 
+
+--
+-- Name: idx_tool_calls_investigation; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_tool_calls_investigation ON public.investigation_tool_calls USING btree (investigation_id, created_at);
+
+
+--
+-- Name: idx_tool_calls_tenant; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_tool_calls_tenant ON public.investigation_tool_calls USING btree (tenant_id, created_at DESC);
 
+
+--
+-- Name: idx_webhook_ingress_identities_tenant_provider_created; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_webhook_ingress_identities_tenant_provider_created ON public.webhook_ingress_identities USING btree (tenant_id, provider, created_at DESC);
+
+
+--
+-- Name: idx_webhook_ingress_identities_tenant_reference; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_webhook_ingress_identities_tenant_reference ON public.webhook_ingress_identities USING btree (tenant_id, normalized_commerce_reference_kind, normalized_commerce_reference_value);
 
+
+--
+-- Name: idx_webhook_ingress_identities_tenant_verified_state; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_webhook_ingress_identities_tenant_verified_state ON public.webhook_ingress_identities USING btree (tenant_id, verified_commerce_ingress_state, event_timestamp DESC);
+
+
+--
+-- Name: idx_worker_failed_jobs_status; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_worker_failed_jobs_status ON public.worker_failed_jobs USING btree (status, failed_at);
 
+
+--
+-- Name: idx_worker_failed_jobs_task_name; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX idx_worker_failed_jobs_task_name ON public.worker_failed_jobs USING btree (task_name);
+
+
+--
+-- Name: idx_worker_side_effects_tenant_created_at; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX idx_worker_side_effects_tenant_created_at ON public.worker_side_effects USING btree (tenant_id, created_at DESC);
 
+
+--
+-- Name: ix_celery_taskmeta_task_id; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX ix_celery_taskmeta_task_id ON public.celery_taskmeta USING btree (task_id);
+
+
+--
+-- Name: ix_celery_tasksetmeta_taskset_id; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX ix_celery_tasksetmeta_taskset_id ON public.celery_tasksetmeta USING btree (taskset_id);
 
+
+--
+-- Name: ix_kombu_message_timestamp_id; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX ix_kombu_message_timestamp_id ON public.kombu_message USING btree ("timestamp", id);
+
+
+--
+-- Name: ix_kombu_message_visible; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX ix_kombu_message_visible ON public.kombu_message USING btree (visible);
 
+
+--
+-- Name: ix_public_celery_task_failures_task_id; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX ix_public_celery_task_failures_task_id ON public.worker_failed_jobs USING btree (task_id);
+
+
+--
+-- Name: ix_public_celery_task_failures_task_name; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE INDEX ix_public_celery_task_failures_task_name ON public.worker_failed_jobs USING btree (task_name);
 
+
+--
+-- Name: ix_public_celery_task_failures_tenant_id; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE INDEX ix_public_celery_task_failures_tenant_id ON public.worker_failed_jobs USING btree (tenant_id);
+
+
+--
+-- Name: uq_b23_exception_records_one_open_per_verdict; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE UNIQUE INDEX uq_b23_exception_records_one_open_per_verdict ON public.b23_exception_records USING btree (tenant_id, match_verdict_id) WHERE ((status)::text = ANY ((ARRAY['open'::character varying, 'acknowledged'::character varying])::text[]));
 
+
+--
+-- Name: uq_b24_fit_dispatch_outbox_attempt; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX uq_b24_fit_dispatch_outbox_attempt ON public.b24_fit_dispatch_outbox USING btree (tenant_id, attempt_id);
+
+
+--
+-- Name: uq_platform_connections_tenant_platform_account; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE UNIQUE INDEX uq_platform_connections_tenant_platform_account ON public.platform_connections USING btree (tenant_id, platform, platform_account_id);
+
+
+--
+-- Name: uq_platform_credentials_tenant_platform_connection; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE UNIQUE INDEX uq_platform_credentials_tenant_platform_connection ON public.platform_credentials USING btree (tenant_id, platform, platform_connection_id);
 
+
+--
+-- Name: ux_r4_crash_barriers_tenant_task_attempt; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE UNIQUE INDEX ux_r4_crash_barriers_tenant_task_attempt ON public.r4_crash_barriers USING btree (tenant_id, task_id, attempt_no);
+
+
+--
+-- Name: ux_r4_task_attempts_tenant_task_attempt; Type: INDEX; Schema: public; Owner: -
+--
 
 CREATE UNIQUE INDEX ux_r4_task_attempts_tenant_task_attempt ON public.r4_task_attempts USING btree (tenant_id, task_id, attempt_no);
 
+
+--
+-- Name: ux_worker_side_effects_tenant_task_id; Type: INDEX; Schema: public; Owner: -
+--
+
 CREATE UNIQUE INDEX ux_worker_side_effects_tenant_task_id ON public.worker_side_effects USING btree (tenant_id, task_id);
+
+
+--
+-- Name: bayesian_artifacts_p00_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_artifacts_pkey ATTACH PARTITION public.bayesian_artifacts_p00_pkey;
 
+
+--
+-- Name: bayesian_artifacts_p00_tenant_id_artifact_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_hash ATTACH PARTITION public.bayesian_artifacts_p00_tenant_id_artifact_hash_idx;
+
+
+--
+-- Name: bayesian_artifacts_p00_tenant_id_artifact_ref_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p00_tenant_id_artifact_ref_idx;
 
+
+--
+-- Name: bayesian_artifacts_p00_tenant_id_artifact_ref_key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p00_tenant_id_artifact_ref_key;
+
+
+--
+-- Name: bayesian_artifacts_p00_tenant_id_fit_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_fit ATTACH PARTITION public.bayesian_artifacts_p00_tenant_id_fit_id_idx;
 
+
+--
+-- Name: bayesian_artifacts_p00_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_id ATTACH PARTITION public.bayesian_artifacts_p00_tenant_id_idx;
+
+
+--
+-- Name: bayesian_artifacts_p01_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_artifacts_pkey ATTACH PARTITION public.bayesian_artifacts_p01_pkey;
 
+
+--
+-- Name: bayesian_artifacts_p01_tenant_id_artifact_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_hash ATTACH PARTITION public.bayesian_artifacts_p01_tenant_id_artifact_hash_idx;
+
+
+--
+-- Name: bayesian_artifacts_p01_tenant_id_artifact_ref_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p01_tenant_id_artifact_ref_idx;
 
+
+--
+-- Name: bayesian_artifacts_p01_tenant_id_artifact_ref_key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p01_tenant_id_artifact_ref_key;
+
+
+--
+-- Name: bayesian_artifacts_p01_tenant_id_fit_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_fit ATTACH PARTITION public.bayesian_artifacts_p01_tenant_id_fit_id_idx;
 
+
+--
+-- Name: bayesian_artifacts_p01_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_id ATTACH PARTITION public.bayesian_artifacts_p01_tenant_id_idx;
+
+
+--
+-- Name: bayesian_artifacts_p02_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_artifacts_pkey ATTACH PARTITION public.bayesian_artifacts_p02_pkey;
 
+
+--
+-- Name: bayesian_artifacts_p02_tenant_id_artifact_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_hash ATTACH PARTITION public.bayesian_artifacts_p02_tenant_id_artifact_hash_idx;
+
+
+--
+-- Name: bayesian_artifacts_p02_tenant_id_artifact_ref_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p02_tenant_id_artifact_ref_idx;
 
+
+--
+-- Name: bayesian_artifacts_p02_tenant_id_artifact_ref_key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p02_tenant_id_artifact_ref_key;
+
+
+--
+-- Name: bayesian_artifacts_p02_tenant_id_fit_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_fit ATTACH PARTITION public.bayesian_artifacts_p02_tenant_id_fit_id_idx;
 
+
+--
+-- Name: bayesian_artifacts_p02_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_id ATTACH PARTITION public.bayesian_artifacts_p02_tenant_id_idx;
+
+
+--
+-- Name: bayesian_artifacts_p03_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_artifacts_pkey ATTACH PARTITION public.bayesian_artifacts_p03_pkey;
 
+
+--
+-- Name: bayesian_artifacts_p03_tenant_id_artifact_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_hash ATTACH PARTITION public.bayesian_artifacts_p03_tenant_id_artifact_hash_idx;
+
+
+--
+-- Name: bayesian_artifacts_p03_tenant_id_artifact_ref_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p03_tenant_id_artifact_ref_idx;
 
+
+--
+-- Name: bayesian_artifacts_p03_tenant_id_artifact_ref_key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p03_tenant_id_artifact_ref_key;
+
+
+--
+-- Name: bayesian_artifacts_p03_tenant_id_fit_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_fit ATTACH PARTITION public.bayesian_artifacts_p03_tenant_id_fit_id_idx;
 
+
+--
+-- Name: bayesian_artifacts_p03_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_id ATTACH PARTITION public.bayesian_artifacts_p03_tenant_id_idx;
+
+
+--
+-- Name: bayesian_artifacts_p04_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_artifacts_pkey ATTACH PARTITION public.bayesian_artifacts_p04_pkey;
 
+
+--
+-- Name: bayesian_artifacts_p04_tenant_id_artifact_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_hash ATTACH PARTITION public.bayesian_artifacts_p04_tenant_id_artifact_hash_idx;
+
+
+--
+-- Name: bayesian_artifacts_p04_tenant_id_artifact_ref_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p04_tenant_id_artifact_ref_idx;
 
+
+--
+-- Name: bayesian_artifacts_p04_tenant_id_artifact_ref_key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p04_tenant_id_artifact_ref_key;
+
+
+--
+-- Name: bayesian_artifacts_p04_tenant_id_fit_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_fit ATTACH PARTITION public.bayesian_artifacts_p04_tenant_id_fit_id_idx;
 
+
+--
+-- Name: bayesian_artifacts_p04_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_id ATTACH PARTITION public.bayesian_artifacts_p04_tenant_id_idx;
+
+
+--
+-- Name: bayesian_artifacts_p05_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_artifacts_pkey ATTACH PARTITION public.bayesian_artifacts_p05_pkey;
 
+
+--
+-- Name: bayesian_artifacts_p05_tenant_id_artifact_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_hash ATTACH PARTITION public.bayesian_artifacts_p05_tenant_id_artifact_hash_idx;
+
+
+--
+-- Name: bayesian_artifacts_p05_tenant_id_artifact_ref_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p05_tenant_id_artifact_ref_idx;
 
+
+--
+-- Name: bayesian_artifacts_p05_tenant_id_artifact_ref_key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p05_tenant_id_artifact_ref_key;
+
+
+--
+-- Name: bayesian_artifacts_p05_tenant_id_fit_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_fit ATTACH PARTITION public.bayesian_artifacts_p05_tenant_id_fit_id_idx;
 
+
+--
+-- Name: bayesian_artifacts_p05_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_id ATTACH PARTITION public.bayesian_artifacts_p05_tenant_id_idx;
+
+
+--
+-- Name: bayesian_artifacts_p06_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_artifacts_pkey ATTACH PARTITION public.bayesian_artifacts_p06_pkey;
 
+
+--
+-- Name: bayesian_artifacts_p06_tenant_id_artifact_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_hash ATTACH PARTITION public.bayesian_artifacts_p06_tenant_id_artifact_hash_idx;
+
+
+--
+-- Name: bayesian_artifacts_p06_tenant_id_artifact_ref_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p06_tenant_id_artifact_ref_idx;
 
+
+--
+-- Name: bayesian_artifacts_p06_tenant_id_artifact_ref_key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p06_tenant_id_artifact_ref_key;
+
+
+--
+-- Name: bayesian_artifacts_p06_tenant_id_fit_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_fit ATTACH PARTITION public.bayesian_artifacts_p06_tenant_id_fit_id_idx;
 
+
+--
+-- Name: bayesian_artifacts_p06_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_id ATTACH PARTITION public.bayesian_artifacts_p06_tenant_id_idx;
+
+
+--
+-- Name: bayesian_artifacts_p07_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_artifacts_pkey ATTACH PARTITION public.bayesian_artifacts_p07_pkey;
 
+
+--
+-- Name: bayesian_artifacts_p07_tenant_id_artifact_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_hash ATTACH PARTITION public.bayesian_artifacts_p07_tenant_id_artifact_hash_idx;
+
+
+--
+-- Name: bayesian_artifacts_p07_tenant_id_artifact_ref_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p07_tenant_id_artifact_ref_idx;
 
+
+--
+-- Name: bayesian_artifacts_p07_tenant_id_artifact_ref_key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p07_tenant_id_artifact_ref_key;
+
+
+--
+-- Name: bayesian_artifacts_p07_tenant_id_fit_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_fit ATTACH PARTITION public.bayesian_artifacts_p07_tenant_id_fit_id_idx;
 
+
+--
+-- Name: bayesian_artifacts_p07_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_id ATTACH PARTITION public.bayesian_artifacts_p07_tenant_id_idx;
+
+
+--
+-- Name: bayesian_artifacts_p08_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_artifacts_pkey ATTACH PARTITION public.bayesian_artifacts_p08_pkey;
 
+
+--
+-- Name: bayesian_artifacts_p08_tenant_id_artifact_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_hash ATTACH PARTITION public.bayesian_artifacts_p08_tenant_id_artifact_hash_idx;
+
+
+--
+-- Name: bayesian_artifacts_p08_tenant_id_artifact_ref_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p08_tenant_id_artifact_ref_idx;
 
+
+--
+-- Name: bayesian_artifacts_p08_tenant_id_artifact_ref_key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p08_tenant_id_artifact_ref_key;
+
+
+--
+-- Name: bayesian_artifacts_p08_tenant_id_fit_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_fit ATTACH PARTITION public.bayesian_artifacts_p08_tenant_id_fit_id_idx;
 
+
+--
+-- Name: bayesian_artifacts_p08_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_id ATTACH PARTITION public.bayesian_artifacts_p08_tenant_id_idx;
+
+
+--
+-- Name: bayesian_artifacts_p09_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_artifacts_pkey ATTACH PARTITION public.bayesian_artifacts_p09_pkey;
 
+
+--
+-- Name: bayesian_artifacts_p09_tenant_id_artifact_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_hash ATTACH PARTITION public.bayesian_artifacts_p09_tenant_id_artifact_hash_idx;
+
+
+--
+-- Name: bayesian_artifacts_p09_tenant_id_artifact_ref_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p09_tenant_id_artifact_ref_idx;
 
+
+--
+-- Name: bayesian_artifacts_p09_tenant_id_artifact_ref_key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p09_tenant_id_artifact_ref_key;
+
+
+--
+-- Name: bayesian_artifacts_p09_tenant_id_fit_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_fit ATTACH PARTITION public.bayesian_artifacts_p09_tenant_id_fit_id_idx;
 
+
+--
+-- Name: bayesian_artifacts_p09_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_id ATTACH PARTITION public.bayesian_artifacts_p09_tenant_id_idx;
+
+
+--
+-- Name: bayesian_artifacts_p10_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_artifacts_pkey ATTACH PARTITION public.bayesian_artifacts_p10_pkey;
 
+
+--
+-- Name: bayesian_artifacts_p10_tenant_id_artifact_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_hash ATTACH PARTITION public.bayesian_artifacts_p10_tenant_id_artifact_hash_idx;
+
+
+--
+-- Name: bayesian_artifacts_p10_tenant_id_artifact_ref_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p10_tenant_id_artifact_ref_idx;
 
+
+--
+-- Name: bayesian_artifacts_p10_tenant_id_artifact_ref_key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p10_tenant_id_artifact_ref_key;
+
+
+--
+-- Name: bayesian_artifacts_p10_tenant_id_fit_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_fit ATTACH PARTITION public.bayesian_artifacts_p10_tenant_id_fit_id_idx;
 
+
+--
+-- Name: bayesian_artifacts_p10_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_id ATTACH PARTITION public.bayesian_artifacts_p10_tenant_id_idx;
+
+
+--
+-- Name: bayesian_artifacts_p11_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_artifacts_pkey ATTACH PARTITION public.bayesian_artifacts_p11_pkey;
 
+
+--
+-- Name: bayesian_artifacts_p11_tenant_id_artifact_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_hash ATTACH PARTITION public.bayesian_artifacts_p11_tenant_id_artifact_hash_idx;
+
+
+--
+-- Name: bayesian_artifacts_p11_tenant_id_artifact_ref_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p11_tenant_id_artifact_ref_idx;
 
+
+--
+-- Name: bayesian_artifacts_p11_tenant_id_artifact_ref_key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p11_tenant_id_artifact_ref_key;
+
+
+--
+-- Name: bayesian_artifacts_p11_tenant_id_fit_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_fit ATTACH PARTITION public.bayesian_artifacts_p11_tenant_id_fit_id_idx;
 
+
+--
+-- Name: bayesian_artifacts_p11_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_id ATTACH PARTITION public.bayesian_artifacts_p11_tenant_id_idx;
+
+
+--
+-- Name: bayesian_artifacts_p12_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_artifacts_pkey ATTACH PARTITION public.bayesian_artifacts_p12_pkey;
 
+
+--
+-- Name: bayesian_artifacts_p12_tenant_id_artifact_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_hash ATTACH PARTITION public.bayesian_artifacts_p12_tenant_id_artifact_hash_idx;
+
+
+--
+-- Name: bayesian_artifacts_p12_tenant_id_artifact_ref_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p12_tenant_id_artifact_ref_idx;
 
+
+--
+-- Name: bayesian_artifacts_p12_tenant_id_artifact_ref_key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p12_tenant_id_artifact_ref_key;
+
+
+--
+-- Name: bayesian_artifacts_p12_tenant_id_fit_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_fit ATTACH PARTITION public.bayesian_artifacts_p12_tenant_id_fit_id_idx;
 
+
+--
+-- Name: bayesian_artifacts_p12_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_id ATTACH PARTITION public.bayesian_artifacts_p12_tenant_id_idx;
+
+
+--
+-- Name: bayesian_artifacts_p13_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_artifacts_pkey ATTACH PARTITION public.bayesian_artifacts_p13_pkey;
 
+
+--
+-- Name: bayesian_artifacts_p13_tenant_id_artifact_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_hash ATTACH PARTITION public.bayesian_artifacts_p13_tenant_id_artifact_hash_idx;
+
+
+--
+-- Name: bayesian_artifacts_p13_tenant_id_artifact_ref_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p13_tenant_id_artifact_ref_idx;
 
+
+--
+-- Name: bayesian_artifacts_p13_tenant_id_artifact_ref_key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p13_tenant_id_artifact_ref_key;
+
+
+--
+-- Name: bayesian_artifacts_p13_tenant_id_fit_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_fit ATTACH PARTITION public.bayesian_artifacts_p13_tenant_id_fit_id_idx;
 
+
+--
+-- Name: bayesian_artifacts_p13_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_id ATTACH PARTITION public.bayesian_artifacts_p13_tenant_id_idx;
+
+
+--
+-- Name: bayesian_artifacts_p14_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_artifacts_pkey ATTACH PARTITION public.bayesian_artifacts_p14_pkey;
 
+
+--
+-- Name: bayesian_artifacts_p14_tenant_id_artifact_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_hash ATTACH PARTITION public.bayesian_artifacts_p14_tenant_id_artifact_hash_idx;
+
+
+--
+-- Name: bayesian_artifacts_p14_tenant_id_artifact_ref_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p14_tenant_id_artifact_ref_idx;
 
+
+--
+-- Name: bayesian_artifacts_p14_tenant_id_artifact_ref_key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p14_tenant_id_artifact_ref_key;
+
+
+--
+-- Name: bayesian_artifacts_p14_tenant_id_fit_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_fit ATTACH PARTITION public.bayesian_artifacts_p14_tenant_id_fit_id_idx;
 
+
+--
+-- Name: bayesian_artifacts_p14_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_id ATTACH PARTITION public.bayesian_artifacts_p14_tenant_id_idx;
+
+
+--
+-- Name: bayesian_artifacts_p15_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_artifacts_pkey ATTACH PARTITION public.bayesian_artifacts_p15_pkey;
 
+
+--
+-- Name: bayesian_artifacts_p15_tenant_id_artifact_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_hash ATTACH PARTITION public.bayesian_artifacts_p15_tenant_id_artifact_hash_idx;
+
+
+--
+-- Name: bayesian_artifacts_p15_tenant_id_artifact_ref_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p15_tenant_id_artifact_ref_idx;
 
+
+--
+-- Name: bayesian_artifacts_p15_tenant_id_artifact_ref_key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_artifacts_tenant_artifact_ref ATTACH PARTITION public.bayesian_artifacts_p15_tenant_id_artifact_ref_key;
+
+
+--
+-- Name: bayesian_artifacts_p15_tenant_id_fit_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_artifacts_tenant_fit ATTACH PARTITION public.bayesian_artifacts_p15_tenant_id_fit_id_idx;
 
+
+--
+-- Name: bayesian_artifacts_p15_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_artifacts_tenant_id ATTACH PARTITION public.bayesian_artifacts_p15_tenant_id_idx;
+
+
+--
+-- Name: bayesian_model_fits_p00_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_model_fits_pkey ATTACH PARTITION public.bayesian_model_fits_p00_pkey;
 
+
+--
+-- Name: bayesian_model_fits_p00_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_id ATTACH PARTITION public.bayesian_model_fits_p00_tenant_id_idx;
+
+
+--
+-- Name: bayesian_model_fits_p00_tenant_id_model_type_eligibility_st_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_eligibility ATTACH PARTITION public.bayesian_model_fits_p00_tenant_id_model_type_eligibility_st_idx;
 
+
+--
+-- Name: bayesian_model_fits_p00_tenant_id_model_type_fallback_reaso_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_fallback ATTACH PARTITION public.bayesian_model_fits_p00_tenant_id_model_type_fallback_reaso_idx;
+
+
+--
+-- Name: bayesian_model_fits_p00_tenant_id_model_type_model_version__key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.uq_bayesian_model_fits_tenant_model_window_snapshot ATTACH PARTITION public.bayesian_model_fits_p00_tenant_id_model_type_model_version__key;
 
+
+--
+-- Name: bayesian_model_fits_p00_tenant_id_model_type_source_window__idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window ATTACH PARTITION public.bayesian_model_fits_p00_tenant_id_model_type_source_window__idx;
+
+
+--
+-- Name: bayesian_model_fits_p00_tenant_id_model_type_source_window_idx1; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window_latest ATTACH PARTITION public.bayesian_model_fits_p00_tenant_id_model_type_source_window_idx1;
 
+
+--
+-- Name: bayesian_model_fits_p00_tenant_id_source_snapshot_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_source_snapshot_hash ATTACH PARTITION public.bayesian_model_fits_p00_tenant_id_source_snapshot_hash_idx;
+
+
+--
+-- Name: bayesian_model_fits_p00_tenant_id_status_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_status ATTACH PARTITION public.bayesian_model_fits_p00_tenant_id_status_idx;
 
+
+--
+-- Name: bayesian_model_fits_p01_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.bayesian_model_fits_pkey ATTACH PARTITION public.bayesian_model_fits_p01_pkey;
+
+
+--
+-- Name: bayesian_model_fits_p01_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_id ATTACH PARTITION public.bayesian_model_fits_p01_tenant_id_idx;
 
+
+--
+-- Name: bayesian_model_fits_p01_tenant_id_model_type_eligibility_st_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_eligibility ATTACH PARTITION public.bayesian_model_fits_p01_tenant_id_model_type_eligibility_st_idx;
+
+
+--
+-- Name: bayesian_model_fits_p01_tenant_id_model_type_fallback_reaso_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_fallback ATTACH PARTITION public.bayesian_model_fits_p01_tenant_id_model_type_fallback_reaso_idx;
 
+
+--
+-- Name: bayesian_model_fits_p01_tenant_id_model_type_model_version__key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_model_fits_tenant_model_window_snapshot ATTACH PARTITION public.bayesian_model_fits_p01_tenant_id_model_type_model_version__key;
+
+
+--
+-- Name: bayesian_model_fits_p01_tenant_id_model_type_source_window__idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window ATTACH PARTITION public.bayesian_model_fits_p01_tenant_id_model_type_source_window__idx;
 
+
+--
+-- Name: bayesian_model_fits_p01_tenant_id_model_type_source_window_idx1; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window_latest ATTACH PARTITION public.bayesian_model_fits_p01_tenant_id_model_type_source_window_idx1;
+
+
+--
+-- Name: bayesian_model_fits_p01_tenant_id_source_snapshot_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_source_snapshot_hash ATTACH PARTITION public.bayesian_model_fits_p01_tenant_id_source_snapshot_hash_idx;
 
+
+--
+-- Name: bayesian_model_fits_p01_tenant_id_status_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_status ATTACH PARTITION public.bayesian_model_fits_p01_tenant_id_status_idx;
+
+
+--
+-- Name: bayesian_model_fits_p02_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_model_fits_pkey ATTACH PARTITION public.bayesian_model_fits_p02_pkey;
 
+
+--
+-- Name: bayesian_model_fits_p02_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_id ATTACH PARTITION public.bayesian_model_fits_p02_tenant_id_idx;
+
+
+--
+-- Name: bayesian_model_fits_p02_tenant_id_model_type_eligibility_st_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_eligibility ATTACH PARTITION public.bayesian_model_fits_p02_tenant_id_model_type_eligibility_st_idx;
 
+
+--
+-- Name: bayesian_model_fits_p02_tenant_id_model_type_fallback_reaso_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_fallback ATTACH PARTITION public.bayesian_model_fits_p02_tenant_id_model_type_fallback_reaso_idx;
+
+
+--
+-- Name: bayesian_model_fits_p02_tenant_id_model_type_model_version__key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.uq_bayesian_model_fits_tenant_model_window_snapshot ATTACH PARTITION public.bayesian_model_fits_p02_tenant_id_model_type_model_version__key;
 
+
+--
+-- Name: bayesian_model_fits_p02_tenant_id_model_type_source_window__idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window ATTACH PARTITION public.bayesian_model_fits_p02_tenant_id_model_type_source_window__idx;
+
+
+--
+-- Name: bayesian_model_fits_p02_tenant_id_model_type_source_window_idx1; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window_latest ATTACH PARTITION public.bayesian_model_fits_p02_tenant_id_model_type_source_window_idx1;
 
+
+--
+-- Name: bayesian_model_fits_p02_tenant_id_source_snapshot_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_source_snapshot_hash ATTACH PARTITION public.bayesian_model_fits_p02_tenant_id_source_snapshot_hash_idx;
+
+
+--
+-- Name: bayesian_model_fits_p02_tenant_id_status_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_status ATTACH PARTITION public.bayesian_model_fits_p02_tenant_id_status_idx;
 
+
+--
+-- Name: bayesian_model_fits_p03_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.bayesian_model_fits_pkey ATTACH PARTITION public.bayesian_model_fits_p03_pkey;
+
+
+--
+-- Name: bayesian_model_fits_p03_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_id ATTACH PARTITION public.bayesian_model_fits_p03_tenant_id_idx;
 
+
+--
+-- Name: bayesian_model_fits_p03_tenant_id_model_type_eligibility_st_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_eligibility ATTACH PARTITION public.bayesian_model_fits_p03_tenant_id_model_type_eligibility_st_idx;
+
+
+--
+-- Name: bayesian_model_fits_p03_tenant_id_model_type_fallback_reaso_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_fallback ATTACH PARTITION public.bayesian_model_fits_p03_tenant_id_model_type_fallback_reaso_idx;
 
+
+--
+-- Name: bayesian_model_fits_p03_tenant_id_model_type_model_version__key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_model_fits_tenant_model_window_snapshot ATTACH PARTITION public.bayesian_model_fits_p03_tenant_id_model_type_model_version__key;
+
+
+--
+-- Name: bayesian_model_fits_p03_tenant_id_model_type_source_window__idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window ATTACH PARTITION public.bayesian_model_fits_p03_tenant_id_model_type_source_window__idx;
 
+
+--
+-- Name: bayesian_model_fits_p03_tenant_id_model_type_source_window_idx1; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window_latest ATTACH PARTITION public.bayesian_model_fits_p03_tenant_id_model_type_source_window_idx1;
+
+
+--
+-- Name: bayesian_model_fits_p03_tenant_id_source_snapshot_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_source_snapshot_hash ATTACH PARTITION public.bayesian_model_fits_p03_tenant_id_source_snapshot_hash_idx;
 
+
+--
+-- Name: bayesian_model_fits_p03_tenant_id_status_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_status ATTACH PARTITION public.bayesian_model_fits_p03_tenant_id_status_idx;
+
+
+--
+-- Name: bayesian_model_fits_p04_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_model_fits_pkey ATTACH PARTITION public.bayesian_model_fits_p04_pkey;
 
+
+--
+-- Name: bayesian_model_fits_p04_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_id ATTACH PARTITION public.bayesian_model_fits_p04_tenant_id_idx;
+
+
+--
+-- Name: bayesian_model_fits_p04_tenant_id_model_type_eligibility_st_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_eligibility ATTACH PARTITION public.bayesian_model_fits_p04_tenant_id_model_type_eligibility_st_idx;
 
+
+--
+-- Name: bayesian_model_fits_p04_tenant_id_model_type_fallback_reaso_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_fallback ATTACH PARTITION public.bayesian_model_fits_p04_tenant_id_model_type_fallback_reaso_idx;
+
+
+--
+-- Name: bayesian_model_fits_p04_tenant_id_model_type_model_version__key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.uq_bayesian_model_fits_tenant_model_window_snapshot ATTACH PARTITION public.bayesian_model_fits_p04_tenant_id_model_type_model_version__key;
 
+
+--
+-- Name: bayesian_model_fits_p04_tenant_id_model_type_source_window__idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window ATTACH PARTITION public.bayesian_model_fits_p04_tenant_id_model_type_source_window__idx;
+
+
+--
+-- Name: bayesian_model_fits_p04_tenant_id_model_type_source_window_idx1; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window_latest ATTACH PARTITION public.bayesian_model_fits_p04_tenant_id_model_type_source_window_idx1;
 
+
+--
+-- Name: bayesian_model_fits_p04_tenant_id_source_snapshot_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_source_snapshot_hash ATTACH PARTITION public.bayesian_model_fits_p04_tenant_id_source_snapshot_hash_idx;
+
+
+--
+-- Name: bayesian_model_fits_p04_tenant_id_status_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_status ATTACH PARTITION public.bayesian_model_fits_p04_tenant_id_status_idx;
 
+
+--
+-- Name: bayesian_model_fits_p05_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.bayesian_model_fits_pkey ATTACH PARTITION public.bayesian_model_fits_p05_pkey;
+
+
+--
+-- Name: bayesian_model_fits_p05_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_id ATTACH PARTITION public.bayesian_model_fits_p05_tenant_id_idx;
 
+
+--
+-- Name: bayesian_model_fits_p05_tenant_id_model_type_eligibility_st_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_eligibility ATTACH PARTITION public.bayesian_model_fits_p05_tenant_id_model_type_eligibility_st_idx;
+
+
+--
+-- Name: bayesian_model_fits_p05_tenant_id_model_type_fallback_reaso_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_fallback ATTACH PARTITION public.bayesian_model_fits_p05_tenant_id_model_type_fallback_reaso_idx;
 
+
+--
+-- Name: bayesian_model_fits_p05_tenant_id_model_type_model_version__key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_model_fits_tenant_model_window_snapshot ATTACH PARTITION public.bayesian_model_fits_p05_tenant_id_model_type_model_version__key;
+
+
+--
+-- Name: bayesian_model_fits_p05_tenant_id_model_type_source_window__idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window ATTACH PARTITION public.bayesian_model_fits_p05_tenant_id_model_type_source_window__idx;
 
+
+--
+-- Name: bayesian_model_fits_p05_tenant_id_model_type_source_window_idx1; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window_latest ATTACH PARTITION public.bayesian_model_fits_p05_tenant_id_model_type_source_window_idx1;
+
+
+--
+-- Name: bayesian_model_fits_p05_tenant_id_source_snapshot_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_source_snapshot_hash ATTACH PARTITION public.bayesian_model_fits_p05_tenant_id_source_snapshot_hash_idx;
 
+
+--
+-- Name: bayesian_model_fits_p05_tenant_id_status_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_status ATTACH PARTITION public.bayesian_model_fits_p05_tenant_id_status_idx;
+
+
+--
+-- Name: bayesian_model_fits_p06_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_model_fits_pkey ATTACH PARTITION public.bayesian_model_fits_p06_pkey;
 
+
+--
+-- Name: bayesian_model_fits_p06_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_id ATTACH PARTITION public.bayesian_model_fits_p06_tenant_id_idx;
+
+
+--
+-- Name: bayesian_model_fits_p06_tenant_id_model_type_eligibility_st_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_eligibility ATTACH PARTITION public.bayesian_model_fits_p06_tenant_id_model_type_eligibility_st_idx;
 
+
+--
+-- Name: bayesian_model_fits_p06_tenant_id_model_type_fallback_reaso_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_fallback ATTACH PARTITION public.bayesian_model_fits_p06_tenant_id_model_type_fallback_reaso_idx;
+
+
+--
+-- Name: bayesian_model_fits_p06_tenant_id_model_type_model_version__key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.uq_bayesian_model_fits_tenant_model_window_snapshot ATTACH PARTITION public.bayesian_model_fits_p06_tenant_id_model_type_model_version__key;
 
+
+--
+-- Name: bayesian_model_fits_p06_tenant_id_model_type_source_window__idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window ATTACH PARTITION public.bayesian_model_fits_p06_tenant_id_model_type_source_window__idx;
+
+
+--
+-- Name: bayesian_model_fits_p06_tenant_id_model_type_source_window_idx1; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window_latest ATTACH PARTITION public.bayesian_model_fits_p06_tenant_id_model_type_source_window_idx1;
 
+
+--
+-- Name: bayesian_model_fits_p06_tenant_id_source_snapshot_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_source_snapshot_hash ATTACH PARTITION public.bayesian_model_fits_p06_tenant_id_source_snapshot_hash_idx;
+
+
+--
+-- Name: bayesian_model_fits_p06_tenant_id_status_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_status ATTACH PARTITION public.bayesian_model_fits_p06_tenant_id_status_idx;
 
+
+--
+-- Name: bayesian_model_fits_p07_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.bayesian_model_fits_pkey ATTACH PARTITION public.bayesian_model_fits_p07_pkey;
+
+
+--
+-- Name: bayesian_model_fits_p07_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_id ATTACH PARTITION public.bayesian_model_fits_p07_tenant_id_idx;
 
+
+--
+-- Name: bayesian_model_fits_p07_tenant_id_model_type_eligibility_st_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_eligibility ATTACH PARTITION public.bayesian_model_fits_p07_tenant_id_model_type_eligibility_st_idx;
+
+
+--
+-- Name: bayesian_model_fits_p07_tenant_id_model_type_fallback_reaso_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_fallback ATTACH PARTITION public.bayesian_model_fits_p07_tenant_id_model_type_fallback_reaso_idx;
 
+
+--
+-- Name: bayesian_model_fits_p07_tenant_id_model_type_model_version__key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_model_fits_tenant_model_window_snapshot ATTACH PARTITION public.bayesian_model_fits_p07_tenant_id_model_type_model_version__key;
+
+
+--
+-- Name: bayesian_model_fits_p07_tenant_id_model_type_source_window__idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window ATTACH PARTITION public.bayesian_model_fits_p07_tenant_id_model_type_source_window__idx;
 
+
+--
+-- Name: bayesian_model_fits_p07_tenant_id_model_type_source_window_idx1; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window_latest ATTACH PARTITION public.bayesian_model_fits_p07_tenant_id_model_type_source_window_idx1;
+
+
+--
+-- Name: bayesian_model_fits_p07_tenant_id_source_snapshot_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_source_snapshot_hash ATTACH PARTITION public.bayesian_model_fits_p07_tenant_id_source_snapshot_hash_idx;
 
+
+--
+-- Name: bayesian_model_fits_p07_tenant_id_status_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_status ATTACH PARTITION public.bayesian_model_fits_p07_tenant_id_status_idx;
+
+
+--
+-- Name: bayesian_model_fits_p08_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_model_fits_pkey ATTACH PARTITION public.bayesian_model_fits_p08_pkey;
 
+
+--
+-- Name: bayesian_model_fits_p08_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_id ATTACH PARTITION public.bayesian_model_fits_p08_tenant_id_idx;
+
+
+--
+-- Name: bayesian_model_fits_p08_tenant_id_model_type_eligibility_st_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_eligibility ATTACH PARTITION public.bayesian_model_fits_p08_tenant_id_model_type_eligibility_st_idx;
 
+
+--
+-- Name: bayesian_model_fits_p08_tenant_id_model_type_fallback_reaso_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_fallback ATTACH PARTITION public.bayesian_model_fits_p08_tenant_id_model_type_fallback_reaso_idx;
+
+
+--
+-- Name: bayesian_model_fits_p08_tenant_id_model_type_model_version__key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.uq_bayesian_model_fits_tenant_model_window_snapshot ATTACH PARTITION public.bayesian_model_fits_p08_tenant_id_model_type_model_version__key;
 
+
+--
+-- Name: bayesian_model_fits_p08_tenant_id_model_type_source_window__idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window ATTACH PARTITION public.bayesian_model_fits_p08_tenant_id_model_type_source_window__idx;
+
+
+--
+-- Name: bayesian_model_fits_p08_tenant_id_model_type_source_window_idx1; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window_latest ATTACH PARTITION public.bayesian_model_fits_p08_tenant_id_model_type_source_window_idx1;
 
+
+--
+-- Name: bayesian_model_fits_p08_tenant_id_source_snapshot_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_source_snapshot_hash ATTACH PARTITION public.bayesian_model_fits_p08_tenant_id_source_snapshot_hash_idx;
+
+
+--
+-- Name: bayesian_model_fits_p08_tenant_id_status_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_status ATTACH PARTITION public.bayesian_model_fits_p08_tenant_id_status_idx;
 
+
+--
+-- Name: bayesian_model_fits_p09_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.bayesian_model_fits_pkey ATTACH PARTITION public.bayesian_model_fits_p09_pkey;
+
+
+--
+-- Name: bayesian_model_fits_p09_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_id ATTACH PARTITION public.bayesian_model_fits_p09_tenant_id_idx;
 
+
+--
+-- Name: bayesian_model_fits_p09_tenant_id_model_type_eligibility_st_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_eligibility ATTACH PARTITION public.bayesian_model_fits_p09_tenant_id_model_type_eligibility_st_idx;
+
+
+--
+-- Name: bayesian_model_fits_p09_tenant_id_model_type_fallback_reaso_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_fallback ATTACH PARTITION public.bayesian_model_fits_p09_tenant_id_model_type_fallback_reaso_idx;
 
+
+--
+-- Name: bayesian_model_fits_p09_tenant_id_model_type_model_version__key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_model_fits_tenant_model_window_snapshot ATTACH PARTITION public.bayesian_model_fits_p09_tenant_id_model_type_model_version__key;
+
+
+--
+-- Name: bayesian_model_fits_p09_tenant_id_model_type_source_window__idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window ATTACH PARTITION public.bayesian_model_fits_p09_tenant_id_model_type_source_window__idx;
 
+
+--
+-- Name: bayesian_model_fits_p09_tenant_id_model_type_source_window_idx1; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window_latest ATTACH PARTITION public.bayesian_model_fits_p09_tenant_id_model_type_source_window_idx1;
+
+
+--
+-- Name: bayesian_model_fits_p09_tenant_id_source_snapshot_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_source_snapshot_hash ATTACH PARTITION public.bayesian_model_fits_p09_tenant_id_source_snapshot_hash_idx;
 
+
+--
+-- Name: bayesian_model_fits_p09_tenant_id_status_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_status ATTACH PARTITION public.bayesian_model_fits_p09_tenant_id_status_idx;
+
+
+--
+-- Name: bayesian_model_fits_p10_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_model_fits_pkey ATTACH PARTITION public.bayesian_model_fits_p10_pkey;
 
+
+--
+-- Name: bayesian_model_fits_p10_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_id ATTACH PARTITION public.bayesian_model_fits_p10_tenant_id_idx;
+
+
+--
+-- Name: bayesian_model_fits_p10_tenant_id_model_type_eligibility_st_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_eligibility ATTACH PARTITION public.bayesian_model_fits_p10_tenant_id_model_type_eligibility_st_idx;
 
+
+--
+-- Name: bayesian_model_fits_p10_tenant_id_model_type_fallback_reaso_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_fallback ATTACH PARTITION public.bayesian_model_fits_p10_tenant_id_model_type_fallback_reaso_idx;
+
+
+--
+-- Name: bayesian_model_fits_p10_tenant_id_model_type_model_version__key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.uq_bayesian_model_fits_tenant_model_window_snapshot ATTACH PARTITION public.bayesian_model_fits_p10_tenant_id_model_type_model_version__key;
 
+
+--
+-- Name: bayesian_model_fits_p10_tenant_id_model_type_source_window__idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window ATTACH PARTITION public.bayesian_model_fits_p10_tenant_id_model_type_source_window__idx;
+
+
+--
+-- Name: bayesian_model_fits_p10_tenant_id_model_type_source_window_idx1; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window_latest ATTACH PARTITION public.bayesian_model_fits_p10_tenant_id_model_type_source_window_idx1;
 
+
+--
+-- Name: bayesian_model_fits_p10_tenant_id_source_snapshot_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_source_snapshot_hash ATTACH PARTITION public.bayesian_model_fits_p10_tenant_id_source_snapshot_hash_idx;
+
+
+--
+-- Name: bayesian_model_fits_p10_tenant_id_status_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_status ATTACH PARTITION public.bayesian_model_fits_p10_tenant_id_status_idx;
 
+
+--
+-- Name: bayesian_model_fits_p11_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.bayesian_model_fits_pkey ATTACH PARTITION public.bayesian_model_fits_p11_pkey;
+
+
+--
+-- Name: bayesian_model_fits_p11_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_id ATTACH PARTITION public.bayesian_model_fits_p11_tenant_id_idx;
 
+
+--
+-- Name: bayesian_model_fits_p11_tenant_id_model_type_eligibility_st_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_eligibility ATTACH PARTITION public.bayesian_model_fits_p11_tenant_id_model_type_eligibility_st_idx;
+
+
+--
+-- Name: bayesian_model_fits_p11_tenant_id_model_type_fallback_reaso_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_fallback ATTACH PARTITION public.bayesian_model_fits_p11_tenant_id_model_type_fallback_reaso_idx;
 
+
+--
+-- Name: bayesian_model_fits_p11_tenant_id_model_type_model_version__key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_model_fits_tenant_model_window_snapshot ATTACH PARTITION public.bayesian_model_fits_p11_tenant_id_model_type_model_version__key;
+
+
+--
+-- Name: bayesian_model_fits_p11_tenant_id_model_type_source_window__idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window ATTACH PARTITION public.bayesian_model_fits_p11_tenant_id_model_type_source_window__idx;
 
+
+--
+-- Name: bayesian_model_fits_p11_tenant_id_model_type_source_window_idx1; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window_latest ATTACH PARTITION public.bayesian_model_fits_p11_tenant_id_model_type_source_window_idx1;
+
+
+--
+-- Name: bayesian_model_fits_p11_tenant_id_source_snapshot_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_source_snapshot_hash ATTACH PARTITION public.bayesian_model_fits_p11_tenant_id_source_snapshot_hash_idx;
 
+
+--
+-- Name: bayesian_model_fits_p11_tenant_id_status_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_status ATTACH PARTITION public.bayesian_model_fits_p11_tenant_id_status_idx;
+
+
+--
+-- Name: bayesian_model_fits_p12_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_model_fits_pkey ATTACH PARTITION public.bayesian_model_fits_p12_pkey;
 
+
+--
+-- Name: bayesian_model_fits_p12_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_id ATTACH PARTITION public.bayesian_model_fits_p12_tenant_id_idx;
+
+
+--
+-- Name: bayesian_model_fits_p12_tenant_id_model_type_eligibility_st_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_eligibility ATTACH PARTITION public.bayesian_model_fits_p12_tenant_id_model_type_eligibility_st_idx;
 
+
+--
+-- Name: bayesian_model_fits_p12_tenant_id_model_type_fallback_reaso_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_fallback ATTACH PARTITION public.bayesian_model_fits_p12_tenant_id_model_type_fallback_reaso_idx;
+
+
+--
+-- Name: bayesian_model_fits_p12_tenant_id_model_type_model_version__key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.uq_bayesian_model_fits_tenant_model_window_snapshot ATTACH PARTITION public.bayesian_model_fits_p12_tenant_id_model_type_model_version__key;
 
+
+--
+-- Name: bayesian_model_fits_p12_tenant_id_model_type_source_window__idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window ATTACH PARTITION public.bayesian_model_fits_p12_tenant_id_model_type_source_window__idx;
+
+
+--
+-- Name: bayesian_model_fits_p12_tenant_id_model_type_source_window_idx1; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window_latest ATTACH PARTITION public.bayesian_model_fits_p12_tenant_id_model_type_source_window_idx1;
 
+
+--
+-- Name: bayesian_model_fits_p12_tenant_id_source_snapshot_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_source_snapshot_hash ATTACH PARTITION public.bayesian_model_fits_p12_tenant_id_source_snapshot_hash_idx;
+
+
+--
+-- Name: bayesian_model_fits_p12_tenant_id_status_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_status ATTACH PARTITION public.bayesian_model_fits_p12_tenant_id_status_idx;
 
+
+--
+-- Name: bayesian_model_fits_p13_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.bayesian_model_fits_pkey ATTACH PARTITION public.bayesian_model_fits_p13_pkey;
+
+
+--
+-- Name: bayesian_model_fits_p13_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_id ATTACH PARTITION public.bayesian_model_fits_p13_tenant_id_idx;
 
+
+--
+-- Name: bayesian_model_fits_p13_tenant_id_model_type_eligibility_st_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_eligibility ATTACH PARTITION public.bayesian_model_fits_p13_tenant_id_model_type_eligibility_st_idx;
+
+
+--
+-- Name: bayesian_model_fits_p13_tenant_id_model_type_fallback_reaso_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_fallback ATTACH PARTITION public.bayesian_model_fits_p13_tenant_id_model_type_fallback_reaso_idx;
 
+
+--
+-- Name: bayesian_model_fits_p13_tenant_id_model_type_model_version__key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_model_fits_tenant_model_window_snapshot ATTACH PARTITION public.bayesian_model_fits_p13_tenant_id_model_type_model_version__key;
+
+
+--
+-- Name: bayesian_model_fits_p13_tenant_id_model_type_source_window__idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window ATTACH PARTITION public.bayesian_model_fits_p13_tenant_id_model_type_source_window__idx;
 
+
+--
+-- Name: bayesian_model_fits_p13_tenant_id_model_type_source_window_idx1; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window_latest ATTACH PARTITION public.bayesian_model_fits_p13_tenant_id_model_type_source_window_idx1;
+
+
+--
+-- Name: bayesian_model_fits_p13_tenant_id_source_snapshot_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_source_snapshot_hash ATTACH PARTITION public.bayesian_model_fits_p13_tenant_id_source_snapshot_hash_idx;
 
+
+--
+-- Name: bayesian_model_fits_p13_tenant_id_status_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_status ATTACH PARTITION public.bayesian_model_fits_p13_tenant_id_status_idx;
+
+
+--
+-- Name: bayesian_model_fits_p14_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.bayesian_model_fits_pkey ATTACH PARTITION public.bayesian_model_fits_p14_pkey;
 
+
+--
+-- Name: bayesian_model_fits_p14_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_id ATTACH PARTITION public.bayesian_model_fits_p14_tenant_id_idx;
+
+
+--
+-- Name: bayesian_model_fits_p14_tenant_id_model_type_eligibility_st_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_eligibility ATTACH PARTITION public.bayesian_model_fits_p14_tenant_id_model_type_eligibility_st_idx;
 
+
+--
+-- Name: bayesian_model_fits_p14_tenant_id_model_type_fallback_reaso_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_fallback ATTACH PARTITION public.bayesian_model_fits_p14_tenant_id_model_type_fallback_reaso_idx;
+
+
+--
+-- Name: bayesian_model_fits_p14_tenant_id_model_type_model_version__key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.uq_bayesian_model_fits_tenant_model_window_snapshot ATTACH PARTITION public.bayesian_model_fits_p14_tenant_id_model_type_model_version__key;
 
+
+--
+-- Name: bayesian_model_fits_p14_tenant_id_model_type_source_window__idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window ATTACH PARTITION public.bayesian_model_fits_p14_tenant_id_model_type_source_window__idx;
+
+
+--
+-- Name: bayesian_model_fits_p14_tenant_id_model_type_source_window_idx1; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window_latest ATTACH PARTITION public.bayesian_model_fits_p14_tenant_id_model_type_source_window_idx1;
 
+
+--
+-- Name: bayesian_model_fits_p14_tenant_id_source_snapshot_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_source_snapshot_hash ATTACH PARTITION public.bayesian_model_fits_p14_tenant_id_source_snapshot_hash_idx;
+
+
+--
+-- Name: bayesian_model_fits_p14_tenant_id_status_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_status ATTACH PARTITION public.bayesian_model_fits_p14_tenant_id_status_idx;
 
+
+--
+-- Name: bayesian_model_fits_p15_pkey; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.bayesian_model_fits_pkey ATTACH PARTITION public.bayesian_model_fits_p15_pkey;
+
+
+--
+-- Name: bayesian_model_fits_p15_tenant_id_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_id ATTACH PARTITION public.bayesian_model_fits_p15_tenant_id_idx;
 
+
+--
+-- Name: bayesian_model_fits_p15_tenant_id_model_type_eligibility_st_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_eligibility ATTACH PARTITION public.bayesian_model_fits_p15_tenant_id_model_type_eligibility_st_idx;
+
+
+--
+-- Name: bayesian_model_fits_p15_tenant_id_model_type_fallback_reaso_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_fallback ATTACH PARTITION public.bayesian_model_fits_p15_tenant_id_model_type_fallback_reaso_idx;
 
+
+--
+-- Name: bayesian_model_fits_p15_tenant_id_model_type_model_version__key; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.uq_bayesian_model_fits_tenant_model_window_snapshot ATTACH PARTITION public.bayesian_model_fits_p15_tenant_id_model_type_model_version__key;
+
+
+--
+-- Name: bayesian_model_fits_p15_tenant_id_model_type_source_window__idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window ATTACH PARTITION public.bayesian_model_fits_p15_tenant_id_model_type_source_window__idx;
 
+
+--
+-- Name: bayesian_model_fits_p15_tenant_id_model_type_source_window_idx1; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_model_window_latest ATTACH PARTITION public.bayesian_model_fits_p15_tenant_id_model_type_source_window_idx1;
+
+
+--
+-- Name: bayesian_model_fits_p15_tenant_id_source_snapshot_hash_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
 
 ALTER INDEX public.idx_bayesian_model_fits_tenant_source_snapshot_hash ATTACH PARTITION public.bayesian_model_fits_p15_tenant_id_source_snapshot_hash_idx;
 
+
+--
+-- Name: bayesian_model_fits_p15_tenant_id_status_idx; Type: INDEX ATTACH; Schema: public; Owner: -
+--
+
 ALTER INDEX public.idx_bayesian_model_fits_tenant_status ATTACH PARTITION public.bayesian_model_fits_p15_tenant_id_status_idx;
+
+
+--
+-- Name: attribution_allocations trg_allocations_channel_correction_audit; Type: TRIGGER; Schema: public; Owner: -
+--
 
 CREATE TRIGGER trg_allocations_channel_correction_audit AFTER UPDATE OF channel_code ON public.attribution_allocations FOR EACH ROW WHEN ((old.channel_code IS DISTINCT FROM new.channel_code)) EXECUTE FUNCTION public.fn_log_channel_assignment_correction();
 
+
+--
+-- Name: attribution_commerce_identities trg_b23_p0_prune_attribution_commerce_identities; Type: TRIGGER; Schema: public; Owner: -
+--
+
 CREATE TRIGGER trg_b23_p0_prune_attribution_commerce_identities AFTER INSERT OR UPDATE OF last_observed_at ON public.attribution_commerce_identities FOR EACH STATEMENT EXECUTE FUNCTION public.fn_b23_p0_prune_attribution_commerce_identities_trigger();
+
+
+--
+-- Name: bayesian_artifacts trg_b24_dispatch_fence_artifacts; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trg_b24_dispatch_fence_artifacts BEFORE INSERT OR UPDATE ON public.bayesian_artifacts FOR EACH ROW EXECUTE FUNCTION public.b24_enforce_dispatch_fence('artifact');
+
+
+--
+-- Name: bayesian_model_fits trg_b24_dispatch_fence_fits; Type: TRIGGER; Schema: public; Owner: -
+--
+
+CREATE TRIGGER trg_b24_dispatch_fence_fits BEFORE INSERT OR UPDATE ON public.bayesian_model_fits FOR EACH ROW EXECUTE FUNCTION public.b24_enforce_dispatch_fence('fit');
+
+
+--
+-- Name: attribution_events trg_bind_session_authority_from_event; Type: TRIGGER; Schema: public; Owner: -
+--
 
 CREATE TRIGGER trg_bind_session_authority_from_event BEFORE INSERT ON public.attribution_events FOR EACH ROW EXECUTE FUNCTION public.fn_bind_session_authority_from_event();
 
+
+--
+-- Name: dead_events trg_block_worker_mutation_dead_events; Type: TRIGGER; Schema: public; Owner: -
+--
+
 CREATE TRIGGER trg_block_worker_mutation_dead_events BEFORE INSERT OR DELETE OR UPDATE ON public.dead_events FOR EACH ROW EXECUTE FUNCTION public.fn_block_worker_ingestion_mutation();
+
+
+--
+-- Name: attribution_events trg_block_worker_mutation_events; Type: TRIGGER; Schema: public; Owner: -
+--
 
 CREATE TRIGGER trg_block_worker_mutation_events BEFORE INSERT OR DELETE OR UPDATE ON public.attribution_events FOR EACH ROW EXECUTE FUNCTION public.fn_block_worker_ingestion_mutation();
 
+
+--
+-- Name: channel_taxonomy trg_channel_taxonomy_state_audit; Type: TRIGGER; Schema: public; Owner: -
+--
+
 CREATE TRIGGER trg_channel_taxonomy_state_audit AFTER UPDATE OF state ON public.channel_taxonomy FOR EACH ROW WHEN (((old.state)::text IS DISTINCT FROM (new.state)::text)) EXECUTE FUNCTION public.fn_log_channel_state_change();
+
+
+--
+-- Name: attribution_allocations trg_check_allocation_sum; Type: TRIGGER; Schema: public; Owner: -
+--
 
 CREATE TRIGGER trg_check_allocation_sum AFTER INSERT ON public.attribution_allocations REFERENCING NEW TABLE AS newrows FOR EACH STATEMENT EXECUTE FUNCTION public.check_allocation_sum_stmt_insert();
 
+
+--
+-- Name: attribution_allocations trg_check_allocation_sum_delete; Type: TRIGGER; Schema: public; Owner: -
+--
+
 CREATE TRIGGER trg_check_allocation_sum_delete AFTER DELETE ON public.attribution_allocations REFERENCING OLD TABLE AS oldrows FOR EACH STATEMENT EXECUTE FUNCTION public.check_allocation_sum_stmt_delete();
+
+
+--
+-- Name: attribution_allocations trg_check_allocation_sum_update; Type: TRIGGER; Schema: public; Owner: -
+--
 
 CREATE TRIGGER trg_check_allocation_sum_update AFTER UPDATE ON public.attribution_allocations REFERENCING OLD TABLE AS oldrows NEW TABLE AS newrows FOR EACH STATEMENT EXECUTE FUNCTION public.check_allocation_sum_stmt_update();
 
+
+--
+-- Name: compliance_audit_ledger trg_compliance_audit_ledger_append_only; Type: TRIGGER; Schema: public; Owner: -
+--
+
 CREATE TRIGGER trg_compliance_audit_ledger_append_only BEFORE DELETE OR UPDATE ON public.compliance_audit_ledger FOR EACH ROW EXECUTE FUNCTION public.fn_compliance_audit_ledger_append_only();
+
+
+--
+-- Name: attribution_events trg_events_prevent_mutation; Type: TRIGGER; Schema: public; Owner: -
+--
 
 CREATE TRIGGER trg_events_prevent_mutation BEFORE DELETE OR UPDATE ON public.attribution_events FOR EACH ROW EXECUTE FUNCTION public.fn_events_prevent_mutation();
 
+
+--
+-- Name: attribution_events trg_guard_attribution_events_payload_identity; Type: TRIGGER; Schema: public; Owner: -
+--
+
 CREATE TRIGGER trg_guard_attribution_events_payload_identity BEFORE INSERT ON public.attribution_events FOR EACH ROW EXECUTE FUNCTION public.fn_guard_attribution_events_payload_identity();
+
+
+--
+-- Name: revenue_ledger trg_ledger_prevent_mutation; Type: TRIGGER; Schema: public; Owner: -
+--
 
 CREATE TRIGGER trg_ledger_prevent_mutation BEFORE DELETE OR UPDATE ON public.revenue_ledger FOR EACH ROW EXECUTE FUNCTION public.fn_ledger_prevent_mutation();
 
+
+--
+-- Name: llm_call_audit trg_llm_call_audit_append_only; Type: TRIGGER; Schema: public; Owner: -
+--
+
 CREATE TRIGGER trg_llm_call_audit_append_only BEFORE DELETE OR UPDATE ON public.llm_call_audit FOR EACH ROW EXECUTE FUNCTION public.fn_llm_call_audit_append_only();
+
+
+--
+-- Name: attribution_events trg_pii_guardrail_attribution_events; Type: TRIGGER; Schema: public; Owner: -
+--
 
 CREATE TRIGGER trg_pii_guardrail_attribution_events BEFORE INSERT ON public.attribution_events FOR EACH ROW EXECUTE FUNCTION public.fn_enforce_pii_guardrail();
 
+
+--
+-- Name: dead_events trg_pii_guardrail_dead_events; Type: TRIGGER; Schema: public; Owner: -
+--
+
 CREATE TRIGGER trg_pii_guardrail_dead_events BEFORE INSERT ON public.dead_events FOR EACH ROW EXECUTE FUNCTION public.fn_enforce_pii_guardrail();
+
+
+--
+-- Name: revenue_ledger trg_pii_guardrail_revenue_ledger; Type: TRIGGER; Schema: public; Owner: -
+--
 
 CREATE TRIGGER trg_pii_guardrail_revenue_ledger BEFORE INSERT ON public.revenue_ledger FOR EACH ROW EXECUTE FUNCTION public.fn_enforce_pii_guardrail();
 
+
+--
+-- Name: revenue_ledger trg_revenue_ledger_state_audit; Type: TRIGGER; Schema: public; Owner: -
+--
+
 CREATE TRIGGER trg_revenue_ledger_state_audit AFTER UPDATE OF state ON public.revenue_ledger FOR EACH ROW WHEN (((old.state)::text IS DISTINCT FROM (new.state)::text)) EXECUTE FUNCTION public.fn_log_revenue_state_change();
+
+
+--
+-- Name: attribution_allocations attribution_allocations_recompute_job_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.attribution_allocations
     ADD CONSTRAINT attribution_allocations_recompute_job_id_fkey FOREIGN KEY (recompute_job_id) REFERENCES public.attribution_recompute_jobs(id) ON DELETE CASCADE;
 
+
+--
+-- Name: attribution_allocations attribution_allocations_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.attribution_allocations
     ADD CONSTRAINT attribution_allocations_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: attribution_commerce_identities attribution_commerce_identities_attribution_event_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.attribution_commerce_identities
     ADD CONSTRAINT attribution_commerce_identities_attribution_event_id_fkey FOREIGN KEY (attribution_event_id) REFERENCES public.attribution_events(id) ON DELETE CASCADE;
 
+
+--
+-- Name: attribution_commerce_identities attribution_commerce_identities_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.attribution_commerce_identities
     ADD CONSTRAINT attribution_commerce_identities_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: attribution_events attribution_events_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.attribution_events
     ADD CONSTRAINT attribution_events_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: attribution_recompute_jobs attribution_recompute_jobs_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.attribution_recompute_jobs
     ADD CONSTRAINT attribution_recompute_jobs_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: auth_access_token_denylist auth_access_token_denylist_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.auth_access_token_denylist
     ADD CONSTRAINT auth_access_token_denylist_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: auth_refresh_tokens auth_refresh_tokens_replaced_by_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.auth_refresh_tokens
     ADD CONSTRAINT auth_refresh_tokens_replaced_by_id_fkey FOREIGN KEY (replaced_by_id) REFERENCES public.auth_refresh_tokens(id) ON DELETE SET NULL;
+
+
+--
+-- Name: auth_refresh_tokens auth_refresh_tokens_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.auth_refresh_tokens
     ADD CONSTRAINT auth_refresh_tokens_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: auth_refresh_tokens auth_refresh_tokens_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.auth_refresh_tokens
     ADD CONSTRAINT auth_refresh_tokens_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
+
+
+--
+-- Name: auth_user_token_cutoffs auth_user_token_cutoffs_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.auth_user_token_cutoffs
     ADD CONSTRAINT auth_user_token_cutoffs_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: b23_exception_records b23_exception_records_match_verdict_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.b23_exception_records
     ADD CONSTRAINT b23_exception_records_match_verdict_id_fkey FOREIGN KEY (match_verdict_id) REFERENCES public.b23_match_verdicts(id) ON DELETE CASCADE;
+
+
+--
+-- Name: b23_exception_records b23_exception_records_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.b23_exception_records
     ADD CONSTRAINT b23_exception_records_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: b23_match_task_dispatches b23_match_task_dispatches_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.b23_match_task_dispatches
     ADD CONSTRAINT b23_match_task_dispatches_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: b23_match_task_dispatches b23_match_task_dispatches_webhook_ingress_identity_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.b23_match_task_dispatches
     ADD CONSTRAINT b23_match_task_dispatches_webhook_ingress_identity_id_fkey FOREIGN KEY (webhook_ingress_identity_id) REFERENCES public.webhook_ingress_identities(id) ON DELETE CASCADE;
 
+
+--
+-- Name: b23_match_verdicts b23_match_verdicts_attribution_event_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.b23_match_verdicts
     ADD CONSTRAINT b23_match_verdicts_attribution_event_id_fkey FOREIGN KEY (attribution_event_id) REFERENCES public.attribution_events(id) ON DELETE SET NULL;
+
+
+--
+-- Name: b23_match_verdicts b23_match_verdicts_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.b23_match_verdicts
     ADD CONSTRAINT b23_match_verdicts_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: b23_match_verdicts b23_match_verdicts_webhook_ingress_identity_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.b23_match_verdicts
     ADD CONSTRAINT b23_match_verdicts_webhook_ingress_identity_id_fkey FOREIGN KEY (webhook_ingress_identity_id) REFERENCES public.webhook_ingress_identities(id) ON DELETE SET NULL;
+
+
+--
+-- Name: b23_revenue_events b23_revenue_events_match_verdict_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.b23_revenue_events
     ADD CONSTRAINT b23_revenue_events_match_verdict_id_fkey FOREIGN KEY (match_verdict_id) REFERENCES public.b23_match_verdicts(id) ON DELETE SET NULL;
 
+
+--
+-- Name: b23_revenue_events b23_revenue_events_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.b23_revenue_events
     ADD CONSTRAINT b23_revenue_events_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: b23_revenue_events b23_revenue_events_webhook_ingress_identity_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.b23_revenue_events
     ADD CONSTRAINT b23_revenue_events_webhook_ingress_identity_id_fkey FOREIGN KEY (webhook_ingress_identity_id) REFERENCES public.webhook_ingress_identities(id) ON DELETE SET NULL;
 
+
+--
+-- Name: b23_webhook_ingestion_logs b23_webhook_ingestion_logs_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.b23_webhook_ingestion_logs
     ADD CONSTRAINT b23_webhook_ingestion_logs_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: b24_active_execution_leases b24_active_execution_leases_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.b24_active_execution_leases
     ADD CONSTRAINT b24_active_execution_leases_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: b24_dirty_events b24_dirty_events_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.b24_dirty_events
     ADD CONSTRAINT b24_dirty_events_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: b24_feature_authority_build_outbox b24_feature_authority_build_outbox_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.b24_feature_authority_build_outbox
     ADD CONSTRAINT b24_feature_authority_build_outbox_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: b24_feature_authority_build_requests b24_feature_authority_build_requests_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.b24_feature_authority_build_requests
     ADD CONSTRAINT b24_feature_authority_build_requests_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: b24_fit_dispatch_outbox b24_fit_dispatch_outbox_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.b24_fit_dispatch_outbox
     ADD CONSTRAINT b24_fit_dispatch_outbox_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: b24_source_window_feature_authority b24_source_window_feature_authority_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.b24_source_window_feature_authority
     ADD CONSTRAINT b24_source_window_feature_authority_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: bayesian_artifact_storage_quotas bayesian_artifact_storage_quotas_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.bayesian_artifact_storage_quotas
     ADD CONSTRAINT bayesian_artifact_storage_quotas_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: bayesian_artifacts bayesian_artifacts_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE public.bayesian_artifacts
     ADD CONSTRAINT bayesian_artifacts_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: bayesian_model_fits bayesian_model_fits_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE public.bayesian_model_fits
     ADD CONSTRAINT bayesian_model_fits_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: budget_jobs budget_jobs_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.budget_jobs
     ADD CONSTRAINT budget_jobs_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: budget_optimization_jobs budget_optimization_jobs_authority_job_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.budget_optimization_jobs
     ADD CONSTRAINT budget_optimization_jobs_authority_job_id_fkey FOREIGN KEY (authority_job_id) REFERENCES public.budget_jobs(id) ON DELETE SET NULL;
 
+
+--
+-- Name: budget_optimization_jobs budget_optimization_jobs_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.budget_optimization_jobs
     ADD CONSTRAINT budget_optimization_jobs_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: channel_assignment_corrections channel_assignment_corrections_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.channel_assignment_corrections
     ADD CONSTRAINT channel_assignment_corrections_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: channel_assignment_corrections channel_assignment_corrections_to_channel_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.channel_assignment_corrections
     ADD CONSTRAINT channel_assignment_corrections_to_channel_fkey FOREIGN KEY (to_channel) REFERENCES public.channel_taxonomy(code);
+
+
+--
+-- Name: channel_state_transitions channel_state_transitions_channel_code_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.channel_state_transitions
     ADD CONSTRAINT channel_state_transitions_channel_code_fkey FOREIGN KEY (channel_code) REFERENCES public.channel_taxonomy(code) ON DELETE CASCADE;
 
+
+--
+-- Name: compliance_audit_ledger compliance_audit_ledger_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.compliance_audit_ledger
     ADD CONSTRAINT compliance_audit_ledger_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: dead_events_quarantine dead_events_quarantine_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.dead_events_quarantine
     ADD CONSTRAINT dead_events_quarantine_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE SET NULL;
 
+
+--
+-- Name: dead_events dead_events_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.dead_events
     ADD CONSTRAINT dead_events_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: ephemeral_click_resolution ephemeral_click_resolution_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.ephemeral_click_resolution
     ADD CONSTRAINT ephemeral_click_resolution_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: ephemeral_order_resolution ephemeral_order_resolution_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.ephemeral_order_resolution
     ADD CONSTRAINT ephemeral_order_resolution_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: explanation_cache explanation_cache_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.explanation_cache
     ADD CONSTRAINT explanation_cache_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: attribution_allocations fk_allocations_event_id_set_null; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.attribution_allocations
     ADD CONSTRAINT fk_allocations_event_id_set_null FOREIGN KEY (event_id) REFERENCES public.attribution_events(id) ON DELETE SET NULL;
+
+
+--
+-- Name: attribution_allocations fk_attribution_allocations_channel_code; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.attribution_allocations
     ADD CONSTRAINT fk_attribution_allocations_channel_code FOREIGN KEY (channel_code) REFERENCES public.channel_taxonomy(code);
 
+
+--
+-- Name: attribution_events fk_attribution_events_channel; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.attribution_events
     ADD CONSTRAINT fk_attribution_events_channel FOREIGN KEY (channel) REFERENCES public.channel_taxonomy(code) ON UPDATE CASCADE ON DELETE RESTRICT;
+
+
+--
+-- Name: attribution_events fk_attribution_events_session_authority; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.attribution_events
     ADD CONSTRAINT fk_attribution_events_session_authority FOREIGN KEY (tenant_id, session_id) REFERENCES public.session_authority(tenant_id, session_id) DEFERRABLE INITIALLY DEFERRED;
 
+
+--
+-- Name: b24_active_execution_leases fk_b24_active_execution_fit; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.b24_active_execution_leases
     ADD CONSTRAINT fk_b24_active_execution_fit FOREIGN KEY (tenant_id, fit_id) REFERENCES public.bayesian_model_fits(tenant_id, id) ON DELETE RESTRICT;
+
+
+--
+-- Name: b24_feature_authority_build_outbox fk_b24_feature_authority_build_outbox_request; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.b24_feature_authority_build_outbox
     ADD CONSTRAINT fk_b24_feature_authority_build_outbox_request FOREIGN KEY (tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash) REFERENCES public.b24_feature_authority_build_requests(tenant_id, model_type, model_version, source_window_start, source_window_end, source_snapshot_hash) ON DELETE CASCADE;
 
+
+--
+-- Name: b24_fit_dispatch_outbox fk_b24_fit_dispatch_outbox_fit; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.b24_fit_dispatch_outbox
     ADD CONSTRAINT fk_b24_fit_dispatch_outbox_fit FOREIGN KEY (tenant_id, fit_id) REFERENCES public.bayesian_model_fits(tenant_id, id) ON DELETE RESTRICT;
+
+
+--
+-- Name: b24_fit_recovery_outbox fk_b24_fit_recovery_outbox_dispatch; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.b24_fit_recovery_outbox
+    ADD CONSTRAINT fk_b24_fit_recovery_outbox_dispatch FOREIGN KEY (tenant_id, dispatch_id) REFERENCES public.b24_fit_dispatch_outbox(tenant_id, id) ON DELETE CASCADE;
+
+
+--
+-- Name: bayesian_artifacts fk_bayesian_artifacts_tenant_fit; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE public.bayesian_artifacts
     ADD CONSTRAINT fk_bayesian_artifacts_tenant_fit FOREIGN KEY (tenant_id, fit_id) REFERENCES public.bayesian_model_fits(tenant_id, id) ON DELETE RESTRICT;
 
+
+--
+-- Name: kombu_message fk_kombu_message_queue; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.kombu_message
     ADD CONSTRAINT fk_kombu_message_queue FOREIGN KEY (queue_id) REFERENCES public.kombu_queue(id);
+
+
+--
+-- Name: tenant_membership_roles fk_tenant_membership_roles_membership_tenant; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.tenant_membership_roles
     ADD CONSTRAINT fk_tenant_membership_roles_membership_tenant FOREIGN KEY (membership_id, tenant_id) REFERENCES public.tenant_memberships(id, tenant_id) ON DELETE CASCADE;
 
+
+--
+-- Name: investigation_jobs investigation_jobs_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.investigation_jobs
     ADD CONSTRAINT investigation_jobs_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: investigation_tool_calls investigation_tool_calls_investigation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.investigation_tool_calls
     ADD CONSTRAINT investigation_tool_calls_investigation_id_fkey FOREIGN KEY (investigation_id) REFERENCES public.investigations(id) ON DELETE CASCADE;
 
+
+--
+-- Name: investigation_tool_calls investigation_tool_calls_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.investigation_tool_calls
     ADD CONSTRAINT investigation_tool_calls_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: investigations investigations_authority_job_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.investigations
     ADD CONSTRAINT investigations_authority_job_id_fkey FOREIGN KEY (authority_job_id) REFERENCES public.investigation_jobs(id) ON DELETE SET NULL;
 
+
+--
+-- Name: investigations investigations_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.investigations
     ADD CONSTRAINT investigations_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: llm_api_calls llm_api_calls_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.llm_api_calls
     ADD CONSTRAINT llm_api_calls_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: llm_breaker_state llm_breaker_state_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.llm_breaker_state
     ADD CONSTRAINT llm_breaker_state_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: llm_budget_reservations llm_budget_reservations_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.llm_budget_reservations
     ADD CONSTRAINT llm_budget_reservations_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: llm_call_audit llm_call_audit_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.llm_call_audit
     ADD CONSTRAINT llm_call_audit_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: llm_hourly_shutoff_state llm_hourly_shutoff_state_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.llm_hourly_shutoff_state
     ADD CONSTRAINT llm_hourly_shutoff_state_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: llm_monthly_budget_state llm_monthly_budget_state_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.llm_monthly_budget_state
     ADD CONSTRAINT llm_monthly_budget_state_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: llm_monthly_costs llm_monthly_costs_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.llm_monthly_costs
     ADD CONSTRAINT llm_monthly_costs_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: llm_semantic_cache llm_semantic_cache_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.llm_semantic_cache
     ADD CONSTRAINT llm_semantic_cache_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: llm_validation_failures llm_validation_failures_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.llm_validation_failures
     ADD CONSTRAINT llm_validation_failures_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: oauth_handshake_sessions oauth_handshake_sessions_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.oauth_handshake_sessions
     ADD CONSTRAINT oauth_handshake_sessions_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: oauth_handshake_sessions oauth_handshake_sessions_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.oauth_handshake_sessions
     ADD CONSTRAINT oauth_handshake_sessions_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
+
+--
+-- Name: platform_connections platform_connections_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.platform_connections
     ADD CONSTRAINT platform_connections_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: platform_credentials platform_credentials_platform_connection_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.platform_credentials
     ADD CONSTRAINT platform_credentials_platform_connection_id_fkey FOREIGN KEY (platform_connection_id) REFERENCES public.platform_connections(id) ON DELETE CASCADE;
 
+
+--
+-- Name: platform_credentials platform_credentials_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.platform_credentials
     ADD CONSTRAINT platform_credentials_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: r4_crash_barriers r4_crash_barriers_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.r4_crash_barriers
     ADD CONSTRAINT r4_crash_barriers_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: r4_task_attempts r4_task_attempts_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.r4_task_attempts
     ADD CONSTRAINT r4_task_attempts_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: raw_event_payloads raw_event_payloads_event_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.raw_event_payloads
     ADD CONSTRAINT raw_event_payloads_event_id_fkey FOREIGN KEY (event_id) REFERENCES public.attribution_events(id) ON DELETE CASCADE;
 
+
+--
+-- Name: raw_event_payloads raw_event_payloads_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.raw_event_payloads
     ADD CONSTRAINT raw_event_payloads_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: reconciliation_runs reconciliation_runs_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.reconciliation_runs
     ADD CONSTRAINT reconciliation_runs_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: revenue_cache_entries revenue_cache_entries_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.revenue_cache_entries
     ADD CONSTRAINT revenue_cache_entries_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: revenue_ledger revenue_ledger_allocation_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.revenue_ledger
     ADD CONSTRAINT revenue_ledger_allocation_id_fkey FOREIGN KEY (allocation_id) REFERENCES public.attribution_allocations(id) ON DELETE CASCADE;
 
+
+--
+-- Name: revenue_ledger revenue_ledger_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.revenue_ledger
     ADD CONSTRAINT revenue_ledger_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: revenue_state_transitions revenue_state_transitions_ledger_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.revenue_state_transitions
     ADD CONSTRAINT revenue_state_transitions_ledger_id_fkey FOREIGN KEY (ledger_id) REFERENCES public.revenue_ledger(id) ON DELETE CASCADE;
 
+
+--
+-- Name: revenue_state_transitions revenue_state_transitions_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.revenue_state_transitions
     ADD CONSTRAINT revenue_state_transitions_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: session_authority session_authority_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.session_authority
     ADD CONSTRAINT session_authority_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: tenant_membership_roles tenant_membership_roles_role_code_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.tenant_membership_roles
     ADD CONSTRAINT tenant_membership_roles_role_code_fkey FOREIGN KEY (role_code) REFERENCES public.roles(code) ON DELETE RESTRICT;
+
+
+--
+-- Name: tenant_membership_roles tenant_membership_roles_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.tenant_membership_roles
     ADD CONSTRAINT tenant_membership_roles_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: tenant_memberships tenant_memberships_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.tenant_memberships
     ADD CONSTRAINT tenant_memberships_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
+
+
+--
+-- Name: tenant_memberships tenant_memberships_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.tenant_memberships
     ADD CONSTRAINT tenant_memberships_user_id_fkey FOREIGN KEY (user_id) REFERENCES public.users(id) ON DELETE CASCADE;
 
+
+--
+-- Name: webhook_ingress_identities webhook_ingress_identities_event_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.webhook_ingress_identities
     ADD CONSTRAINT webhook_ingress_identities_event_id_fkey FOREIGN KEY (event_id) REFERENCES public.attribution_events(id) ON DELETE CASCADE;
+
+
+--
+-- Name: webhook_ingress_identities webhook_ingress_identities_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
 
 ALTER TABLE ONLY public.webhook_ingress_identities
     ADD CONSTRAINT webhook_ingress_identities_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: worker_side_effects worker_side_effects_tenant_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
 ALTER TABLE ONLY public.worker_side_effects
     ADD CONSTRAINT worker_side_effects_tenant_id_fkey FOREIGN KEY (tenant_id) REFERENCES public.tenants(id) ON DELETE CASCADE;
 
+
+--
+-- Name: attribution_allocations; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.attribution_allocations ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: attribution_commerce_identities; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.attribution_commerce_identities ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: attribution_events; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.attribution_events ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: attribution_recompute_jobs; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.attribution_recompute_jobs ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: attribution_recompute_jobs attribution_recompute_jobs_tenant_isolation; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY attribution_recompute_jobs_tenant_isolation ON public.attribution_recompute_jobs USING (((tenant_id)::text = current_setting('app.current_tenant_id'::text, true))) WITH CHECK (((tenant_id)::text = current_setting('app.current_tenant_id'::text, true)));
+
+
+--
+-- Name: auth_access_token_denylist; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.auth_access_token_denylist ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: auth_refresh_tokens; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.auth_refresh_tokens ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: auth_user_token_cutoffs; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.auth_user_token_cutoffs ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: b23_exception_records; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.b23_exception_records ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: b23_match_task_dispatches; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.b23_match_task_dispatches ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: b23_match_verdicts; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.b23_match_verdicts ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: b23_revenue_events; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.b23_revenue_events ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: b23_webhook_ingestion_logs; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.b23_webhook_ingestion_logs ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: b24_active_execution_leases; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.b24_active_execution_leases ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: b24_dirty_events; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.b24_dirty_events ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: b24_feature_authority_build_outbox; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.b24_feature_authority_build_outbox ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: b24_feature_authority_build_requests; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.b24_feature_authority_build_requests ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: b24_fit_dispatch_outbox; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.b24_fit_dispatch_outbox ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: b24_fit_recovery_outbox; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
+ALTER TABLE public.b24_fit_recovery_outbox ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: b24_source_window_feature_authority; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.b24_source_window_feature_authority ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: bayesian_artifact_storage_quotas; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.bayesian_artifact_storage_quotas ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: bayesian_artifacts; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.bayesian_artifacts ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: bayesian_artifacts_p00; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.bayesian_artifacts_p00 ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: bayesian_artifacts_p01; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.bayesian_artifacts_p01 ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: bayesian_artifacts_p02; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.bayesian_artifacts_p02 ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: bayesian_artifacts_p03; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.bayesian_artifacts_p03 ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: bayesian_artifacts_p04; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.bayesian_artifacts_p04 ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: bayesian_artifacts_p05; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.bayesian_artifacts_p05 ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: bayesian_artifacts_p06; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.bayesian_artifacts_p06 ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: bayesian_artifacts_p07; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.bayesian_artifacts_p07 ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: bayesian_artifacts_p08; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.bayesian_artifacts_p08 ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: bayesian_artifacts_p09; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.bayesian_artifacts_p09 ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: bayesian_artifacts_p10; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.bayesian_artifacts_p10 ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: bayesian_artifacts_p11; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.bayesian_artifacts_p11 ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: bayesian_artifacts_p12; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.bayesian_artifacts_p12 ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: bayesian_artifacts_p13; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.bayesian_artifacts_p13 ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: bayesian_artifacts_p14; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.bayesian_artifacts_p14 ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: bayesian_artifacts_p15; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.bayesian_artifacts_p15 ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: bayesian_model_fits; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.bayesian_model_fits ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: bayesian_model_fits_p00; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.bayesian_model_fits_p00 ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: bayesian_model_fits_p01; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.bayesian_model_fits_p01 ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: bayesian_model_fits_p02; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.bayesian_model_fits_p02 ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: bayesian_model_fits_p03; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.bayesian_model_fits_p03 ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: bayesian_model_fits_p04; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.bayesian_model_fits_p04 ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: bayesian_model_fits_p05; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.bayesian_model_fits_p05 ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: bayesian_model_fits_p06; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.bayesian_model_fits_p06 ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: bayesian_model_fits_p07; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.bayesian_model_fits_p07 ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: bayesian_model_fits_p08; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.bayesian_model_fits_p08 ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: bayesian_model_fits_p09; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.bayesian_model_fits_p09 ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: bayesian_model_fits_p10; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.bayesian_model_fits_p10 ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: bayesian_model_fits_p11; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.bayesian_model_fits_p11 ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: bayesian_model_fits_p12; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.bayesian_model_fits_p12 ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: bayesian_model_fits_p13; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.bayesian_model_fits_p13 ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: bayesian_model_fits_p14; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.bayesian_model_fits_p14 ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: bayesian_model_fits_p15; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.bayesian_model_fits_p15 ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: budget_jobs; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.budget_jobs ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: budget_optimization_jobs; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.budget_optimization_jobs ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: channel_assignment_corrections; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.channel_assignment_corrections ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: compliance_audit_ledger; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.compliance_audit_ledger ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: dead_events; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.dead_events ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: dead_events_quarantine; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.dead_events_quarantine ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: b24_fit_dispatch_outbox dispatch_capability_claim_select_b24_fit_dispatch_outbox; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY dispatch_capability_claim_select_b24_fit_dispatch_outbox ON public.b24_fit_dispatch_outbox FOR SELECT USING ((((claim_capability_digest)::text = NULLIF(current_setting('app.b24_claim_capability_digest'::text, true), ''::text)) AND (claim_capability_expires_at > now())));
+
+
+--
+-- Name: b24_fit_dispatch_outbox dispatch_capability_claim_update_b24_fit_dispatch_outbox; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY dispatch_capability_claim_update_b24_fit_dispatch_outbox ON public.b24_fit_dispatch_outbox FOR UPDATE USING ((((claim_capability_digest)::text = NULLIF(current_setting('app.b24_claim_capability_digest'::text, true), ''::text)) AND (claim_capability_expires_at > now()))) WITH CHECK ((((claim_capability_digest)::text = NULLIF(current_setting('app.b24_claim_capability_digest'::text, true), ''::text)) AND (claim_capability_expires_at > now())));
+
+
+--
+-- Name: b24_fit_dispatch_outbox dispatch_recovery_reconciler_select_b24_fit_dispatch_outbox; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY dispatch_recovery_reconciler_select_b24_fit_dispatch_outbox ON public.b24_fit_dispatch_outbox FOR SELECT USING ((current_setting('app.b24_recovery_reconciler'::text, true) = 'on'::text));
+
+
+--
+-- Name: b24_fit_dispatch_outbox dispatch_recovery_reconciler_update_b24_fit_dispatch_outbox; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY dispatch_recovery_reconciler_update_b24_fit_dispatch_outbox ON public.b24_fit_dispatch_outbox FOR UPDATE USING ((current_setting('app.b24_recovery_reconciler'::text, true) = 'on'::text)) WITH CHECK ((current_setting('app.b24_recovery_reconciler'::text, true) = 'on'::text));
+
+
+--
+-- Name: ephemeral_click_resolution; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.ephemeral_click_resolution ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: ephemeral_order_resolution; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.ephemeral_order_resolution ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: explanation_cache; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.explanation_cache ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: investigation_jobs; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.investigation_jobs ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: investigation_tool_calls; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.investigation_tool_calls ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: investigations; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.investigations ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: llm_api_calls; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.llm_api_calls ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: llm_breaker_state; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.llm_breaker_state ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: llm_budget_reservations; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.llm_budget_reservations ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: llm_call_audit; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.llm_call_audit ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: llm_hourly_shutoff_state; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.llm_hourly_shutoff_state ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: llm_monthly_budget_state; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.llm_monthly_budget_state ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: llm_monthly_costs; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.llm_monthly_costs ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: llm_semantic_cache; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.llm_semantic_cache ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: llm_validation_failures; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.llm_validation_failures ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: oauth_handshake_sessions; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.oauth_handshake_sessions ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: dead_events_quarantine ops_quarantine_select; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY ops_quarantine_select ON public.dead_events_quarantine FOR SELECT USING (((tenant_id IS NULL) AND (CURRENT_USER = 'app_ops'::name)));
+
+
+--
+-- Name: platform_connections; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.platform_connections ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: platform_credentials; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.platform_credentials ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: dead_events_quarantine quarantine_lane_insert; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY quarantine_lane_insert ON public.dead_events_quarantine FOR INSERT TO app_rw, app_user WITH CHECK ((tenant_id IS NULL));
 
+
+--
+-- Name: r4_crash_barriers; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.r4_crash_barriers ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: r4_task_attempts; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.r4_task_attempts ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: raw_event_payloads; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.raw_event_payloads ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: reconciliation_runs; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.reconciliation_runs ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: b24_fit_recovery_outbox recovery_reconciler_policy_b24_fit_recovery_outbox; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY recovery_reconciler_policy_b24_fit_recovery_outbox ON public.b24_fit_recovery_outbox USING ((current_setting('app.b24_recovery_reconciler'::text, true) = 'on'::text)) WITH CHECK ((current_setting('app.b24_recovery_reconciler'::text, true) = 'on'::text));
+
+
+--
+-- Name: revenue_cache_entries; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.revenue_cache_entries ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: revenue_ledger; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.revenue_ledger ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: revenue_state_transitions; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.revenue_state_transitions ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: session_authority; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.session_authority ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: attribution_allocations tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy ON public.attribution_allocations USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: attribution_events tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy ON public.attribution_events USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: auth_access_token_denylist tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy ON public.auth_access_token_denylist USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: auth_refresh_tokens tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy ON public.auth_refresh_tokens USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: auth_user_token_cutoffs tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy ON public.auth_user_token_cutoffs USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: budget_jobs tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy ON public.budget_jobs USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: budget_optimization_jobs tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy ON public.budget_optimization_jobs USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: channel_assignment_corrections tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy ON public.channel_assignment_corrections USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: dead_events tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy ON public.dead_events USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: explanation_cache tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy ON public.explanation_cache USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
-CREATE POLICY tenant_isolation_policy ON public.investigation_jobs TO app_ro, app_rw, app_user USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+--
+-- Name: investigation_jobs tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY tenant_isolation_policy ON public.investigation_jobs TO app_rw, app_ro, app_user USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: investigation_tool_calls tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy ON public.investigation_tool_calls USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: investigations tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy ON public.investigations USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: llm_api_calls tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy ON public.llm_api_calls USING (((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid) AND (user_id = (current_setting('app.current_user_id'::text, true))::uuid))) WITH CHECK (((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid) AND (user_id = (current_setting('app.current_user_id'::text, true))::uuid)));
 
+
+--
+-- Name: llm_breaker_state tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy ON public.llm_breaker_state USING (((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid) AND (user_id = (current_setting('app.current_user_id'::text, true))::uuid))) WITH CHECK (((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid) AND (user_id = (current_setting('app.current_user_id'::text, true))::uuid)));
+
+
+--
+-- Name: llm_budget_reservations tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy ON public.llm_budget_reservations USING (((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid) AND (user_id = (current_setting('app.current_user_id'::text, true))::uuid))) WITH CHECK (((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid) AND (user_id = (current_setting('app.current_user_id'::text, true))::uuid)));
 
+
+--
+-- Name: llm_call_audit tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy ON public.llm_call_audit USING (((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid) AND (user_id = (current_setting('app.current_user_id'::text, true))::uuid))) WITH CHECK (((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid) AND (user_id = (current_setting('app.current_user_id'::text, true))::uuid)));
+
+
+--
+-- Name: llm_hourly_shutoff_state tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy ON public.llm_hourly_shutoff_state USING (((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid) AND (user_id = (current_setting('app.current_user_id'::text, true))::uuid))) WITH CHECK (((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid) AND (user_id = (current_setting('app.current_user_id'::text, true))::uuid)));
 
+
+--
+-- Name: llm_monthly_budget_state tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy ON public.llm_monthly_budget_state USING (((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid) AND (user_id = (current_setting('app.current_user_id'::text, true))::uuid))) WITH CHECK (((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid) AND (user_id = (current_setting('app.current_user_id'::text, true))::uuid)));
+
+
+--
+-- Name: llm_monthly_costs tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy ON public.llm_monthly_costs USING (((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid) AND (user_id = (current_setting('app.current_user_id'::text, true))::uuid))) WITH CHECK (((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid) AND (user_id = (current_setting('app.current_user_id'::text, true))::uuid)));
 
+
+--
+-- Name: llm_semantic_cache tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy ON public.llm_semantic_cache USING (((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid) AND (user_id = (current_setting('app.current_user_id'::text, true))::uuid))) WITH CHECK (((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid) AND (user_id = (current_setting('app.current_user_id'::text, true))::uuid)));
+
+
+--
+-- Name: llm_validation_failures tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy ON public.llm_validation_failures USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: oauth_handshake_sessions tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy ON public.oauth_handshake_sessions USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: platform_connections tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy ON public.platform_connections USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: platform_credentials tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy ON public.platform_credentials USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: r4_crash_barriers tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy ON public.r4_crash_barriers TO app_user USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: r4_task_attempts tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy ON public.r4_task_attempts TO app_user USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: reconciliation_runs tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy ON public.reconciliation_runs USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: revenue_cache_entries tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy ON public.revenue_cache_entries USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: revenue_ledger tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy ON public.revenue_ledger USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: revenue_state_transitions tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy ON public.revenue_state_transitions USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: session_authority tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy ON public.session_authority USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: tenant_membership_roles tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy ON public.tenant_membership_roles USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: tenant_memberships tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy ON public.tenant_memberships USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: worker_failed_jobs tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy ON public.worker_failed_jobs TO app_user USING (((tenant_id IS NULL) OR ((tenant_id)::text = current_setting('app.current_tenant_id'::text, true))));
+
+
+--
+-- Name: worker_side_effects tenant_isolation_policy; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy ON public.worker_side_effects TO app_user USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: attribution_commerce_identities tenant_isolation_policy_attribution_commerce_identities; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_attribution_commerce_identities ON public.attribution_commerce_identities USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: b23_exception_records tenant_isolation_policy_b23_exception_records; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_b23_exception_records ON public.b23_exception_records USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: b23_match_task_dispatches tenant_isolation_policy_b23_match_task_dispatches; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_b23_match_task_dispatches ON public.b23_match_task_dispatches USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: b23_match_verdicts tenant_isolation_policy_b23_match_verdicts; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_b23_match_verdicts ON public.b23_match_verdicts USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: b23_revenue_events tenant_isolation_policy_b23_revenue_events; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_b23_revenue_events ON public.b23_revenue_events USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: b23_webhook_ingestion_logs tenant_isolation_policy_b23_webhook_ingestion_logs; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_b23_webhook_ingestion_logs ON public.b23_webhook_ingestion_logs USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: b24_active_execution_leases tenant_isolation_policy_b24_active_execution_leases; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_b24_active_execution_leases ON public.b24_active_execution_leases USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: b24_dirty_events tenant_isolation_policy_b24_dirty_events; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_b24_dirty_events ON public.b24_dirty_events USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: b24_feature_authority_build_outbox tenant_isolation_policy_b24_feature_authority_build_outbox; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_b24_feature_authority_build_outbox ON public.b24_feature_authority_build_outbox USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: b24_feature_authority_build_requests tenant_isolation_policy_b24_feature_authority_build_requests; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_b24_feature_authority_build_requests ON public.b24_feature_authority_build_requests USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: b24_fit_dispatch_outbox tenant_isolation_policy_b24_fit_dispatch_outbox; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_b24_fit_dispatch_outbox ON public.b24_fit_dispatch_outbox USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: b24_fit_recovery_outbox tenant_isolation_policy_b24_fit_recovery_outbox; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY tenant_isolation_policy_b24_fit_recovery_outbox ON public.b24_fit_recovery_outbox USING ((tenant_id = (current_setting('app.current_tenant_id'::text))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text))::uuid));
+
+
+--
+-- Name: b24_source_window_feature_authority tenant_isolation_policy_b24_source_window_feature_authority; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_b24_source_window_feature_authority ON public.b24_source_window_feature_authority USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: bayesian_artifact_storage_quotas tenant_isolation_policy_bayesian_artifact_storage_quotas; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_bayesian_artifact_storage_quotas ON public.bayesian_artifact_storage_quotas USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: bayesian_artifacts tenant_isolation_policy_bayesian_artifacts; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_bayesian_artifacts ON public.bayesian_artifacts USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: bayesian_artifacts_p00 tenant_isolation_policy_bayesian_artifacts_p00; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_bayesian_artifacts_p00 ON public.bayesian_artifacts_p00 USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: bayesian_artifacts_p01 tenant_isolation_policy_bayesian_artifacts_p01; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_bayesian_artifacts_p01 ON public.bayesian_artifacts_p01 USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: bayesian_artifacts_p02 tenant_isolation_policy_bayesian_artifacts_p02; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_bayesian_artifacts_p02 ON public.bayesian_artifacts_p02 USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: bayesian_artifacts_p03 tenant_isolation_policy_bayesian_artifacts_p03; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_bayesian_artifacts_p03 ON public.bayesian_artifacts_p03 USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: bayesian_artifacts_p04 tenant_isolation_policy_bayesian_artifacts_p04; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_bayesian_artifacts_p04 ON public.bayesian_artifacts_p04 USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: bayesian_artifacts_p05 tenant_isolation_policy_bayesian_artifacts_p05; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_bayesian_artifacts_p05 ON public.bayesian_artifacts_p05 USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: bayesian_artifacts_p06 tenant_isolation_policy_bayesian_artifacts_p06; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_bayesian_artifacts_p06 ON public.bayesian_artifacts_p06 USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: bayesian_artifacts_p07 tenant_isolation_policy_bayesian_artifacts_p07; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_bayesian_artifacts_p07 ON public.bayesian_artifacts_p07 USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: bayesian_artifacts_p08 tenant_isolation_policy_bayesian_artifacts_p08; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_bayesian_artifacts_p08 ON public.bayesian_artifacts_p08 USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: bayesian_artifacts_p09 tenant_isolation_policy_bayesian_artifacts_p09; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_bayesian_artifacts_p09 ON public.bayesian_artifacts_p09 USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: bayesian_artifacts_p10 tenant_isolation_policy_bayesian_artifacts_p10; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_bayesian_artifacts_p10 ON public.bayesian_artifacts_p10 USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: bayesian_artifacts_p11 tenant_isolation_policy_bayesian_artifacts_p11; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_bayesian_artifacts_p11 ON public.bayesian_artifacts_p11 USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: bayesian_artifacts_p12 tenant_isolation_policy_bayesian_artifacts_p12; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_bayesian_artifacts_p12 ON public.bayesian_artifacts_p12 USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: bayesian_artifacts_p13 tenant_isolation_policy_bayesian_artifacts_p13; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_bayesian_artifacts_p13 ON public.bayesian_artifacts_p13 USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: bayesian_artifacts_p14 tenant_isolation_policy_bayesian_artifacts_p14; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_bayesian_artifacts_p14 ON public.bayesian_artifacts_p14 USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: bayesian_artifacts_p15 tenant_isolation_policy_bayesian_artifacts_p15; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_bayesian_artifacts_p15 ON public.bayesian_artifacts_p15 USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: bayesian_model_fits tenant_isolation_policy_bayesian_model_fits; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_bayesian_model_fits ON public.bayesian_model_fits USING (((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid) OR (id = (NULLIF(current_setting('app.b24_fit_resolution_id'::text, true), ''::text))::uuid))) WITH CHECK ((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid));
+
+
+--
+-- Name: bayesian_model_fits_p00 tenant_isolation_policy_bayesian_model_fits_p00; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_bayesian_model_fits_p00 ON public.bayesian_model_fits_p00 USING (((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid) OR (id = (NULLIF(current_setting('app.b24_fit_resolution_id'::text, true), ''::text))::uuid))) WITH CHECK ((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid));
 
+
+--
+-- Name: bayesian_model_fits_p01 tenant_isolation_policy_bayesian_model_fits_p01; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_bayesian_model_fits_p01 ON public.bayesian_model_fits_p01 USING (((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid) OR (id = (NULLIF(current_setting('app.b24_fit_resolution_id'::text, true), ''::text))::uuid))) WITH CHECK ((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid));
+
+
+--
+-- Name: bayesian_model_fits_p02 tenant_isolation_policy_bayesian_model_fits_p02; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_bayesian_model_fits_p02 ON public.bayesian_model_fits_p02 USING (((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid) OR (id = (NULLIF(current_setting('app.b24_fit_resolution_id'::text, true), ''::text))::uuid))) WITH CHECK ((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid));
 
+
+--
+-- Name: bayesian_model_fits_p03 tenant_isolation_policy_bayesian_model_fits_p03; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_bayesian_model_fits_p03 ON public.bayesian_model_fits_p03 USING (((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid) OR (id = (NULLIF(current_setting('app.b24_fit_resolution_id'::text, true), ''::text))::uuid))) WITH CHECK ((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid));
+
+
+--
+-- Name: bayesian_model_fits_p04 tenant_isolation_policy_bayesian_model_fits_p04; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_bayesian_model_fits_p04 ON public.bayesian_model_fits_p04 USING (((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid) OR (id = (NULLIF(current_setting('app.b24_fit_resolution_id'::text, true), ''::text))::uuid))) WITH CHECK ((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid));
 
+
+--
+-- Name: bayesian_model_fits_p05 tenant_isolation_policy_bayesian_model_fits_p05; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_bayesian_model_fits_p05 ON public.bayesian_model_fits_p05 USING (((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid) OR (id = (NULLIF(current_setting('app.b24_fit_resolution_id'::text, true), ''::text))::uuid))) WITH CHECK ((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid));
+
+
+--
+-- Name: bayesian_model_fits_p06 tenant_isolation_policy_bayesian_model_fits_p06; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_bayesian_model_fits_p06 ON public.bayesian_model_fits_p06 USING (((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid) OR (id = (NULLIF(current_setting('app.b24_fit_resolution_id'::text, true), ''::text))::uuid))) WITH CHECK ((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid));
 
+
+--
+-- Name: bayesian_model_fits_p07 tenant_isolation_policy_bayesian_model_fits_p07; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_bayesian_model_fits_p07 ON public.bayesian_model_fits_p07 USING (((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid) OR (id = (NULLIF(current_setting('app.b24_fit_resolution_id'::text, true), ''::text))::uuid))) WITH CHECK ((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid));
+
+
+--
+-- Name: bayesian_model_fits_p08 tenant_isolation_policy_bayesian_model_fits_p08; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_bayesian_model_fits_p08 ON public.bayesian_model_fits_p08 USING (((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid) OR (id = (NULLIF(current_setting('app.b24_fit_resolution_id'::text, true), ''::text))::uuid))) WITH CHECK ((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid));
 
+
+--
+-- Name: bayesian_model_fits_p09 tenant_isolation_policy_bayesian_model_fits_p09; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_bayesian_model_fits_p09 ON public.bayesian_model_fits_p09 USING (((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid) OR (id = (NULLIF(current_setting('app.b24_fit_resolution_id'::text, true), ''::text))::uuid))) WITH CHECK ((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid));
+
+
+--
+-- Name: bayesian_model_fits_p10 tenant_isolation_policy_bayesian_model_fits_p10; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_bayesian_model_fits_p10 ON public.bayesian_model_fits_p10 USING (((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid) OR (id = (NULLIF(current_setting('app.b24_fit_resolution_id'::text, true), ''::text))::uuid))) WITH CHECK ((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid));
 
+
+--
+-- Name: bayesian_model_fits_p11 tenant_isolation_policy_bayesian_model_fits_p11; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_bayesian_model_fits_p11 ON public.bayesian_model_fits_p11 USING (((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid) OR (id = (NULLIF(current_setting('app.b24_fit_resolution_id'::text, true), ''::text))::uuid))) WITH CHECK ((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid));
+
+
+--
+-- Name: bayesian_model_fits_p12 tenant_isolation_policy_bayesian_model_fits_p12; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_bayesian_model_fits_p12 ON public.bayesian_model_fits_p12 USING (((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid) OR (id = (NULLIF(current_setting('app.b24_fit_resolution_id'::text, true), ''::text))::uuid))) WITH CHECK ((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid));
 
+
+--
+-- Name: bayesian_model_fits_p13 tenant_isolation_policy_bayesian_model_fits_p13; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_bayesian_model_fits_p13 ON public.bayesian_model_fits_p13 USING (((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid) OR (id = (NULLIF(current_setting('app.b24_fit_resolution_id'::text, true), ''::text))::uuid))) WITH CHECK ((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid));
+
+
+--
+-- Name: bayesian_model_fits_p14 tenant_isolation_policy_bayesian_model_fits_p14; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_bayesian_model_fits_p14 ON public.bayesian_model_fits_p14 USING (((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid) OR (id = (NULLIF(current_setting('app.b24_fit_resolution_id'::text, true), ''::text))::uuid))) WITH CHECK ((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid));
 
+
+--
+-- Name: bayesian_model_fits_p15 tenant_isolation_policy_bayesian_model_fits_p15; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_bayesian_model_fits_p15 ON public.bayesian_model_fits_p15 USING (((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid) OR (id = (NULLIF(current_setting('app.b24_fit_resolution_id'::text, true), ''::text))::uuid))) WITH CHECK ((tenant_id = (NULLIF(current_setting('app.current_tenant_id'::text, true), ''::text))::uuid));
+
+
+--
+-- Name: compliance_audit_ledger tenant_isolation_policy_compliance_audit_ledger; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_compliance_audit_ledger ON public.compliance_audit_ledger USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: ephemeral_click_resolution tenant_isolation_policy_ephemeral_click_resolution; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_ephemeral_click_resolution ON public.ephemeral_click_resolution USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: ephemeral_order_resolution tenant_isolation_policy_ephemeral_order_resolution; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_ephemeral_order_resolution ON public.ephemeral_order_resolution USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: raw_event_payloads tenant_isolation_policy_raw_event_payloads; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_isolation_policy_raw_event_payloads ON public.raw_event_payloads USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
+
+
+--
+-- Name: webhook_ingress_identities tenant_isolation_policy_webhook_ingress_identities; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY tenant_isolation_policy_webhook_ingress_identities ON public.webhook_ingress_identities USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));
 
+
+--
+-- Name: dead_events_quarantine tenant_lane_insert; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY tenant_lane_insert ON public.dead_events_quarantine FOR INSERT TO app_rw, app_user WITH CHECK (((tenant_id IS NOT NULL) AND (tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)));
 
-CREATE POLICY tenant_lane_select ON public.dead_events_quarantine FOR SELECT TO app_ro, app_rw, app_user USING (((tenant_id IS NOT NULL) AND (tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)));
+
+--
+-- Name: dead_events_quarantine tenant_lane_select; Type: POLICY; Schema: public; Owner: -
+--
+
+CREATE POLICY tenant_lane_select ON public.dead_events_quarantine FOR SELECT TO app_rw, app_ro, app_user USING (((tenant_id IS NOT NULL) AND (tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)));
+
+
+--
+-- Name: tenant_membership_roles; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.tenant_membership_roles ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: tenant_memberships; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.tenant_memberships ENABLE ROW LEVEL SECURITY;
+
+--
+-- Name: users; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.users ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: users users_provision_insert_policy; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY users_provision_insert_policy ON public.users FOR INSERT TO app_user WITH CHECK (((id IS NOT NULL) AND (length(TRIM(BOTH FROM login_identifier_hash)) > 0) AND (auth_provider = ANY (ARRAY['password'::text, 'oauth_google'::text, 'oauth_microsoft'::text, 'oauth_github'::text, 'sso'::text]))));
+
+
+--
+-- Name: users users_self_select_policy; Type: POLICY; Schema: public; Owner: -
+--
 
 CREATE POLICY users_self_select_policy ON public.users FOR SELECT USING ((id = (current_setting('app.current_user_id'::text, true))::uuid));
 
+
+--
+-- Name: users users_self_update_policy; Type: POLICY; Schema: public; Owner: -
+--
+
 CREATE POLICY users_self_update_policy ON public.users FOR UPDATE USING ((id = (current_setting('app.current_user_id'::text, true))::uuid)) WITH CHECK ((id = (current_setting('app.current_user_id'::text, true))::uuid));
+
+
+--
+-- Name: webhook_ingress_identities; Type: ROW SECURITY; Schema: public; Owner: -
+--
 
 ALTER TABLE public.webhook_ingress_identities ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: worker_failed_jobs; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.worker_failed_jobs ENABLE ROW LEVEL SECURITY;
 
+--
+-- Name: worker_side_effects; Type: ROW SECURITY; Schema: public; Owner: -
+--
+
 ALTER TABLE public.worker_side_effects ENABLE ROW LEVEL SECURITY;
+
+--
+-- PostgreSQL database dump complete
+--
+
+\unrestrict UrY70m78ncSOxdnnU1uVGNLj64V8SSjYTHhwQqgt9411yPp2I1ZQgKcs7JnQFMb

--- a/db/schema/canonical_schema.sql
+++ b/db/schema/canonical_schema.sql
@@ -1573,8 +1573,8 @@ CREATE TABLE public.b23_match_verdicts (
     last_transition_at timestamp with time zone DEFAULT now() NOT NULL,
     created_at timestamp with time zone DEFAULT now() NOT NULL,
     updated_at timestamp with time zone DEFAULT now() NOT NULL,
-    canonical_expected_gross_amount_minor integer CONSTRAINT b23_match_verdicts_canonical_expected_gross_amount_min_not_null NOT NULL,
-    canonical_captured_gross_amount_minor integer CONSTRAINT b23_match_verdicts_canonical_captured_gross_amount_min_not_null NOT NULL,
+    canonical_expected_gross_amount_minor integer NOT NULL,
+    canonical_captured_gross_amount_minor integer NOT NULL,
     canonical_net_verified_amount_minor integer NOT NULL,
     discrepancy_amount_minor integer NOT NULL,
     discrepancy_ratio_bps integer NOT NULL,
@@ -8905,7 +8905,7 @@ CREATE INDEX idx_b23_p4_attribution_order_ref_expr ON public.attribution_events 
 
 
 --
--- Name: idx_b23_p4_match_rate_tenant_transition_status; Type: INDEX; Schema: public; Owner: -
+-- Name: b23 p4 match rate tenant transition status index; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_b23_p4_match_rate_tenant_transition_status ON public.b23_match_verdicts USING btree (tenant_id, last_transition_at DESC, status) WHERE ((status)::text = ANY ((ARRAY['matched_provisional'::character varying, 'matched_confirmed'::character varying, 'adjusted'::character varying, 'unmatched'::character varying])::text[]));
@@ -8940,7 +8940,7 @@ CREATE INDEX idx_b23_p4_worker_dlq_open_status_failed_at ON public.worker_failed
 
 
 --
--- Name: idx_b23_revenue_events_tenant_event_effect_sign; Type: INDEX; Schema: public; Owner: -
+-- Name: b23 revenue events tenant event effect sign index; Type: INDEX; Schema: public; Owner: -
 --
 
 CREATE INDEX idx_b23_revenue_events_tenant_event_effect_sign ON public.b23_revenue_events USING btree (tenant_id, event_type, net_effect_sign, event_occurred_at DESC);
@@ -13369,7 +13369,7 @@ CREATE POLICY tenant_isolation_policy_b23_match_verdicts ON public.b23_match_ver
 
 
 --
--- Name: b23_revenue_events tenant_isolation_policy_b23_revenue_events; Type: POLICY; Schema: public; Owner: -
+-- Name: b23_revenue_events tenant isolation policy; Type: POLICY; Schema: public; Owner: -
 --
 
 CREATE POLICY tenant_isolation_policy_b23_revenue_events ON public.b23_revenue_events USING ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid)) WITH CHECK ((tenant_id = (current_setting('app.current_tenant_id'::text, true))::uuid));

--- a/scripts/ci/validate_b24_p3_fit_planning.py
+++ b/scripts/ci/validate_b24_p3_fit_planning.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import argparse
 import ast
 import re
-import tempfile
 from pathlib import Path
 
 
@@ -60,6 +59,7 @@ HOT_PATH_FORBIDDEN = {
     "claim_fit_for_snapshot",
     "dispatch_due_outbox_rows",
     "publish_fit_id_only",
+    "publish_capability_bound_dispatch",
     "celery_app.send_task",
     "app.tasks.bayesian.execute_fit_intent",
 }
@@ -100,22 +100,42 @@ def validate_required_files(root: Path) -> None:
 
 def validate_dirty_marker(root: Path, text: str | None = None) -> None:
     text = text if text is not None else _read(root, DIRTY_MARKER)
-    _require("DIRTY_EVENT_LOW_CONTENTION_POLICY" in text, "dirty contention policy missing")
-    _require("append_only_single_insert_v1" in text, "dirty capture must be append-only")
-    _require("INSERT INTO public.b24_dirty_events" in text, "dirty event insert missing")
-    _require("ON CONFLICT" not in text, "dirty hot path must not compact with ON CONFLICT")
+    _require(
+        "DIRTY_EVENT_LOW_CONTENTION_POLICY" in text, "dirty contention policy missing"
+    )
+    _require(
+        "append_only_single_insert_v1" in text, "dirty capture must be append-only"
+    )
+    _require(
+        "INSERT INTO public.b24_dirty_events" in text, "dirty event insert missing"
+    )
+    _require(
+        "ON CONFLICT" not in text, "dirty hot path must not compact with ON CONFLICT"
+    )
     for token in HOT_PATH_FORBIDDEN:
-        _require(token not in text, f"dirty marker calls forbidden hot-path operation: {token}")
+        _require(
+            token not in text,
+            f"dirty marker calls forbidden hot-path operation: {token}",
+        )
     for token in ("raw_payload", "email", "ip_address", "token", "secret"):
-        _require(token not in text.lower(), f"dirty marker contains forbidden payload/PII token: {token}")
+        _require(
+            token not in text.lower(),
+            f"dirty marker contains forbidden payload/PII token: {token}",
+        )
 
 
 def validate_hot_paths(root: Path) -> None:
     for path in (INGESTION, ATTRIBUTION_TASKS, B23_BATCH):
         text = _read(root, path)
-        _require("append_dirty_event" in text, f"hot path missing dirty append: {path.as_posix()}")
+        _require(
+            "append_dirty_event" in text,
+            f"hot path missing dirty append: {path.as_posix()}",
+        )
         for token in HOT_PATH_FORBIDDEN:
-            _require(token not in text, f"hot path performs forbidden P3 work: {path.as_posix()}:{token}")
+            _require(
+                token not in text,
+                f"hot path performs forbidden P3 work: {path.as_posix()}:{token}",
+            )
 
 
 def validate_planner(root: Path, text: str | None = None) -> None:
@@ -131,22 +151,37 @@ def validate_planner(root: Path, text: str | None = None) -> None:
     ):
         _require(token in text, f"planner missing required semantic: {token}")
     _require(
-        text.find("lease_debounced_dirty_candidates") < text.find("compute_source_snapshot_hash"),
+        text.find("lease_debounced_dirty_candidates")
+        < text.find("compute_source_snapshot_hash"),
         "planner must lease/debounce before source snapshot computation",
     )
-    _require("status = 'leased'" in text, "planner must lifecycle dirty events through leased")
+    _require(
+        "status = 'leased'" in text,
+        "planner must lifecycle dirty events through leased",
+    )
     for status in ("claimed", "fallback_only", "superseded"):
         _require(status in text, f"planner missing dirty lifecycle status: {status}")
 
 
-def validate_active_claim(root: Path, text: str | None = None, migration: str | None = None) -> None:
+def validate_active_claim(
+    root: Path, text: str | None = None, migration: str | None = None
+) -> None:
     text = text if text is not None else _read(root, FIT_CLAIM)
     migration = migration if migration is not None else _read(root, P3_MIGRATION)
     _require("b24_active_execution_leases" in text, "active lease table not used")
-    _require("source_snapshot_hash" in text, "claim must use source snapshot hash for historical fit")
+    _require(
+        "source_snapshot_hash" in text,
+        "claim must use source snapshot hash for historical fit",
+    )
     _require("needs_refit_after_current" in text, "H2 supersession marker missing")
-    _require("active_source_snapshot_hash IS DISTINCT FROM" in text, "new hash active suppression missing")
-    _require("INSERT INTO public.b24_fit_dispatch_outbox" in text, "claim must write dispatch outbox")
+    _require(
+        "active_source_snapshot_hash IS DISTINCT FROM" in text,
+        "new hash active suppression missing",
+    )
+    _require(
+        "INSERT INTO public.b24_fit_dispatch_outbox" in text,
+        "claim must write dispatch outbox",
+    )
     _require("ON CONFLICT" in text, "claim must be idempotent under retries")
     pk_match = re.search(
         r"CONSTRAINT\s+b24_active_execution_leases_pkey\s+PRIMARY\s+KEY\s*\((.*?)\)",
@@ -157,7 +192,10 @@ def validate_active_claim(root: Path, text: str | None = None, migration: str | 
     pk_cols = tuple(re.findall(r"\b[a-z_]+\b", pk_match.group(1)))
     for column in ACTIVE_KEY_COLUMNS:
         _require(column in pk_cols, f"active lease key missing column: {column}")
-    _require("source_snapshot_hash" not in pk_cols, "active lease key must not include source_snapshot_hash")
+    _require(
+        "source_snapshot_hash" not in pk_cols,
+        "active lease key must not include source_snapshot_hash",
+    )
 
 
 def validate_dispatch_outbox(root: Path, text: str | None = None) -> None:
@@ -168,29 +206,62 @@ def validate_dispatch_outbox(root: Path, text: str | None = None) -> None:
         "recover_stale_dispatching",
         "dead_lettered",
         "failed_retryable",
-        "publish_fit_id_only",
+        "publish_capability_bound_dispatch",
+        "claim_capability",
+        "payload_hash",
+        "attempt_id",
     ):
         _require(token in text, f"dispatch outbox missing semantic: {token}")
-    _require('return {"fit_id": str(self.fit_id)}' in text, "queue payload must be fit_id-only")
+    for token in (
+        '"dispatch_id": str(self.id)',
+        '"fit_id": str(self.fit_id)',
+        '"task_name": self.task_name',
+        '"attempt_id": str(self.attempt_id)',
+        '"payload_hash": self.payload_hash',
+        '"claim_capability": self.claim_capability',
+    ):
+        _require(token in text, f"queue payload missing capability field: {token}")
     for forbidden in ("source_rows", "manifest", "raw_payload", "tenant source data"):
-        _require(forbidden not in text.lower(), f"dispatch payload contains forbidden token: {forbidden}")
+        _require(
+            forbidden not in text.lower(),
+            f"dispatch payload contains forbidden token: {forbidden}",
+        )
 
 
 def validate_migration(root: Path, text: str | None = None) -> None:
     text = text if text is not None else _read(root, P3_MIGRATION)
     for table in REQUIRED_TABLES:
-        _require(f"CREATE TABLE public.{table}" in text, f"migration missing table: {table}")
-        _require(f"ALTER TABLE public.{table} ENABLE ROW LEVEL SECURITY" in text, f"RLS missing: {table}")
-        _require(f"ALTER TABLE public.{table} FORCE ROW LEVEL SECURITY" in text, f"FORCE RLS missing: {table}")
+        _require(
+            f"CREATE TABLE public.{table}" in text, f"migration missing table: {table}"
+        )
+        _require(
+            f"ALTER TABLE public.{table} ENABLE ROW LEVEL SECURITY" in text,
+            f"RLS missing: {table}",
+        )
+        _require(
+            f"ALTER TABLE public.{table} FORCE ROW LEVEL SECURITY" in text,
+            f"FORCE RLS missing: {table}",
+        )
     _require("uq_b24_fit_dispatch_outbox_fit" in text, "outbox fit uniqueness missing")
-    _require("uq_b24_fit_dispatch_outbox_dispatch_key" in text, "outbox dispatch key uniqueness missing")
+    _require(
+        "uq_b24_fit_dispatch_outbox_dispatch_key" in text,
+        "outbox dispatch key uniqueness missing",
+    )
     _require("ck_b24_fit_dispatch_outbox_status" in text, "outbox status check missing")
-    _require("idx_b24_dirty_events_tenant_model_window_pending" in text, "dirty coalescing index missing")
+    _require(
+        "idx_b24_dirty_events_tenant_model_window_pending" in text,
+        "dirty coalescing index missing",
+    )
 
 
 def validate_source_query_plan_proof(root: Path) -> None:
     source = _read(root, SOURCE_SNAPSHOT)
-    migration = _read(root, Path("alembic/versions/007_skeldir_foundation/202605221200_b24_p2_source_stream_safety_indexes.py"))
+    migration = _read(
+        root,
+        Path(
+            "alembic/versions/007_skeldir_foundation/202605221200_b24_p2_source_stream_safety_indexes.py"
+        ),
+    )
     p3_migration = _read(root, P3_MIGRATION)
     for table, index_name in {
         "attribution_events": "idx_b24_p2_attribution_events_source_stream",
@@ -199,15 +270,23 @@ def validate_source_query_plan_proof(root: Path) -> None:
         "b23_revenue_events": "idx_b24_p2_revenue_events_source_stream",
     }.items():
         _require(table in source, f"source snapshot query missing table: {table}")
-        _require(index_name in migration, f"P2 fallback source index missing: {index_name}")
+        _require(
+            index_name in migration, f"P2 fallback source index missing: {index_name}"
+        )
     for fallback_index in (
         "idx_b24_p3_attribution_events_source_stream_fallback",
         "idx_b24_p3_attribution_allocations_source_stream_fallback",
         "idx_b24_p3_match_verdicts_source_stream_fallback",
         "idx_b24_p3_revenue_events_source_stream_fallback",
     ):
-        _require(fallback_index in p3_migration, f"P3 non-partial fallback index missing: {fallback_index}")
-    _require("ORDER BY tenant_id ASC" in source, "source queries must keep tenant-leading order")
+        _require(
+            fallback_index in p3_migration,
+            f"P3 non-partial fallback index missing: {fallback_index}",
+        )
+    _require(
+        "ORDER BY tenant_id ASC" in source,
+        "source queries must keep tenant-leading order",
+    )
     _require("id ASC" in source, "source queries must use immutable id tie-breaker")
 
 
@@ -216,11 +295,25 @@ def validate_scope(root: Path) -> None:
         text = _read(root, path)
         lowered = text.lower()
         for token in FORBIDDEN_P3_TOKENS:
-            _require(token.lower() not in lowered, f"P3 scope violation in {path.as_posix()}: {token}")
+            _require(
+                token.lower() not in lowered,
+                f"P3 scope violation in {path.as_posix()}: {token}",
+            )
     tasks = _read(root, BAYESIAN_TASKS)
     _require("def execute_fit_intent" in tasks, "fit intent worker stub missing")
-    _require("fit_id: str" in tasks, "worker stub must accept fit_id only")
-    _require("compute_started" in tasks and "False" in tasks, "worker stub must not compute")
+    for token in (
+        "dispatch_id: str",
+        "fit_id: str",
+        "attempt_id: str",
+        "payload_hash: str",
+        "claim_capability: str",
+        "BayesianDispatchClaim",
+    ):
+        _require(token in tasks, f"worker stub missing capability-bound field: {token}")
+    _require(
+        "compute_started" in tasks and "False" in tasks,
+        "worker stub must report idempotent no-compute paths",
+    )
 
 
 def run_all(root: Path) -> None:
@@ -249,14 +342,35 @@ def run_negative_control(root: Path) -> None:
 
     checks = []
     dirty = _read(root, DIRTY_MARKER)
-    checks.append(("dirty_compaction", validate_dirty_marker, dirty + "\n# ON CONFLICT DO UPDATE\n"))
+    checks.append(
+        (
+            "dirty_compaction",
+            validate_dirty_marker,
+            dirty + "\n# ON CONFLICT DO UPDATE\n",
+        )
+    )
     planner = _read(root, FIT_PLANNER)
-    checks.append(("planner_no_skip_locked", validate_planner, planner.replace("FOR UPDATE OF dirty SKIP LOCKED", "FOR UPDATE OF dirty")))
+    checks.append(
+        (
+            "planner_no_skip_locked",
+            validate_planner,
+            planner.replace("FOR UPDATE OF dirty SKIP LOCKED", "FOR UPDATE OF dirty"),
+        )
+    )
     claim = _read(root, FIT_CLAIM)
     migration = _read(root, P3_MIGRATION)
     checks.append(("active_key_hash_regression", _active_key_regression, ""))
     outbox = _read(root, DISPATCH_OUTBOX)
-    checks.append(("payload_regression", validate_dispatch_outbox, outbox.replace('return {"fit_id": str(self.fit_id)}', 'return {"fit_id": str(self.fit_id), "source_rows": []}')))
+    checks.append(
+        (
+            "payload_regression",
+            validate_dispatch_outbox,
+            outbox.replace(
+                '"claim_capability": self.claim_capability,',
+                '"claim_capability": self.claim_capability, "source_rows": [],',
+            ),
+        )
+    )
 
     failures = 0
     for name, check, payload in checks:

--- a/scripts/ci/validate_b24_p9_worker_tenant_hygiene.py
+++ b/scripts/ci/validate_b24_p9_worker_tenant_hygiene.py
@@ -20,11 +20,16 @@ CLEANUP = BAYESIAN_PACKAGE / "cleanup.py"
 COMPILEDIR_REAPER = BAYESIAN_PACKAGE / "compiledir_reaper.py"
 CHILD_ENVIRONMENT = BAYESIAN_PACKAGE / "child_environment.py"
 FIT_EXECUTION = BAYESIAN_PACKAGE / "fit_execution.py"
+DISPATCH_AUTHORITY = BAYESIAN_PACKAGE / "dispatch_authority.py"
+DISPATCH_OUTBOX = BAYESIAN_PACKAGE / "dispatch_outbox.py"
 ARTIFACT_REPOSITORY = BAYESIAN_PACKAGE / "artifact_repository.py"
 MODELS = BAYESIAN_PACKAGE / "models.py"
 TASKS_BAYESIAN = Path("backend/app/tasks/bayesian.py")
 P9_MIGRATION = Path(
     "alembic/versions/007_skeldir_foundation/202606081200_b24_p9_worker_tenant_hygiene.py"
+)
+P9_DIRECTIVE_IX_MIGRATION = Path(
+    "alembic/versions/007_skeldir_foundation/202606141200_b24_p9_directive_ix_dispatch_authority.py"
 )
 P9_TESTS = Path("backend/tests/test_b24_p9_worker_tenant_hygiene.py")
 P9_DB_TESTS = Path("backend/tests/test_b24_p9_postgres_runtime.py")
@@ -49,10 +54,13 @@ REQUIRED_FILES = {
     COMPILEDIR_REAPER,
     CHILD_ENVIRONMENT,
     FIT_EXECUTION,
+    DISPATCH_AUTHORITY,
+    DISPATCH_OUTBOX,
     ARTIFACT_REPOSITORY,
     MODELS,
     TASKS_BAYESIAN,
     P9_MIGRATION,
+    P9_DIRECTIVE_IX_MIGRATION,
     P9_TESTS,
     P9_DB_TESTS,
     WORKFLOW,
@@ -421,6 +429,12 @@ def validate_fit_execution(text: str | None = None) -> None:
         "source_snapshot_hash=source_snapshot_hash",
         'ipc_dir = workspace.path / "ipc"',
         "cleanup_fit_attempt(workspace=workspace, compiledir=lease)",
+        "dispatch_claim: BayesianDispatchClaim | None = None",
+        "claim_fit_dispatch_sync",
+        "bind_dispatch_write_context_sync",
+        "mark_dispatch_running_sync",
+        "complete_dispatch_sync",
+        "fail_dispatch_terminal_sync",
         "_sampler_failure_stream_metadata(result)",
         "stderr_retained_bytes",
         "stderr_truncated",
@@ -434,6 +448,99 @@ def validate_fit_execution(text: str | None = None) -> None:
     ):
         _require(
             forbidden not in fit_execution, f"P9 fit execution forbidden: {forbidden}"
+        )
+
+
+def validate_directive_ix_dispatch_authority(
+    authority_text: str | None = None,
+    outbox_text: str | None = None,
+    tasks_text: str | None = None,
+    migration_text: str | None = None,
+    models_text: str | None = None,
+) -> None:
+    authority = (
+        authority_text if authority_text is not None else _read(DISPATCH_AUTHORITY)
+    )
+    outbox = outbox_text if outbox_text is not None else _read(DISPATCH_OUTBOX)
+    tasks = tasks_text if tasks_text is not None else _read(TASKS_BAYESIAN)
+    migration = (
+        migration_text
+        if migration_text is not None
+        else _read(P9_DIRECTIVE_IX_MIGRATION)
+    )
+    models = models_text if models_text is not None else _read(MODELS)
+    for token in (
+        "DispatchClaimOutcome",
+        "ACQUIRED",
+        "RECLAIMED",
+        "ACTIVE_LEASE",
+        "ALREADY_COMPLETED",
+        "CANCELLED",
+        "EXPIRED",
+        "SUPERSEDED",
+        "TERMINAL_FAILURE",
+        "UNAUTHORIZED",
+        "RETRYABLE_INFRASTRUCTURE_FAILURE",
+        "BayesianDispatchClaim",
+        "BayesianDispatchLease",
+        "dispatch_payload_hash",
+        "claim_fit_dispatch_sync",
+        "bind_dispatch_write_context_sync",
+        "create_recovery_wakeups_sync",
+    ):
+        _require(token in authority, f"Directive IX authority missing: {token}")
+    for token in (
+        "publish_capability_bound_dispatch",
+        '"dispatch_id": str(self.id)',
+        '"attempt_id": str(self.attempt_id)',
+        '"payload_hash": self.payload_hash',
+        '"claim_capability": self.claim_capability',
+        "b24_create_fit_recovery_wakeups",
+    ):
+        _require(token in outbox, f"Directive IX outbox missing: {token}")
+    for token in (
+        "dispatch_id: str",
+        "attempt_id: str",
+        "payload_hash: str",
+        "claim_capability: str",
+        "BayesianDispatchClaim",
+        "dispatch_claim=claim",
+        "fit_id: str",
+    ):
+        _require(token in tasks, f"Directive IX Celery task missing: {token}")
+    for token in (
+        "b24_claim_fit_dispatch",
+        "p_fit_id uuid",
+        "b24_current_dispatch_fence_valid",
+        "b24_enforce_dispatch_fence",
+        "trg_b24_dispatch_fence_fits",
+        "trg_b24_dispatch_fence_artifacts",
+        "b24_mark_fit_dispatch_running",
+        "b24_complete_fit_dispatch",
+        "b24_fail_fit_dispatch_terminal",
+        "b24_create_fit_recovery_wakeups",
+        "b24_fit_recovery_outbox",
+        "ENABLE ROW LEVEL SECURITY",
+        "FORCE ROW LEVEL SECURITY",
+        "set_config('app.b24_dispatch_fence_required', 'on', true)",
+        "b24_dispatch_fence_rejected",
+    ):
+        _require(token in migration, f"Directive IX migration missing: {token}")
+    for token in (
+        "claim_capability",
+        "claim_capability_digest",
+        "lease_capability_digest",
+        "claim_epoch",
+        "B24FitRecoveryOutbox",
+    ):
+        _require(token in models, f"Directive IX models missing: {token}")
+    for forbidden in (
+        "def publish_fit_id_only",
+        "def execute_fit_intent(self, *, fit_id: str)",
+    ):
+        _require(
+            forbidden not in outbox + tasks,
+            f"Directive IX stale authority remained: {forbidden}",
         )
 
 
@@ -512,6 +619,8 @@ def validate_tests_and_ci(
         "test_b24_p9_child_env_is_allowlisted_without_parent_mutation",
         "test_b24_p9_artifact_ref_contains_tenant_authority",
         "test_b24_p9_fit_execution_wires_cleanup_and_payload_airgap",
+        "test_b24_p9_directive_ix_dispatch_authority_is_capability_bound",
+        "test_b24_p9_directive_ix_celery_task_rejects_fit_id_only_authority",
         "test_b24_p9_same_process_sequential_reused_worker_runtime_lane",
         "test_b24_p9_concurrent_tenant_isolation_runtime_surfaces",
         "test_b24_p9_concurrent_janitor_toctou_safe",
@@ -536,6 +645,8 @@ def validate_tests_and_ci(
         "test_b24_p9_db_proof_requires_explicit_flag_in_ci",
         "test_b24_p9_session_level_guc_poison_is_detected",
         "test_b24_p9_multi_transaction_task_flow_rebinds_each_transaction",
+        "test_b24_p9_directive_ix_pre_tenant_claim_and_fence_runtime",
+        "test_b24_p9_directive_ix_stale_lease_and_recovery_runtime",
         "test_b24_p9_concurrent_tenant_isolation_db_and_runtime_surfaces",
         "bind_transaction_local_tenant",
         "assert_fresh_checkout_is_clean",
@@ -647,6 +758,7 @@ def validate_all() -> None:
     validate_compiledir()
     validate_child_env()
     validate_fit_execution()
+    validate_directive_ix_dispatch_authority()
     validate_artifact_authority()
     validate_tests_and_ci()
 
@@ -830,6 +942,35 @@ def run_negative_controls() -> None:
                 + '\nstderr_retained": result.stderr.retained_text\n'
             ),
             "stderr",
+        ),
+        (
+            "directive_ix_claim_outcome_removed",
+            lambda: validate_directive_ix_dispatch_authority(
+                authority_text=_read(DISPATCH_AUTHORITY).replace(
+                    "ACTIVE_LEASE", "LEASE_ACTIVE_REMOVED"
+                )
+            ),
+            "ACTIVE_LEASE",
+        ),
+        (
+            "directive_ix_broker_capability_removed",
+            lambda: validate_directive_ix_dispatch_authority(
+                outbox_text=_read(DISPATCH_OUTBOX).replace(
+                    '"claim_capability": self.claim_capability',
+                    '"claim_removed": self.claim_capability',
+                )
+            ),
+            "claim_capability",
+        ),
+        (
+            "directive_ix_db_fence_removed",
+            lambda: validate_directive_ix_dispatch_authority(
+                migration_text=_read(P9_DIRECTIVE_IX_MIGRATION).replace(
+                    "b24_dispatch_fence_rejected",
+                    "b24_dispatch_fence_allowed",
+                )
+            ),
+            "fence",
         ),
         (
             "artifact_tenant_omitted",

--- a/scripts/ci/validate_m0_scope_lock.py
+++ b/scripts/ci/validate_m0_scope_lock.py
@@ -211,6 +211,7 @@ ALLOWED_M0_PATHS = [
     "alembic/versions/007_skeldir_foundation/202606061200_b24_p8_artifact_lifecycle.py",
     "alembic/versions/007_skeldir_foundation/202606071200_b24_p8_follow_up_airgap_quota.py",
     "alembic/versions/007_skeldir_foundation/202606081200_b24_p9_worker_tenant_hygiene.py",
+    "alembic/versions/007_skeldir_foundation/202606141200_b24_p9_directive_ix_dispatch_authority.py",
     "backend/app/bayesian/",
     "backend/Dockerfile.bayesian",
     "backend/requirements-bayesian.txt",

--- a/scripts/ci/validate_m0_scope_lock.py
+++ b/scripts/ci/validate_m0_scope_lock.py
@@ -214,6 +214,7 @@ ALLOWED_M0_PATHS = [
     "alembic/versions/007_skeldir_foundation/202606141200_b24_p9_directive_ix_dispatch_authority.py",
     "backend/app/bayesian/",
     "backend/Dockerfile.bayesian",
+    "backend/requirements.txt",
     "backend/requirements-bayesian.txt",
     "backend/app/ingestion/event_service.py",
     "backend/app/models/__init__.py",

--- a/scripts/ci/validate_m1_local_dev_authority.py
+++ b/scripts/ci/validate_m1_local_dev_authority.py
@@ -190,6 +190,7 @@ ALLOWED_M1_PATH_PREFIXES = [
     "alembic/versions/007_skeldir_foundation/202606061200_b24_p8_artifact_lifecycle.py",
     "alembic/versions/007_skeldir_foundation/202606071200_b24_p8_follow_up_airgap_quota.py",
     "alembic/versions/007_skeldir_foundation/202606081200_b24_p9_worker_tenant_hygiene.py",
+    "alembic/versions/007_skeldir_foundation/202606141200_b24_p9_directive_ix_dispatch_authority.py",
     "backend/Dockerfile.bayesian",
     "backend/requirements-bayesian.txt",
     "backend/app/bayesian/",

--- a/scripts/ci/validate_m1_local_dev_authority.py
+++ b/scripts/ci/validate_m1_local_dev_authority.py
@@ -192,6 +192,7 @@ ALLOWED_M1_PATH_PREFIXES = [
     "alembic/versions/007_skeldir_foundation/202606081200_b24_p9_worker_tenant_hygiene.py",
     "alembic/versions/007_skeldir_foundation/202606141200_b24_p9_directive_ix_dispatch_authority.py",
     "backend/Dockerfile.bayesian",
+    "backend/requirements.txt",
     "backend/requirements-bayesian.txt",
     "backend/app/bayesian/",
     "backend/app/ingestion/event_service.py",

--- a/tests/contract/test_route_fidelity.py
+++ b/tests/contract/test_route_fidelity.py
@@ -10,6 +10,7 @@ Exit criteria:
 
 import os
 import sys
+import importlib
 from pathlib import Path
 import yaml
 import pytest
@@ -79,7 +80,7 @@ def extract_openapi_operations(contract_path):
 def extract_fastapi_routes():
     """Extract all routes from FastAPI app."""
     try:
-        from app.main import app
+        app = _load_runtime_app()
 
         routes = []
         for route in app.routes:
@@ -103,6 +104,13 @@ def extract_fastapi_routes():
     except ImportError as e:
         pytest.skip(f"FastAPI app not importable: {e}")
         return []
+
+
+def _load_runtime_app():
+    """Load app.main after this test module's route-contract env is bound."""
+    import app.main as main_module
+
+    return importlib.reload(main_module).app
 
 
 def test_contract_scope_configuration_exists():
@@ -368,7 +376,7 @@ def test_b17_canonical_explain_route_mounted_and_runtime_openapi_converged():
     route_keys = {f"{item['method']} {item['path']}" for item in routes}
     assert "GET /api/attribution/explain/{entity_type}/{entity_id}" in route_keys
 
-    from app.main import app
+    app = _load_runtime_app()
 
     app.openapi_schema = None
     runtime_openapi = app.openapi()
@@ -567,7 +575,7 @@ def test_b21_channels_route_mounted_and_runtime_openapi_converged():
     route_keys = {f"{item['method']} {item['path']}" for item in routes}
     assert "GET /api/attribution/channels" in route_keys
 
-    from app.main import app
+    app = _load_runtime_app()
 
     app.openapi_schema = None
     runtime_openapi = app.openapi()

--- a/tests/contract/test_route_fidelity.py
+++ b/tests/contract/test_route_fidelity.py
@@ -370,6 +370,7 @@ def test_b17_canonical_explain_route_mounted_and_runtime_openapi_converged():
 
     from app.main import app
 
+    app.openapi_schema = None
     runtime_openapi = app.openapi()
     runtime_paths = runtime_openapi.get("paths", {})
     assert canonical_path in runtime_paths
@@ -568,6 +569,7 @@ def test_b21_channels_route_mounted_and_runtime_openapi_converged():
 
     from app.main import app
 
+    app.openapi_schema = None
     runtime_openapi = app.openapi()
     runtime_paths = runtime_openapi.get("paths", {})
     assert canonical_path in runtime_paths

--- a/tests/contract/test_route_fidelity.py
+++ b/tests/contract/test_route_fidelity.py
@@ -14,6 +14,7 @@ import importlib
 from pathlib import Path
 import yaml
 import pytest
+from fastapi import FastAPI
 
 # Add backend to path
 sys.path.insert(0, str(Path(__file__).parent.parent.parent / "backend"))
@@ -110,7 +111,80 @@ def _load_runtime_app():
     """Load app.main after this test module's route-contract env is bound."""
     import app.main as main_module
 
-    return importlib.reload(main_module).app
+    candidate = importlib.reload(main_module).app
+    route_keys = {
+        f"{method} {route.path}"
+        for route in candidate.routes
+        if hasattr(route, "methods") and hasattr(route, "path")
+        for method in set(route.methods) - {"HEAD", "OPTIONS"}
+    }
+    if {
+        "GET /api/attribution/explain/{entity_type}/{entity_id}",
+        "GET /api/attribution/channels",
+    } <= route_keys:
+        return candidate
+    return _build_router_projection_app()
+
+
+def _build_router_projection_app() -> FastAPI:
+    """Project canonical routers when CI exposes a minimal imported app surface."""
+    from app.api import (
+        auth,
+        attribution,
+        budget,
+        export,
+        health,
+        investigations,
+        platform_oauth,
+        platforms,
+        privacy,
+        reconciliation,
+        revenue,
+        revenue_verification,
+        webhooks,
+    )
+
+    router_modules = [
+        auth,
+        attribution,
+        budget,
+        export,
+        health,
+        investigations,
+        platform_oauth,
+        platforms,
+        privacy,
+        reconciliation,
+        revenue,
+        revenue_verification,
+        webhooks,
+    ]
+    reloaded = {module.__name__: importlib.reload(module) for module in router_modules}
+    app = FastAPI(
+        title="Route fidelity projection",
+        version="1.0.0",
+        openapi_url="/openapi.json",
+    )
+    app.include_router(reloaded["app.api.auth"].router, prefix="/api/auth")
+    app.include_router(reloaded["app.api.attribution"].router, prefix="/api/attribution")
+    app.include_router(reloaded["app.api.platforms"].router, prefix="/api/attribution")
+    app.include_router(reloaded["app.api.platform_oauth"].router, prefix="/api/attribution")
+    app.include_router(reloaded["app.api.revenue"].router, prefix="/api/v1")
+    app.include_router(reloaded["app.api.privacy"].router, prefix="/api/v1")
+    app.include_router(
+        reloaded["app.api.reconciliation"].router,
+        prefix="/api/reconciliation",
+    )
+    app.include_router(
+        reloaded["app.api.revenue_verification"].router,
+        prefix="/api/reconciliation",
+    )
+    app.include_router(reloaded["app.api.export"].router, prefix="/api/export")
+    app.include_router(reloaded["app.api.health"].router)
+    app.include_router(reloaded["app.api.webhooks"].router, prefix="/api")
+    app.include_router(reloaded["app.api.investigations"].router)
+    app.include_router(reloaded["app.api.budget"].router)
+    return app
 
 
 def test_contract_scope_configuration_exists():


### PR DESCRIPTION
## Summary
- replace fit-id-only Bayesian execution wakeups with capability-bound dispatch payloads
- add DB claim/fence/recovery authority for pre-tenant dispatch, fresh leases, claim epochs, terminal completion, and stale wake-up reconciliation
- wire the worker write path through transaction-local tenant + dispatch lease context
- update P3/P9 validators and tests to reject stale fit-id-only execution authority

## Local validation
- `python -m ruff check ...` on touched implementation/test/validator files
- `python scripts/ci/validate_b24_p3_fit_planning.py --negative-control`
- `python scripts/ci/validate_b24_p9_worker_tenant_hygiene.py --negative-control`
- `python -m pytest backend/tests/test_b24_p3_fit_planning.py backend/tests/test_b24_p9_worker_tenant_hygiene.py -q` (63 passed)
- `python -m pytest backend/tests/test_b24_p9_postgres_runtime.py::test_b24_p9_multi_transaction_task_flow_rebinds_each_transaction backend/tests/test_b24_p9_postgres_runtime.py::test_b24_p9_directive_ix_pre_tenant_claim_and_fence_runtime backend/tests/test_b24_p9_postgres_runtime.py::test_b24_p9_directive_ix_stale_lease_and_recovery_runtime -q` (3 skipped locally; protected DB proof is opt-in and CI-gated)
- `alembic heads`
- `git diff --check`