### PR TITLE
[codex] Implement B2.4-P9 failure ACK recovery proof

### DIFF
--- a/alembic/versions/007_skeldir_foundation/202606201430_b24_p9_directive_xiv_failure_ack_recovery.py
+++ b/alembic/versions/007_skeldir_foundation/202606201430_b24_p9_directive_xiv_failure_ack_recovery.py
@@ -1,0 +1,126 @@
+"""B2.4-P9 Directive XIV failure-ACK recovery.
+
+Revision ID: 202606201430
+Revises: 202606201300
+Create Date: 2026-06-20 14:30:00.000000
+"""
+
+from __future__ import annotations
+
+from alembic import op
+
+
+revision = "202606201430"
+down_revision = "202606201300"
+branch_labels = None
+depends_on = None
+
+
+def _grant_if_role_exists(role: str, statement: str) -> None:
+    op.execute(
+        f"""
+        DO $$
+        BEGIN
+            IF EXISTS (SELECT 1 FROM pg_roles WHERE rolname = '{role}') THEN
+                EXECUTE {statement!r};
+            END IF;
+        END $$;
+        """
+    )
+
+
+_RECOVERABLE_FAILURE_FUNCTION = """
+CREATE OR REPLACE FUNCTION public.b24_fail_fit_dispatch_recoverable(p_reason text)
+RETURNS text
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public, pg_temp
+AS $$
+DECLARE
+    v_row record;
+    v_terminal boolean;
+    v_status text;
+BEGIN
+    SELECT *
+    INTO v_row
+    FROM public.b24_fit_dispatch_outbox outbox
+    WHERE outbox.id = NULLIF(current_setting('app.b24_dispatch_id', true), '')::uuid
+      AND public.b24_current_dispatch_fence_valid(outbox.tenant_id, outbox.fit_id)
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'b24_dispatch_recoverable_failure_fence_rejected';
+    END IF;
+
+    v_terminal := COALESCE(v_row.claim_count, 0) >= COALESCE(v_row.max_attempts, 1);
+    v_status := CASE WHEN v_terminal THEN 'failed_terminal' ELSE 'failed_retryable' END;
+
+    UPDATE public.bayesian_model_fits fit
+    SET status = CASE WHEN v_terminal THEN 'failed' ELSE 'queued' END,
+        fallback_applied = CASE WHEN v_terminal THEN true ELSE false END,
+        fallback_reason = CASE
+            WHEN v_terminal THEN COALESCE(NULLIF(p_reason, ''), 'worker_failure')
+            ELSE NULL
+        END,
+        credible_interval_status = CASE
+            WHEN v_terminal THEN 'not_available'
+            ELSE fit.credible_interval_status
+        END,
+        diagnostic_status = CASE
+            WHEN v_terminal THEN 'unavailable'
+            ELSE fit.diagnostic_status
+        END,
+        diagnostic_failure_reason = CASE
+            WHEN v_terminal THEN 'skipped_non_sampled'
+            ELSE fit.diagnostic_failure_reason
+        END,
+        completed_at = CASE WHEN v_terminal THEN now() ELSE NULL END,
+        updated_at = now()
+    WHERE fit.tenant_id = v_row.tenant_id
+      AND fit.id = v_row.fit_id
+      AND fit.status IN ('pending', 'queued', 'running', 'persist_pending');
+
+    UPDATE public.b24_fit_dispatch_outbox outbox
+    SET status = v_status,
+        terminal_reason = LEFT(
+            'recoverable_ack:' || COALESCE(NULLIF(p_reason, ''), 'worker_failure'),
+            512
+        ),
+        lease_owner = NULL,
+        lease_capability_digest = NULL,
+        lease_acquired_at = NULL,
+        lease_expires_at = NULL,
+        last_heartbeat_at = NULL,
+        assigned_worker_generation = NULL,
+        assignment_generation = assignment_generation + 1,
+        assignment_expires_at = NULL,
+        assignment_reason = 'failure_ack_recovery_required',
+        next_recovery_at = now(),
+        completed_at = CASE WHEN v_terminal THEN now() ELSE NULL END,
+        updated_at = now()
+    WHERE outbox.tenant_id = v_row.tenant_id
+      AND outbox.id = v_row.id;
+
+    RETURN v_status;
+END
+$$;
+"""
+
+
+def upgrade() -> None:
+    op.execute(_RECOVERABLE_FAILURE_FUNCTION)
+    for role in ("app_worker", "app_user"):
+        _grant_if_role_exists(
+            role,
+            (
+                "GRANT EXECUTE ON FUNCTION "
+                "public.b24_fail_fit_dispatch_recoverable(text) TO "
+                f"{role}"
+            ),
+        )
+
+
+def downgrade() -> None:
+    op.execute(
+        "DROP FUNCTION IF EXISTS public.b24_fail_fit_dispatch_recoverable(text)"
+    )  # CI:DESTRUCTIVE_OK - rollback removes Directive XIV recoverable failure API.

--- a/backend/app/bayesian/dispatch_authority.py
+++ b/backend/app/bayesian/dispatch_authority.py
@@ -191,6 +191,19 @@ def fail_dispatch_terminal_sync(
     )
 
 
+def fail_dispatch_recoverable_sync(
+    conn, *, lease: BayesianDispatchLease, reason: str
+) -> DispatchClaimOutcome:
+    bind_dispatch_write_context_sync(conn, lease=lease)
+    status = conn.execute(
+        text("SELECT public.b24_fail_fit_dispatch_recoverable(:reason)"),
+        {"reason": reason[:256]},
+    ).scalar_one()
+    if str(status) == "failed_terminal":
+        return DispatchClaimOutcome.TERMINAL_FAILURE
+    return DispatchClaimOutcome.RETRYABLE_INFRASTRUCTURE_FAILURE
+
+
 def create_recovery_wakeups_sync(conn, *, batch_size: int = 25) -> int:
     return int(
         conn.execute(

--- a/backend/app/bayesian/dispatch_outbox.py
+++ b/backend/app/bayesian/dispatch_outbox.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime, timedelta, timezone
 from enum import StrEnum
 from typing import Callable
@@ -77,6 +77,7 @@ class RecoveryOutboxRow:
     payload_hash: str
     recovery_generation: int
     publish_attempt_count: int
+    published_task_id: str | None = None
 
     @property
     def queue_payload(self) -> dict[str, str]:
@@ -494,14 +495,17 @@ async def publish_due_recovery_rows(
         batch_size=batch_size,
         stale_publishing_seconds=stale_publishing_seconds,
     )
+    attempted_rows: list[RecoveryOutboxRow] = []
     for row in rows:
         try:
-            publish(row)
+            published_task_id = publish(row)
         except Exception as exc:
             await mark_recovery_publish_failed(session, row=row, error=str(exc))
+            attempted_rows.append(row)
             continue
         await mark_recovery_published(session, row=row)
-    return rows
+        attempted_rows.append(replace(row, published_task_id=published_task_id))
+    return attempted_rows
 
 
 def lease_due_recovery_rows_sync(
@@ -678,11 +682,14 @@ def publish_due_recovery_rows_sync(
         batch_size=batch_size,
         stale_publishing_seconds=stale_publishing_seconds,
     )
+    attempted_rows: list[RecoveryOutboxRow] = []
     for row in rows:
         try:
-            publish(row)
+            published_task_id = publish(row)
         except Exception as exc:
             mark_recovery_publish_failed_sync(conn, row=row, error=str(exc))
+            attempted_rows.append(row)
             continue
         mark_recovery_published_sync(conn, row=row)
-    return rows
+        attempted_rows.append(replace(row, published_task_id=published_task_id))
+    return attempted_rows

--- a/backend/app/bayesian/fit_execution.py
+++ b/backend/app/bayesian/fit_execution.py
@@ -29,6 +29,7 @@ from app.bayesian.dispatch_authority import (
     bind_dispatch_write_context_sync,
     claim_fit_dispatch_sync,
     complete_dispatch_sync,
+    fail_dispatch_recoverable_sync,
     fail_dispatch_terminal_sync,
     mark_dispatch_running_sync,
 )
@@ -804,23 +805,16 @@ def execute_fit_intent_sync(
                             conn, lease=dispatch_lease, reason=diagnostic_reason
                         )
                 else:
-                    _mark_fit_failure(
-                        conn,
-                        tenant_id=tenant_id,
-                        fit_id=fit_id,
-                        status=FitStatus.FAILED,
-                        fallback_reason=FallbackReason.WORKER_FAILURE,
-                        runtime_seconds=runtime_seconds,
-                        dispatch_lease=dispatch_lease,
-                    )
                     if dispatch_lease is not None:
-                        fail_dispatch_terminal_sync(
+                        fail_dispatch_recoverable_sync(
                             conn,
                             lease=dispatch_lease,
                             reason=FallbackReason.WORKER_FAILURE.value,
                         )
             return {
-                "status": "failed",
+                "status": (
+                    "failed" if diagnostic_reason is not None else "failed_retryable"
+                ),
                 "fallback_reason": (
                     FallbackReason.NO_CONVERGENCE.value
                     if diagnostic_reason is not None

--- a/backend/app/tasks/bayesian.py
+++ b/backend/app/tasks/bayesian.py
@@ -28,8 +28,10 @@ from app.bayesian.dispatch_authority import (
     BayesianDispatchClaim,
     BayesianDispatchLease,
     BayesianWorkerClaimAuthority,
+    DispatchClaimOutcome,
     claim_fit_dispatch_sync,
     create_recovery_wakeups_sync,
+    fail_dispatch_recoverable_sync,
     mark_dispatch_running_sync,
 )
 from app.bayesian.dispatch_outbox import publish_due_recovery_rows_sync
@@ -54,6 +56,9 @@ FEATURE_AUTHORITY_DISPATCH_TASK_NAME = (
     "app.tasks.bayesian.dispatch_feature_authority_build"
 )
 RECOVERY_RECONCILER_TASK_NAME = "app.tasks.bayesian.reconcile_fit_recovery_wakeups"
+RECOVERABLE_FAILURE_ACK_PROBE_TASK_NAME = (
+    "app.tasks.bayesian.probe_recoverable_failure_ack"
+)
 FEATURE_AUTHORITY_DISPATCH_RETRY_BACKOFF_S = 30
 FEATURE_AUTHORITY_MAX_DISPATCH_ATTEMPTS = 5
 
@@ -76,6 +81,7 @@ REQUIRED_BAYESIAN_TASK_NAMES = frozenset(
         "app.tasks.bayesian.run_mcmc_inference",
         "app.tasks.bayesian.execute_fit_intent",
         RECOVERY_RECONCILER_TASK_NAME,
+        RECOVERABLE_FAILURE_ACK_PROBE_TASK_NAME,
         FEATURE_AUTHORITY_DISPATCH_TASK_NAME,
         FEATURE_AUTHORITY_BUILD_TASK_NAME,
         "app.tasks.bayesian.run_resource_contention",
@@ -406,7 +412,97 @@ def execute_fit_intent(
     payload.setdefault(
         "compute_started", payload.get("status") == "sampled_unvalidated"
     )
+    payload.setdefault("dispatch_id", str(claim.dispatch_id))
+    payload.setdefault("fit_id", str(claim.fit_id))
+    payload.setdefault("recovery_generation", int(claim.recovery_generation))
     _append_probe_event({"event": "bayesian_fit_intent_executed", **payload})
+    return payload
+
+
+@_bayesian_task(
+    bind=True,
+    name=RECOVERABLE_FAILURE_ACK_PROBE_TASK_NAME,
+    routing_key="bayesian.task",
+    soft_time_limit=30,
+    time_limit=60,
+    acks_late=True,
+    max_retries=0,
+)
+def probe_recoverable_failure_ack(
+    self,
+    *,
+    dispatch_id: str,
+    fit_id: str,
+    task_name: str,
+    attempt_id: str,
+    payload_hash: str,
+    recovery_generation: str = "0",
+    correlation_id: str,
+) -> dict:
+    """Physically acknowledge a recoverable failure through the Bayesian queue."""
+
+    assert_bayesian_worker_boot_topology_proven()
+    if task_name != BAYESIAN_FIT_EXECUTION_TASK:
+        raise RuntimeError("bayesian_dispatch_task_name_mismatch")
+    claim = BayesianDispatchClaim(
+        dispatch_id=_as_uuid(dispatch_id),
+        fit_id=_as_uuid(fit_id),
+        task_name=task_name,
+        attempt_id=_as_uuid(attempt_id),
+        payload_hash=payload_hash,
+        recovery_generation=int(recovery_generation),
+    )
+    worker_authority = current_bayesian_worker_claim_authority()
+    task_id = str(self.request.id)
+    engine = create_bayesian_worker_engine()
+    try:
+        with engine.begin() as conn:
+            lease = claim_fit_dispatch_sync(
+                conn,
+                claim=claim,
+                worker_authority=worker_authority,
+            )
+            if not isinstance(lease, BayesianDispatchLease):
+                payload = {
+                    "status": str(lease).lower(),
+                    "claim_outcome": str(lease),
+                    "task_id": task_id,
+                    "correlation_id": correlation_id,
+                    "dispatch_id": str(claim.dispatch_id),
+                    "fit_id": str(claim.fit_id),
+                    "compute_started": False,
+                    "worker_generation": worker_authority.generation_id,
+                    "worker_pid": worker_authority.pid,
+                }
+                _append_probe_event(
+                    {"event": "bayesian_recoverable_failure_ack_probe", **payload}
+                )
+                return payload
+            mark_dispatch_running_sync(conn, lease=lease)
+            outcome = fail_dispatch_recoverable_sync(
+                conn,
+                lease=lease,
+                reason="directive_xiv_acknowledged_worker_failure",
+            )
+    finally:
+        engine.dispose()
+    payload = {
+        "status": (
+            "failed_terminal"
+            if outcome is DispatchClaimOutcome.TERMINAL_FAILURE
+            else "failed_retryable"
+        ),
+        "claim_outcome": outcome.value,
+        "task_id": task_id,
+        "correlation_id": correlation_id,
+        "dispatch_id": str(claim.dispatch_id),
+        "fit_id": str(claim.fit_id),
+        "compute_started": False,
+        "worker_generation": worker_authority.generation_id,
+        "worker_pid": worker_authority.pid,
+        "failure_taxonomy": "recoverable_acknowledged_worker_failure",
+    }
+    _append_probe_event({"event": "bayesian_recoverable_failure_ack_probe", **payload})
     return payload
 
 
@@ -445,8 +541,15 @@ def reconcile_fit_recovery_wakeups(
         "status": "ok",
         "task_id": task_id,
         "recovery_wakeups_created": int(created),
-        "recovery_wakeups_published": len(published_rows),
+        "recovery_wakeups_published": sum(
+            1 for row in published_rows if row.published_task_id is not None
+        ),
         "recovery_dispatch_ids": [str(row.dispatch_id) for row in published_rows],
+        "recovery_published_task_ids": [
+            str(row.published_task_id)
+            for row in published_rows
+            if row.published_task_id is not None
+        ],
     }
     logger.info(
         "bayesian_recovery_reconciler_completed",

--- a/backend/tests/test_b24_p9_postgres_runtime.py
+++ b/backend/tests/test_b24_p9_postgres_runtime.py
@@ -35,6 +35,7 @@ from app.bayesian.dispatch_authority import (
     claim_fit_dispatch_sync,
     complete_dispatch_sync,
     dispatch_payload_hash,
+    fail_dispatch_recoverable_sync,
     mark_dispatch_running_sync,
     register_worker_process_authority_sync,
 )
@@ -329,6 +330,20 @@ def _read_log(path: Path) -> str:
     return path.read_text(encoding="utf-8", errors="replace")
 
 
+def _read_probe_events(path: Path) -> list[dict[str, object]]:
+    events: list[dict[str, object]] = []
+    if not path.exists():
+        return events
+    for line in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        try:
+            payload = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(payload, dict):
+            events.append(payload)
+    return events
+
+
 def _wait_for_log(path: Path, token: str, *, timeout_s: float = 20.0) -> str:
     deadline = time.monotonic() + timeout_s
     while time.monotonic() < deadline:
@@ -337,6 +352,132 @@ def _wait_for_log(path: Path, token: str, *, timeout_s: float = 20.0) -> str:
             return text
         time.sleep(0.25)
     return _read_log(path)
+
+
+def _wait_for_probe_event(
+    path: Path, event_name: str, *, timeout_s: float = 30.0
+) -> dict[str, object]:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        for event in _read_probe_events(path):
+            if event.get("event") == event_name:
+                return event
+        time.sleep(0.25)
+    events = _read_probe_events(path)
+    raise AssertionError(f"probe event {event_name!r} not observed; events={events!r}")
+
+
+def _wait_for_probe_event_matching(
+    path: Path,
+    event_name: str,
+    *,
+    predicate,
+    timeout_s: float = 30.0,
+) -> dict[str, object]:
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        for event in _read_probe_events(path):
+            if event.get("event") == event_name and predicate(event):
+                return event
+        time.sleep(0.25)
+    events = _read_probe_events(path)
+    raise AssertionError(
+        f"probe event {event_name!r} matching predicate not observed; events={events!r}"
+    )
+
+
+def _poll_dispatch_state(
+    sync_engine,
+    *,
+    tenant_id: UUID,
+    dispatch_id: UUID,
+    expected,
+    timeout_s: float = 30.0,
+) -> dict[str, object]:
+    deadline = time.monotonic() + timeout_s
+    last_state: dict[str, object] | None = None
+    while time.monotonic() < deadline:
+        with sync_engine.begin() as conn:
+            _set_tenant_context(conn, tenant_id)
+            row = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT
+                            dispatch.status AS dispatch_status,
+                            dispatch.fit_id,
+                            dispatch.attempt_id,
+                            dispatch.recovery_generation,
+                            dispatch.claim_count,
+                            dispatch.lease_owner,
+                            dispatch.assignment_reason,
+                            dispatch.assignment_expires_at,
+                            dispatch.terminal_reason,
+                            fit.status AS fit_status,
+                            COUNT(recovery.id) AS recovery_rows,
+                            COALESCE(MAX(recovery.status), '') AS recovery_status,
+                            COALESCE(MAX(recovery.publish_attempt_count), 0)
+                                AS recovery_publish_attempt_count
+                        FROM public.b24_fit_dispatch_outbox dispatch
+                        JOIN public.bayesian_model_fits fit
+                          ON fit.tenant_id = dispatch.tenant_id
+                         AND fit.id = dispatch.fit_id
+                        LEFT JOIN public.b24_fit_recovery_outbox recovery
+                          ON recovery.tenant_id = dispatch.tenant_id
+                         AND recovery.dispatch_id = dispatch.id
+                        WHERE dispatch.tenant_id = :tenant_id
+                          AND dispatch.id = :dispatch_id
+                        GROUP BY
+                            dispatch.status,
+                            dispatch.fit_id,
+                            dispatch.attempt_id,
+                            dispatch.recovery_generation,
+                            dispatch.claim_count,
+                            dispatch.lease_owner,
+                            dispatch.assignment_reason,
+                            dispatch.assignment_expires_at,
+                            dispatch.terminal_reason,
+                            fit.status
+                        """
+                    ),
+                    {
+                        "tenant_id": str(tenant_id),
+                        "dispatch_id": str(dispatch_id),
+                    },
+                )
+                .mappings()
+                .one()
+            )
+            last_state = dict(row)
+        if expected(last_state):
+            return last_state
+        time.sleep(0.25)
+    raise AssertionError(f"dispatch state did not match: {last_state!r}")
+
+
+def _assert_dispatch_state_remains(
+    sync_engine,
+    *,
+    tenant_id: UUID,
+    dispatch_id: UUID,
+    expected,
+    duration_s: float = 2.5,
+) -> dict[str, object]:
+    deadline = time.monotonic() + duration_s
+    last_state: dict[str, object] | None = None
+    while time.monotonic() < deadline:
+        state = _poll_dispatch_state(
+            sync_engine,
+            tenant_id=tenant_id,
+            dispatch_id=dispatch_id,
+            expected=lambda row: True,
+            timeout_s=0.1,
+        )
+        last_state = state
+        assert expected(state), state
+        time.sleep(0.25)
+    assert last_state is not None
+    return last_state
 
 
 def _backend_state(observer, pid: int) -> dict[str, object] | None:
@@ -1812,6 +1953,468 @@ async def test_b24_p9_directive_xiii_shared_recovery_claim_liveness(
                 )
                 == DispatchClaimOutcome.ACTIVE_LEASE
             )
+    finally:
+        sync_engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_b24_p9_directive_xiv_failure_ack_revokes_stale_authority(
+    test_tenant_pair,
+) -> None:
+    await _assert_table_exists("b24_fit_dispatch_outbox")
+    tenant_a, _tenant_b = test_tenant_pair
+    fit_id = uuid4()
+    dispatch_id = uuid4()
+    attempt_id = uuid4()
+    payload_hash = dispatch_payload_hash(fit_id=fit_id)
+    await _insert_fit(tenant_a, fit_id=fit_id, source_hash="4" * 64)
+
+    sync_engine = create_engine(
+        to_sync_postgres_dsn(get_database_url()),
+        poolclass=NullPool,
+    )
+    try:
+        with sync_engine.begin() as conn:
+            worker_authority = _register_test_worker_authority(
+                conn,
+                generation_id="directive-xiv-failure-ack-generation",
+                pid=4260,
+                process_token="directive-xiv-failure-ack-token",
+            )
+            _set_tenant_context(conn, tenant_a)
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO public.b24_fit_dispatch_outbox (
+                        tenant_id,
+                        id,
+                        fit_id,
+                        dispatch_key,
+                        task_name,
+                        attempt_id,
+                        payload_hash,
+                        assigned_worker_generation,
+                        assignment_generation,
+                        assignment_expires_at,
+                        assignment_reason,
+                        recovery_generation,
+                        status,
+                        next_attempt_at,
+                        next_recovery_at
+                    )
+                    VALUES (
+                        :tenant_id,
+                        :dispatch_id,
+                        :fit_id,
+                        :dispatch_key,
+                        :task_name,
+                        :attempt_id,
+                        :payload_hash,
+                        NULL,
+                        1,
+                        now() + interval '10 minutes',
+                        'recovery_shared_eligible',
+                        1,
+                        'dispatched',
+                        now(),
+                        now() + interval '10 minutes'
+                    )
+                    """
+                ),
+                {
+                    "tenant_id": str(tenant_a),
+                    "dispatch_id": str(dispatch_id),
+                    "fit_id": str(fit_id),
+                    "dispatch_key": f"b24-p9-xiv-failure-ack:{tenant_a}:{fit_id}",
+                    "task_name": BAYESIAN_FIT_EXECUTION_TASK,
+                    "attempt_id": str(attempt_id),
+                    "payload_hash": payload_hash,
+                },
+            )
+
+        claim = BayesianDispatchClaim(
+            dispatch_id=dispatch_id,
+            fit_id=fit_id,
+            task_name=BAYESIAN_FIT_EXECUTION_TASK,
+            attempt_id=attempt_id,
+            payload_hash=payload_hash,
+            recovery_generation=1,
+        )
+        with sync_engine.begin() as conn:
+            lease = claim_fit_dispatch_sync(
+                conn,
+                claim=claim,
+                worker_authority=worker_authority,
+                lease_seconds=120,
+            )
+            assert isinstance(lease, BayesianDispatchLease)
+            mark_dispatch_running_sync(conn, lease=lease)
+            outcome = fail_dispatch_recoverable_sync(
+                conn,
+                lease=lease,
+                reason="directive_xiv_acknowledged_worker_failure",
+            )
+            assert outcome is DispatchClaimOutcome.RETRYABLE_INFRASTRUCTURE_FAILURE
+
+        with sync_engine.begin() as conn:
+            _set_tenant_context(conn, tenant_a)
+            bind_dispatch_write_context_sync(conn, lease=lease)
+            with pytest.raises(DBAPIError, match="b24_dispatch_fence_rejected"):
+                conn.execute(
+                    text(
+                        """
+                        UPDATE public.bayesian_model_fits
+                        SET updated_at = now()
+                        WHERE tenant_id = :tenant_id
+                          AND id = :fit_id
+                        """
+                    ),
+                    {"tenant_id": str(tenant_a), "fit_id": str(fit_id)},
+                )
+
+        with sync_engine.begin() as conn:
+            assert (
+                claim_fit_dispatch_sync(
+                    conn,
+                    claim=claim,
+                    worker_authority=worker_authority,
+                )
+                == DispatchClaimOutcome.UNAUTHORIZED
+            )
+            count = conn.execute(
+                text("SELECT public.b24_create_fit_recovery_wakeups(10)")
+            ).scalar_one()
+            assert int(count) == 1
+
+        with sync_engine.begin() as conn:
+            _set_tenant_context(conn, tenant_a)
+            state = (
+                conn.execute(
+                    text(
+                        """
+                        SELECT
+                            dispatch.status,
+                            dispatch.attempt_id,
+                            dispatch.recovery_generation,
+                            dispatch.assignment_reason,
+                            fit.status AS fit_status
+                        FROM public.b24_fit_dispatch_outbox dispatch
+                        JOIN public.bayesian_model_fits fit
+                          ON fit.tenant_id = dispatch.tenant_id
+                         AND fit.id = dispatch.fit_id
+                        WHERE dispatch.tenant_id = :tenant_id
+                          AND dispatch.id = :dispatch_id
+                        """
+                    ),
+                    {
+                        "tenant_id": str(tenant_a),
+                        "dispatch_id": str(dispatch_id),
+                    },
+                )
+                .mappings()
+                .one()
+            )
+            assert state["status"] == "stale_recovered"
+            assert state["attempt_id"] != attempt_id
+            assert int(state["recovery_generation"]) == 2
+            assert state["assignment_reason"] == "stale_recovery"
+            assert state["fit_status"] == "queued"
+            recovered_attempt_id = state["attempt_id"]
+
+        recovered_claim = BayesianDispatchClaim(
+            dispatch_id=dispatch_id,
+            fit_id=fit_id,
+            task_name=BAYESIAN_FIT_EXECUTION_TASK,
+            attempt_id=recovered_attempt_id,
+            payload_hash=payload_hash,
+            recovery_generation=2,
+        )
+        wrong_payload_claim = BayesianDispatchClaim(
+            dispatch_id=dispatch_id,
+            fit_id=fit_id,
+            task_name=BAYESIAN_FIT_EXECUTION_TASK,
+            attempt_id=recovered_attempt_id,
+            payload_hash="0" * 64,
+            recovery_generation=2,
+        )
+        with sync_engine.begin() as conn:
+            rows = publish_due_recovery_rows_sync(conn, batch_size=10)
+            assert len(rows) == 1
+            assert (
+                claim_fit_dispatch_sync(
+                    conn,
+                    claim=wrong_payload_claim,
+                    worker_authority=worker_authority,
+                )
+                == DispatchClaimOutcome.UNAUTHORIZED
+            )
+            lease = claim_fit_dispatch_sync(
+                conn,
+                claim=recovered_claim,
+                worker_authority=worker_authority,
+                lease_seconds=120,
+            )
+            assert isinstance(lease, BayesianDispatchLease)
+            assert lease.outcome is DispatchClaimOutcome.RECLAIMED
+    finally:
+        sync_engine.dispose()
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_b24_p9_directive_xiv_broker_backed_failure_ack_recovery(
+    test_tenant_pair,
+    tmp_path: Path,
+) -> None:
+    await _assert_table_exists("b24_fit_dispatch_outbox")
+    await _assert_table_exists("b24_fit_recovery_outbox")
+    tenant_a, _tenant_b = test_tenant_pair
+    fit_id = uuid4()
+    dispatch_id = uuid4()
+    attempt_id = uuid4()
+    correlation_id = uuid4()
+    payload_hash = dispatch_payload_hash(fit_id=fit_id)
+    await _insert_fit(tenant_a, fit_id=fit_id, source_hash="3" * 64)
+
+    sync_engine = create_engine(
+        to_sync_postgres_dsn(get_database_url()),
+        poolclass=NullPool,
+    )
+    try:
+        with sync_engine.begin() as conn:
+            _set_tenant_context(conn, tenant_a)
+            conn.execute(
+                text(
+                    """
+                    INSERT INTO public.b24_fit_dispatch_outbox (
+                        tenant_id,
+                        id,
+                        fit_id,
+                        dispatch_key,
+                        task_name,
+                        attempt_id,
+                        payload_hash,
+                        assigned_worker_generation,
+                        assignment_generation,
+                        assignment_expires_at,
+                        assignment_reason,
+                        recovery_generation,
+                        status,
+                        next_attempt_at,
+                        next_recovery_at
+                    )
+                    VALUES (
+                        :tenant_id,
+                        :dispatch_id,
+                        :fit_id,
+                        :dispatch_key,
+                        :task_name,
+                        :attempt_id,
+                        :payload_hash,
+                        NULL,
+                        1,
+                        now() + interval '10 minutes',
+                        'recovery_shared_eligible',
+                        1,
+                        'dispatched',
+                        now(),
+                        now() + interval '10 minutes'
+                    )
+                    """
+                ),
+                {
+                    "tenant_id": str(tenant_a),
+                    "dispatch_id": str(dispatch_id),
+                    "fit_id": str(fit_id),
+                    "dispatch_key": f"b24-p9-xiv-broker:{tenant_a}:{fit_id}",
+                    "task_name": BAYESIAN_FIT_EXECUTION_TASK,
+                    "attempt_id": str(attempt_id),
+                    "payload_hash": payload_hash,
+                },
+            )
+
+        from app.celery_app import celery_app
+        from app.core.queues import QUEUE_BAYESIAN
+        from app.tasks.bayesian import (
+            RECOVERABLE_FAILURE_ACK_PROBE_TASK_NAME,
+            RECOVERY_RECONCILER_TASK_NAME,
+        )
+
+        original_eager = celery_app.conf.task_always_eager
+        celery_app.conf.task_always_eager = False
+        worker_log = tmp_path / "p9_xiv_failure_ack_worker.log"
+        probe_log = tmp_path / "p9_xiv_failure_ack_probe.jsonl"
+        worker_env = _worker_env(include_bayesian_tasks=True, log_path=probe_log)
+        worker_env["B24_BAYESIAN_WORKSPACE_ROOT"] = str(tmp_path / "workspaces")
+        worker_env["B24_PYTENSOR_ROOT"] = str(tmp_path / "compiledirs")
+        worker_log_handle = worker_log.open("w", encoding="utf-8", buffering=1)
+        process: subprocess.Popen[str] | None = None
+        try:
+            assert celery_app.conf.task_always_eager is False
+            broker_url = str(celery_app.conf.broker_url)
+            assert "postgresql://" in broker_url
+            assert "memory://" not in broker_url
+
+            ack_probe_result = celery_app.send_task(
+                RECOVERABLE_FAILURE_ACK_PROBE_TASK_NAME,
+                kwargs={
+                    "dispatch_id": str(dispatch_id),
+                    "fit_id": str(fit_id),
+                    "task_name": BAYESIAN_FIT_EXECUTION_TASK,
+                    "attempt_id": str(attempt_id),
+                    "payload_hash": payload_hash,
+                    "recovery_generation": "1",
+                    "correlation_id": str(correlation_id),
+                },
+                queue=QUEUE_BAYESIAN,
+                routing_key=f"{QUEUE_BAYESIAN}.task",
+            )
+            no_worker_state = _assert_dispatch_state_remains(
+                sync_engine,
+                tenant_id=tenant_a,
+                dispatch_id=dispatch_id,
+                expected=lambda row: row["dispatch_status"] == "dispatched"
+                and int(row["claim_count"]) == 0
+                and int(row["recovery_rows"]) == 0,
+                duration_s=2.5,
+            )
+            assert no_worker_state["fit_status"] == "queued"
+            assert no_worker_state["assignment_reason"] == "recovery_shared_eligible"
+
+            process = subprocess.Popen(
+                [
+                    sys.executable,
+                    "-m",
+                    "celery",
+                    "-A",
+                    "app.celery_app.celery_app",
+                    "worker",
+                    "-P",
+                    "solo",
+                    "-c",
+                    "1",
+                    "-Q",
+                    QUEUE_BAYESIAN,
+                    "--loglevel=INFO",
+                    "--without-gossip",
+                    "--without-mingle",
+                    "--without-heartbeat",
+                ],
+                cwd=ROOT / "backend",
+                env=worker_env,
+                text=True,
+                stdout=worker_log_handle,
+                stderr=subprocess.STDOUT,
+            )
+            ready_log = _wait_for_log(worker_log, " ready", timeout_s=90)
+            worker_log_handle.flush()
+            assert process.poll() is None, ready_log
+            assert " ready" in ready_log
+            assert f".> {QUEUE_BAYESIAN}" in ready_log
+
+            ack_event = _wait_for_probe_event(
+                probe_log,
+                "bayesian_recoverable_failure_ack_probe",
+                timeout_s=90,
+            )
+            assert ack_event["task_id"] == str(ack_probe_result.id)
+            assert ack_event["correlation_id"] == str(correlation_id)
+            assert ack_event["dispatch_id"] == str(dispatch_id)
+            assert ack_event["failure_taxonomy"] == (
+                "recoverable_acknowledged_worker_failure"
+            )
+            assert ack_event["worker_generation"]
+            assert int(ack_event["worker_pid"]) > 0
+
+            failure_ack_state = _poll_dispatch_state(
+                sync_engine,
+                tenant_id=tenant_a,
+                dispatch_id=dispatch_id,
+                expected=lambda row: row["dispatch_status"] == "failed_retryable"
+                and row["fit_status"] == "queued"
+                and row["assignment_reason"] == "failure_ack_recovery_required"
+                and int(row["claim_count"]) == 1
+                and int(row["recovery_rows"]) == 0,
+                timeout_s=30,
+            )
+            assert failure_ack_state["assignment_expires_at"] is None
+
+            stale_claim = BayesianDispatchClaim(
+                dispatch_id=dispatch_id,
+                fit_id=fit_id,
+                task_name=BAYESIAN_FIT_EXECUTION_TASK,
+                attempt_id=attempt_id,
+                payload_hash=payload_hash,
+                recovery_generation=1,
+            )
+            with sync_engine.begin() as conn:
+                stale_authority = _register_test_worker_authority(
+                    conn,
+                    generation_id="directive-xiv-stale-duplicate-generation",
+                    pid=4261,
+                    process_token="directive-xiv-stale-duplicate-token",
+                )
+                assert (
+                    claim_fit_dispatch_sync(
+                        conn,
+                        claim=stale_claim,
+                        worker_authority=stale_authority,
+                    )
+                    == DispatchClaimOutcome.UNAUTHORIZED
+                )
+
+            recovery_result = celery_app.send_task(
+                RECOVERY_RECONCILER_TASK_NAME,
+                kwargs={"batch_size": 10, "stale_publishing_seconds": 1},
+                queue=QUEUE_BAYESIAN,
+                routing_key=f"{QUEUE_BAYESIAN}.task",
+            )
+            recovery_event = _wait_for_probe_event(
+                probe_log,
+                "bayesian_recovery_reconciler_completed",
+                timeout_s=90,
+            )
+            assert recovery_event["task_id"] == str(recovery_result.id)
+            assert recovery_event["recovery_wakeups_created"] >= 1
+            assert recovery_event["recovery_wakeups_published"] >= 1
+            assert str(dispatch_id) in recovery_event["recovery_dispatch_ids"]
+            published_task_ids = recovery_event["recovery_published_task_ids"]
+            assert isinstance(published_task_ids, list)
+            assert published_task_ids
+
+            executed_event = _wait_for_probe_event_matching(
+                probe_log,
+                "bayesian_fit_intent_executed",
+                predicate=lambda event: event.get("dispatch_id") == str(dispatch_id)
+                and event.get("task_id") in published_task_ids,
+                timeout_s=90,
+            )
+            assert executed_event["task_id"] in published_task_ids
+            assert executed_event["dispatch_id"] == str(dispatch_id)
+            assert executed_event["compute_started"] is False
+
+            final_state = _poll_dispatch_state(
+                sync_engine,
+                tenant_id=tenant_a,
+                dispatch_id=dispatch_id,
+                expected=lambda row: row["dispatch_status"]
+                in {"completed", "failed_terminal", "failed_retryable"}
+                and int(row["recovery_rows"]) >= 1
+                and row["recovery_status"] == "published"
+                and int(row["recovery_publish_attempt_count"]) >= 1
+                and int(row["recovery_generation"]) == 2
+                and int(row["claim_count"]) >= 2,
+                timeout_s=30,
+            )
+            assert final_state["assignment_reason"] == "recovery_shared_eligible"
+            if final_state["dispatch_status"] != "failed_retryable":
+                assert final_state["lease_owner"]
+        finally:
+            celery_app.conf.task_always_eager = original_eager
+            if process is not None:
+                _terminate_worker(process)
+            worker_log_handle.close()
     finally:
         sync_engine.dispose()
 

--- a/backend/tests/test_b24_p9_worker_tenant_hygiene.py
+++ b/backend/tests/test_b24_p9_worker_tenant_hygiene.py
@@ -379,7 +379,7 @@ def test_b24_p9_celery_worker_init_runs_boot_probe_before_ready_and_prerun() -> 
     assert "task_prerun" not in boot_probe
     assert "if _BAYESIAN_TASKS_REGISTERED:" in tasks
     assert "ensure_bayesian_worker_boot_probe_signal_registered()" in tasks
-    assert tasks.count("assert_bayesian_worker_boot_topology_proven()") >= 6
+    assert tasks.count("assert_bayesian_worker_boot_topology_proven()") >= 8
 
 
 def test_b24_p9_non_bayesian_worker_registry_excludes_bayesian_tasks() -> None:
@@ -852,6 +852,7 @@ def test_b24_p9_directive_x_dispatch_authority_is_broker_independent() -> None:
         "BayesianWorkerClaimAuthority",
         "claim_fit_dispatch_sync",
         "bind_dispatch_write_context_sync",
+        "fail_dispatch_recoverable_sync",
         "register_worker_process_authority_sync",
     ):
         assert token in authority
@@ -910,10 +911,14 @@ def test_b24_p9_directive_xi_recovery_scheduler_is_production_wired() -> None:
         in tasks
     )
     assert "RECOVERY_RECONCILER_TASK_NAME" in tasks
+    assert "RECOVERABLE_FAILURE_ACK_PROBE_TASK_NAME" in tasks
     assert "create_recovery_wakeups_sync(conn, batch_size=batch_size)" in tasks
     assert "publish_due_recovery_rows_sync(" in tasks
+    assert "probe_recoverable_failure_ack" in tasks
+    assert "fail_dispatch_recoverable_sync(" in tasks
     assert "assert_bayesian_worker_boot_topology_proven()" in tasks
     assert '"event_type": "bayesian.recovery"' in tasks
+    assert "recovery_published_task_ids" in tasks
 
     assert '"b24-p9-bayesian-recovery-reconciler"' in beat
     assert '"task": "app.tasks.bayesian.reconcile_fit_recovery_wakeups"' in beat
@@ -928,6 +933,7 @@ def test_b24_p9_directive_xi_recovery_scheduler_is_production_wired() -> None:
     assert "lease_due_recovery_rows_sync" in outbox
     assert "mark_recovery_published_sync" in outbox
     assert "mark_recovery_publish_failed_sync" in outbox
+    assert "published_task_id" in outbox
     assert "app.b24_recovery_reconciler" in outbox
     assert "app.b24_dispatch_claim_access" in outbox
     assert "status = 'publishing'" in outbox

--- a/db/schema/canonical_schema.sql
+++ b/db/schema/canonical_schema.sql
@@ -395,6 +395,84 @@ CREATE FUNCTION public.b24_enforce_dispatch_fence() RETURNS trigger
 
 
 --
+-- Name: b24_fail_fit_dispatch_recoverable(text); Type: FUNCTION; Schema: public; Owner: -
+--
+
+CREATE FUNCTION public.b24_fail_fit_dispatch_recoverable(p_reason text) RETURNS text
+    LANGUAGE plpgsql SECURITY DEFINER
+    SET search_path TO 'public', 'pg_temp'
+    AS $$
+DECLARE
+    v_row record;
+    v_terminal boolean;
+    v_status text;
+BEGIN
+    SELECT *
+    INTO v_row
+    FROM b24_fit_dispatch_outbox outbox
+    WHERE outbox.id = NULLIF(current_setting('app.b24_dispatch_id', true), '')::uuid
+      AND b24_current_dispatch_fence_valid(outbox.tenant_id, outbox.fit_id)
+    FOR UPDATE;
+
+    IF NOT FOUND THEN
+        RAISE EXCEPTION 'b24_dispatch_recoverable_failure_fence_rejected';
+    END IF;
+
+    v_terminal := COALESCE(v_row.claim_count, 0) >= COALESCE(v_row.max_attempts, 1);
+    v_status := CASE WHEN v_terminal THEN 'failed_terminal' ELSE 'failed_retryable' END;
+
+    UPDATE public.bayesian_model_fits fit
+    SET status = CASE WHEN v_terminal THEN 'failed' ELSE 'queued' END,
+        fallback_applied = CASE WHEN v_terminal THEN true ELSE false END,
+        fallback_reason = CASE
+            WHEN v_terminal THEN COALESCE(NULLIF(p_reason, ''), 'worker_failure')
+            ELSE NULL
+        END,
+        credible_interval_status = CASE
+            WHEN v_terminal THEN 'not_available'
+            ELSE fit.credible_interval_status
+        END,
+        diagnostic_status = CASE
+            WHEN v_terminal THEN 'unavailable'
+            ELSE fit.diagnostic_status
+        END,
+        diagnostic_failure_reason = CASE
+            WHEN v_terminal THEN 'skipped_non_sampled'
+            ELSE fit.diagnostic_failure_reason
+        END,
+        completed_at = CASE WHEN v_terminal THEN now() ELSE NULL END,
+        updated_at = now()
+    WHERE fit.tenant_id = v_row.tenant_id
+      AND fit.id = v_row.fit_id
+      AND fit.status IN ('pending', 'queued', 'running', 'persist_pending');
+
+    UPDATE public.b24_fit_dispatch_outbox outbox
+    SET status = v_status,
+        terminal_reason = LEFT(
+            'recoverable_ack:' || COALESCE(NULLIF(p_reason, ''), 'worker_failure'),
+            512
+        ),
+        lease_owner = NULL,
+        lease_capability_digest = NULL,
+        lease_acquired_at = NULL,
+        lease_expires_at = NULL,
+        last_heartbeat_at = NULL,
+        assigned_worker_generation = NULL,
+        assignment_generation = assignment_generation + 1,
+        assignment_expires_at = NULL,
+        assignment_reason = 'failure_ack_recovery_required',
+        next_recovery_at = now(),
+        completed_at = CASE WHEN v_terminal THEN now() ELSE NULL END,
+        updated_at = now()
+    WHERE outbox.tenant_id = v_row.tenant_id
+      AND outbox.id = v_row.id;
+
+    RETURN v_status;
+END
+$$;
+
+
+--
 -- Name: b24_fail_fit_dispatch_terminal(text); Type: FUNCTION; Schema: public; Owner: -
 --
 

--- a/scripts/ci/validate_b24_p9_worker_tenant_hygiene.py
+++ b/scripts/ci/validate_b24_p9_worker_tenant_hygiene.py
@@ -39,6 +39,9 @@ P9_DIRECTIVE_X_MIGRATION = Path(
 P9_DIRECTIVE_XIII_MIGRATION = Path(
     "alembic/versions/007_skeldir_foundation/202606201300_b24_p9_directive_xiii_shared_recovery.py"
 )
+P9_DIRECTIVE_XIV_MIGRATION = Path(
+    "alembic/versions/007_skeldir_foundation/202606201430_b24_p9_directive_xiv_failure_ack_recovery.py"
+)
 P9_TESTS = Path("backend/tests/test_b24_p9_worker_tenant_hygiene.py")
 P9_DB_TESTS = Path("backend/tests/test_b24_p9_postgres_runtime.py")
 WORKFLOW = Path(".github/workflows/b2_4-gate-dry-run.yml")
@@ -72,6 +75,7 @@ REQUIRED_FILES = {
     P9_DIRECTIVE_IX_MIGRATION,
     P9_DIRECTIVE_X_MIGRATION,
     P9_DIRECTIVE_XIII_MIGRATION,
+    P9_DIRECTIVE_XIV_MIGRATION,
     P9_TESTS,
     P9_DB_TESTS,
     WORKFLOW,
@@ -280,7 +284,7 @@ def validate_bayesian_worker_boot_probe(
         "P9 Bayesian task module must register boot probe signal only when tasks are registered",
     )
     _require(
-        tasks.count("assert_bayesian_worker_boot_topology_proven()") >= 7,
+        tasks.count("assert_bayesian_worker_boot_topology_proven()") >= 8,
         "P9 Bayesian task entries must fail closed on missing boot proof",
     )
     for token in (
@@ -302,7 +306,7 @@ def validate_bayesian_worker_boot_probe(
             f"P9 Bayesian task registration still depends on topology env: {forbidden}",
         )
     _require(
-        tasks.count("@_bayesian_task(") >= 6,
+        tasks.count("@_bayesian_task(") >= 8,
         "P9 Bayesian task entries must use the structural task-registration gate",
     )
     _require(
@@ -489,11 +493,13 @@ def validate_directive_ix_dispatch_authority(
         + _read(P9_DIRECTIVE_X_MIGRATION)
         + "\n"
         + _read(P9_DIRECTIVE_XIII_MIGRATION)
+        + "\n"
+        + _read(P9_DIRECTIVE_XIV_MIGRATION)
     )
     current_migration = (
         migration_text
         if migration_text is not None
-        else _read(P9_DIRECTIVE_XIII_MIGRATION)
+        else _read(P9_DIRECTIVE_XIV_MIGRATION)
     )
     models = models_text if models_text is not None else _read(MODELS)
     for token in (
@@ -515,6 +521,7 @@ def validate_directive_ix_dispatch_authority(
         "claim_fit_dispatch_sync",
         "bind_dispatch_write_context_sync",
         "create_recovery_wakeups_sync",
+        "fail_dispatch_recoverable_sync",
         "register_worker_process_authority_sync",
     ):
         _require(token in authority, f"Directive IX authority missing: {token}")
@@ -526,6 +533,7 @@ def validate_directive_ix_dispatch_authority(
         "lease_due_recovery_rows_sync",
         "mark_recovery_published_sync",
         "mark_recovery_publish_failed_sync",
+        "published_task_id",
         "DEFAULT_STALE_RECOVERY_PUBLISHING_SECONDS = 300",
         "app.b24_recovery_reconciler",
         "app.b24_dispatch_claim_access",
@@ -552,9 +560,14 @@ def validate_directive_ix_dispatch_authority(
         "dispatch_claim=claim",
         "worker_authority=worker_authority",
         "RECOVERY_RECONCILER_TASK_NAME",
+        "RECOVERABLE_FAILURE_ACK_PROBE_TASK_NAME",
         "create_recovery_wakeups_sync(conn, batch_size=batch_size)",
         "publish_due_recovery_rows_sync(",
+        "probe_recoverable_failure_ack",
+        "fail_dispatch_recoverable_sync(",
+        "bayesian_recoverable_failure_ack_probe",
         "bayesian_recovery_reconciler_completed",
+        "recovery_published_task_ids",
         "fit_id: str",
     ):
         _require(token in tasks, f"Directive IX Celery task missing: {token}")
@@ -598,6 +611,9 @@ def validate_directive_ix_dispatch_authority(
         "b24_mark_fit_dispatch_running",
         "b24_complete_fit_dispatch",
         "b24_fail_fit_dispatch_terminal",
+        "b24_fail_fit_dispatch_recoverable",
+        "failure_ack_recovery_required",
+        "recoverable_ack:",
         "b24_create_fit_recovery_wakeups",
         "b24_fit_recovery_outbox",
         "ENABLE ROW LEVEL SECURITY",
@@ -657,13 +673,15 @@ def validate_artifact_authority(
 
 
 def validate_tests_and_ci(
+    p9_tests_text: str | None = None,
+    p9_db_tests_text: str | None = None,
     workflow_text: str | None = None,
     ci_workflow_text: str | None = None,
     b07_p5_timeout_test_text: str | None = None,
     required_status_text: str | None = None,
 ) -> None:
-    tests = _read(P9_TESTS)
-    db_tests = _read(P9_DB_TESTS)
+    tests = p9_tests_text if p9_tests_text is not None else _read(P9_TESTS)
+    db_tests = p9_db_tests_text if p9_db_tests_text is not None else _read(P9_DB_TESTS)
     workflow = workflow_text if workflow_text is not None else _read(WORKFLOW)
     ci_workflow = (
         ci_workflow_text if ci_workflow_text is not None else _read(CI_WORKFLOW)
@@ -734,10 +752,16 @@ def validate_tests_and_ci(
         "test_b24_p9_directive_xi_stale_publishing_recovery_quarantines",
         "test_b24_p9_directive_xiii_shared_recovery_claim_liveness",
         "test_b24_p9_directive_xiii_broker_backed_recovery_liveness",
+        "test_b24_p9_directive_xiv_failure_ack_revokes_stale_authority",
+        "test_b24_p9_directive_xiv_broker_backed_failure_ack_recovery",
         "celery_app.conf.task_always_eager = False",
         "assert celery_app.conf.task_always_eager is False",
+        "bayesian_recoverable_failure_ack_probe",
         "bayesian_recovery_reconciler_completed",
         "bayesian_fit_intent_executed",
+        "_assert_dispatch_state_remains",
+        "failure_ack_recovery_required",
+        "recovery_published_task_ids",
         "recovery_shared_eligible",
         "postgresql://",
         "memory://",
@@ -1065,6 +1089,8 @@ def run_negative_controls() -> None:
                 + _read(P9_DIRECTIVE_X_MIGRATION)
                 + "\n"
                 + _read(P9_DIRECTIVE_XIII_MIGRATION)
+                + "\n"
+                + _read(P9_DIRECTIVE_XIV_MIGRATION)
                 + "\nPERFORM set_config('app.b24_dispatch_fence_required', 'on', true);\n"
             ),
             "caller-controlled GUC",
@@ -1078,6 +1104,8 @@ def run_negative_controls() -> None:
                     + _read(P9_DIRECTIVE_X_MIGRATION)
                     + "\n"
                     + _read(P9_DIRECTIVE_XIII_MIGRATION)
+                    + "\n"
+                    + _read(P9_DIRECTIVE_XIV_MIGRATION)
                 ).replace(
                     "p_worker_process_token text",
                     "p_worker_process_token_removed text",
@@ -1101,9 +1129,77 @@ def run_negative_controls() -> None:
                         "v_shared_recovery_eligible",
                         "v_specific_replacement_only",
                     )
+                    + "\n"
+                    + _read(P9_DIRECTIVE_XIV_MIGRATION)
                 ),
             ),
             "recovery_shared_eligible",
+        ),
+        (
+            "directive_xiv_recoverable_failure_api_removed",
+            lambda: validate_directive_ix_dispatch_authority(
+                authority_text=_read(DISPATCH_AUTHORITY).replace(
+                    "fail_dispatch_recoverable_sync",
+                    "fail_dispatch_recoverable_removed",
+                ),
+                migration_text=(
+                    _read(P9_DIRECTIVE_IX_MIGRATION)
+                    + "\n"
+                    + _read(P9_DIRECTIVE_X_MIGRATION)
+                    + "\n"
+                    + _read(P9_DIRECTIVE_XIII_MIGRATION)
+                    + "\n"
+                    + _read(P9_DIRECTIVE_XIV_MIGRATION).replace(
+                        "b24_fail_fit_dispatch_recoverable",
+                        "b24_fail_fit_dispatch_recoverable_removed",
+                    )
+                ),
+            ),
+            "recoverable",
+        ),
+        (
+            "directive_xiv_failure_ack_assignment_revocation_removed",
+            lambda: validate_directive_ix_dispatch_authority(
+                migration_text=(
+                    _read(P9_DIRECTIVE_IX_MIGRATION)
+                    + "\n"
+                    + _read(P9_DIRECTIVE_X_MIGRATION)
+                    + "\n"
+                    + _read(P9_DIRECTIVE_XIII_MIGRATION)
+                    + "\n"
+                    + _read(P9_DIRECTIVE_XIV_MIGRATION).replace(
+                        "failure_ack_recovery_required",
+                        "initial_dispatch",
+                    )
+                ),
+            ),
+            "failure_ack",
+        ),
+        (
+            "directive_xiv_recovery_task_correlation_removed",
+            lambda: validate_directive_ix_dispatch_authority(
+                outbox_text=_read(DISPATCH_OUTBOX).replace(
+                    "published_task_id", "published_task_removed"
+                ),
+                tasks_text=_read(TASKS_BAYESIAN).replace(
+                    "recovery_published_task_ids", "recovery_task_ids_removed"
+                ),
+            ),
+            "published_task",
+        ),
+        (
+            "directive_xiv_broker_failure_ack_proof_removed",
+            lambda: validate_tests_and_ci(
+                p9_db_tests_text=_read(P9_DB_TESTS).replace(
+                    "test_b24_p9_directive_xiv_broker_backed_failure_ack_recovery",
+                    "test_b24_p9_directive_xiv_broker_backed_failure_ack_removed",
+                ),
+                b07_p5_timeout_test_text=_read(B07_P5_TIMEOUT_RUNTIME_TEST),
+                required_status_text=_read(REQUIRED_STATUS_CONTRACT),
+                workflow_text=_read(WORKFLOW),
+                ci_workflow_text=_read(CI_WORKFLOW),
+            ),
+            "failure_ack",
         ),
         (
             "directive_ix_db_fence_rejection_removed",
@@ -1114,6 +1210,8 @@ def run_negative_controls() -> None:
                     + _read(P9_DIRECTIVE_X_MIGRATION)
                     + "\n"
                     + _read(P9_DIRECTIVE_XIII_MIGRATION)
+                    + "\n"
+                    + _read(P9_DIRECTIVE_XIV_MIGRATION)
                 ).replace(
                     "b24_dispatch_fence_rejected",
                     "b24_dispatch_fence_allowed",

--- a/scripts/ci/validate_m0_scope_lock.py
+++ b/scripts/ci/validate_m0_scope_lock.py
@@ -215,6 +215,7 @@ ALLOWED_M0_PATHS = [
     "alembic/versions/007_skeldir_foundation/202606141200_b24_p9_directive_ix_dispatch_authority.py",
     "alembic/versions/007_skeldir_foundation/202606181200_b24_p9_directive_x_broker_independent_authority.py",
     "alembic/versions/007_skeldir_foundation/202606201300_b24_p9_directive_xiii_shared_recovery.py",
+    "alembic/versions/007_skeldir_foundation/202606201430_b24_p9_directive_xiv_failure_ack_recovery.py",
     "backend/app/bayesian/",
     "backend/Dockerfile.bayesian",
     "backend/requirements.txt",

--- a/scripts/ci/validate_m1_local_dev_authority.py
+++ b/scripts/ci/validate_m1_local_dev_authority.py
@@ -194,6 +194,7 @@ ALLOWED_M1_PATH_PREFIXES = [
     "alembic/versions/007_skeldir_foundation/202606141200_b24_p9_directive_ix_dispatch_authority.py",
     "alembic/versions/007_skeldir_foundation/202606181200_b24_p9_directive_x_broker_independent_authority.py",
     "alembic/versions/007_skeldir_foundation/202606201300_b24_p9_directive_xiii_shared_recovery.py",
+    "alembic/versions/007_skeldir_foundation/202606201430_b24_p9_directive_xiv_failure_ack_recovery.py",
     "backend/Dockerfile.bayesian",
     "backend/requirements.txt",
     "backend/requirements-bayesian.txt",


### PR DESCRIPTION
﻿## What changed

- Adds `public.b24_fail_fit_dispatch_recoverable(text)` as the durable failure-ACK transition for recoverable worker/infrastructure failures.
- Wires worker execution infrastructure failure to recoverable dispatch state instead of immediate terminal dispatch failure.
- Revokes the old assignment/lease after failure-ACK so duplicate old broker delivery cannot reclaim before recovery rotates the attempt.
- Adds a broker-backed `probe_recoverable_failure_ack` task and exposes recovery-published replacement task ids for cross-process correlation.
- Adds DB/runtime proofs for stale authority rejection, durable no-worker no-progress, real broker + real worker failure-ACK recovery, replacement claim, and final durable convergence.
- Extends P9 validator negative controls and M0/M1 scope allowlists for the XIV migration.

## Local validation

- `python -m py_compile backend/app/tasks/bayesian.py backend/app/bayesian/dispatch_authority.py backend/app/bayesian/dispatch_outbox.py backend/app/bayesian/fit_execution.py scripts/ci/validate_b24_p9_worker_tenant_hygiene.py alembic/versions/007_skeldir_foundation/202606201430_b24_p9_directive_xiv_failure_ack_recovery.py`
- `python scripts/ci/validate_b24_p9_worker_tenant_hygiene.py --negative-control`
- `python -m black --check ...`
- `python -m pytest backend/tests/test_b24_p9_worker_tenant_hygiene.py -q -rA`
- `python -m pytest backend/tests/test_b24_p9_postgres_runtime.py -q -rA` (local collection succeeded; protected DB proofs skipped locally by design)
- `python scripts/ci/validate_m0_scope_lock.py --baseline-sha 5ccc29c2de5458b7e7c33d678c0f806bddc80938`
- `python scripts/ci/validate_m1_local_dev_authority.py --baseline-sha 5ccc29c2de5458b7e7c33d678c0f806bddc80938`
- `git diff --check`
