### PR TITLE
fix(r2): qualify bootstrap materialized view creation

### DIFF
--- a/.github/workflows/r2-data-truth-hardening.yml
+++ b/.github/workflows/r2-data-truth-hardening.yml
@@ -295,7 +295,7 @@ jobs:
               return updated
 
           allocation_summary_view_bootstrap = textwrap.dedent("""\
-              CREATE MATERIALIZED VIEW mv_allocation_summary AS
+              CREATE MATERIALIZED VIEW public.mv_allocation_summary AS
                SELECT aa.tenant_id,
                   aa.event_id,
                   aa.model_version,
@@ -320,7 +320,7 @@ jobs:
               allocation_summary_view_bootstrap,
           )
           reconciliation_status_view_bootstrap = textwrap.dedent("""\
-              CREATE MATERIALIZED VIEW mv_reconciliation_status AS
+              CREATE MATERIALIZED VIEW public.mv_reconciliation_status AS
                SELECT rr.tenant_id,
                   rr.state,
                   rr.last_run_at,


### PR DESCRIPTION
﻿## Summary
- qualifies the bootstrap materialized-view creation targets as `public.mv_allocation_summary` and `public.mv_reconciliation_status`
- keeps the previous schema-qualified source relations and allocation trigger-function deferral intact

## Root cause
Main R2 for PR #547 got past relation lookup but failed with `ERROR: no schema has been selected to create in` because the bootstrap replacement emitted `CREATE MATERIALIZED VIEW mv_allocation_summary AS` without a target schema while the CI session has no create schema selected.

## Validation
- extracted and compiled the embedded R2 bootstrap Python from `.github/workflows/r2-data-truth-hardening.yml`
- regenerated `/tmp/canonical_schema_r2_bootstrap.sql`
- asserted generated SQL order: allocation table < `public.mv_allocation_summary` < allocation trigger function < allocation trigger
- asserted generated SQL no longer contains unqualified `CREATE MATERIALIZED VIEW mv_allocation_summary AS` or `CREATE MATERIALIZED VIEW mv_reconciliation_status AS`
- `git diff --check`

Local full R2 container replay was not available because `podman` is not installed in this desktop environment; the authoritative replay remains the main-only R2 workflow after merge.
