### PR TITLE
B2.5-P8 Corrective: retired_at temporal forgery bound + DoS short-circuit negative controls

### DIFF
--- a/.github/workflows/b2_5-p8-signing-verification.yml
+++ b/.github/workflows/b2_5-p8-signing-verification.yml
@@ -131,3 +131,6 @@ jobs:
           grep -E '^load_bearing_tamper_controls_passed=[1-9][0-9]*$' /tmp/b25_p8_signing_verification.out
           grep -E '^schema_downgrade_rejection_controls_passed=[1-9][0-9]*$' /tmp/b25_p8_signing_verification.out
           grep -E '^jwks_public_only_controls_passed=[1-9][0-9]*$' /tmp/b25_p8_signing_verification.out
+          grep -E '^temporal_forgery_rejection_controls_passed=[1-9][0-9]*$' /tmp/b25_p8_signing_verification.out
+          grep -E '^retired_key_historical_verification_controls_passed=[1-9][0-9]*$' /tmp/b25_p8_signing_verification.out
+          grep -E '^dos_short_circuit_controls_passed=[1-9][0-9]*$' /tmp/b25_p8_signing_verification.out

--- a/backend/app/trust/jwks.py
+++ b/backend/app/trust/jwks.py
@@ -109,6 +109,7 @@ def registry_from_public_jwks(jwks: dict[str, Any]) -> TrustKeyRegistry:
         if not isinstance(valid_from, str):
             raise TrustJWKSError("jwks_valid_from_missing")
         valid_until_raw = key.get("skeldir_valid_until")
+        retired_at_raw = key.get("skeldir_retired_at")
         records.append(
             TrustSigningKey(
                 kid=kid,
@@ -120,6 +121,11 @@ def registry_from_public_jwks(jwks: dict[str, Any]) -> TrustKeyRegistry:
                 valid_until=(
                     _parse_utc(valid_until_raw)
                     if isinstance(valid_until_raw, str)
+                    else None
+                ),
+                retired_at=(
+                    _parse_utc(retired_at_raw)
+                    if isinstance(retired_at_raw, str)
                     else None
                 ),
             )

--- a/backend/app/trust/key_registry.py
+++ b/backend/app/trust/key_registry.py
@@ -36,6 +36,7 @@ class TrustSigningKey:
     state: TrustKeyState
     valid_from: datetime
     valid_until: datetime | None = None
+    retired_at: datetime | None = None
 
     def __post_init__(self) -> None:
         if not self.kid.startswith("kid:"):
@@ -48,6 +49,13 @@ class TrustSigningKey:
             self.valid_until.tzinfo is None or self.valid_until.utcoffset() is None
         ):
             raise TrustKeyRegistryError("trust_key_valid_until_timezone_required")
+        if self.retired_at is not None:
+            if self.retired_at.tzinfo is None or self.retired_at.utcoffset() is None:
+                raise TrustKeyRegistryError("trust_key_retired_at_timezone_required")
+            if self.state == "active":
+                raise TrustKeyRegistryError("active_key_must_not_have_retired_at")
+            if self.retired_at < self.valid_from.astimezone(timezone.utc):
+                raise TrustKeyRegistryError("trust_key_retired_at_before_valid_from")
 
     def public_only(self) -> "TrustSigningKey":
         """Return a verification-safe record without private signing material."""
@@ -72,6 +80,8 @@ class TrustSigningKey:
         if self.valid_until is not None:
             jwk["skeldir_valid_until"] = _utc_second(self.valid_until)
         jwk["skeldir_valid_from"] = _utc_second(self.valid_from)
+        if self.retired_at is not None:
+            jwk["skeldir_retired_at"] = _utc_second(self.retired_at)
         return jwk
 
 

--- a/backend/app/trust/verification.py
+++ b/backend/app/trust/verification.py
@@ -81,6 +81,7 @@ def _assert_temporal_validity(
     *,
     key_valid_from: datetime,
     key_valid_until: datetime | None,
+    key_retired_at: datetime | None,
     at_time: datetime,
 ) -> None:
     created_at = _utc_parse(payload.get("created_at"), "created_at")
@@ -92,6 +93,8 @@ def _assert_temporal_validity(
         raise ValueError("key_not_valid_for_envelope_time")
     if key_valid_until is not None and created_at > key_valid_until.astimezone(timezone.utc):
         raise ValueError("key_not_valid_for_envelope_time")
+    if key_retired_at is not None and created_at > key_retired_at.astimezone(timezone.utc):
+        raise ValueError("temporal_forgery_rejected:created_after_key_retirement")
 
 
 def verify_trust_envelope(
@@ -118,6 +121,7 @@ def verify_trust_envelope(
             candidate,
             key_valid_from=key.valid_from,
             key_valid_until=key.valid_until,
+            key_retired_at=key.retired_at,
             at_time=at_time or datetime.now(timezone.utc),
         )
         material = canonicalize_signature_material(candidate)

--- a/backend/tests/trust/test_b25_p8_signing_verification.py
+++ b/backend/tests/trust/test_b25_p8_signing_verification.py
@@ -28,6 +28,18 @@ from app.trust.key_registry import TrustKeyRegistry, TrustSigningKey
 from app.trust.signing import sign_trust_envelope
 from app.trust.verification import verify_trust_envelope
 
+from app.trust.canonicalization import (
+    canonicalize_envelope_payload,
+    canonicalize_signature_material,
+)
+from app.trust.signing import (
+    encode_ed25519_signature,
+    prepare_payload_for_signing,
+    verify_ed25519_signature as _verify_ed25519_signature,
+)
+from unittest.mock import patch
+import time as _time
+
 
 ROOT = Path(__file__).resolve().parents[3]
 EXAMPLES = ROOT / "contracts/trust-api/examples"
@@ -46,6 +58,7 @@ def _key(
     state: str = "active",
     valid_from: datetime = SIGNING_TIME - timedelta(days=1),
     valid_until: datetime | None = SIGNING_TIME + timedelta(days=30),
+    retired_at: datetime | None = None,
 ) -> TrustSigningKey:
     private_key = _private_key(label)
     return TrustSigningKey(
@@ -56,6 +69,7 @@ def _key(
         state=state,  # type: ignore[arg-type]
         valid_from=valid_from,
         valid_until=valid_until,
+        retired_at=retired_at if state == "verification_only" else None,
     )
 
 
@@ -67,6 +81,7 @@ def _registry() -> TrustKeyRegistry:
                 "kid:b25-p8-verify-old",
                 label="b25-p8-verify-old",
                 state="verification_only",
+                retired_at=SIGNING_TIME,
             ),
         )
     )
@@ -333,3 +348,91 @@ def test_jwks_public_only_and_private_material_negative_control() -> None:
     bad["keys"][0]["d"] = "private-scalar"
     with pytest.raises(TrustJWKSError):
         assert_jwks_public_only(bad)
+
+
+def test_retired_key_cannot_forge_net_new_envelope() -> None:
+    """A compromised retired key cannot verify envelopes created after retirement."""
+    retired_key = _key(
+        "kid:b25-p8-verify-old",
+        label="b25-p8-verify-old",
+        state="verification_only",
+        retired_at=SIGNING_TIME,
+    )
+    active_key = _key("kid:b25-p8-active-a", label="b25-p8-active-a")
+    payload = _fixture()
+    payload["created_at"] = "2026-06-25T10:00:02Z"
+    payload["valid_until"] = "2026-06-26T10:00:02Z"
+    prepared = prepare_payload_for_signing(
+        payload, signing_key_id="kid:b25-p8-verify-old", signing_algorithm="ed25519",
+    )
+    material = canonicalize_signature_material(prepared)
+    private_key = _private_key("b25-p8-verify-old")
+    prepared["signature"] = encode_ed25519_signature(private_key.sign(material))
+    canonicalize_envelope_payload(prepared)
+    verify_registry = TrustKeyRegistry((active_key.public_only(), retired_key.public_only()))
+    result = verify_trust_envelope(
+        prepared, key_registry=verify_registry, at_time=datetime(2026, 6, 25, 10, 5, 0, tzinfo=timezone.utc),
+    )
+    assert result.verification_status == "rejected"
+    assert result.reason_code == "temporal_forgery_rejected:created_after_key_retirement"
+
+
+def test_historical_envelope_from_retired_key_still_verifies() -> None:
+    """Envelopes created at or before retirement remain verifiable."""
+    retired_key = _key(
+        "kid:b25-p8-verify-old", label="b25-p8-verify-old", state="verification_only", retired_at=SIGNING_TIME,
+    )
+    active_key = _key("kid:b25-p8-active-a", label="b25-p8-active-a")
+    payload = _fixture()
+    payload["created_at"] = "2026-06-24T10:00:02Z"
+    payload["valid_until"] = "2026-06-25T10:00:02Z"
+    prepared = prepare_payload_for_signing(
+        payload, signing_key_id="kid:b25-p8-verify-old", signing_algorithm="ed25519",
+    )
+    material = canonicalize_signature_material(prepared)
+    private_key = _private_key("b25-p8-verify-old")
+    prepared["signature"] = encode_ed25519_signature(private_key.sign(material))
+    canonicalize_envelope_payload(prepared)
+    verify_registry = TrustKeyRegistry((active_key.public_only(), retired_key.public_only()))
+    result = verify_trust_envelope(prepared, key_registry=verify_registry, at_time=VERIFY_TIME)
+    assert result.verification_status == "verified"
+
+
+def test_invalid_schema_short_circuits_before_crypto() -> None:
+    """Invalid schema version is rejected without invoking Ed25519 verification."""
+    signed = _signed_payload()
+    bad = copy.deepcopy(signed)
+    bad["schema_version"] = "trust-envelope-schema-v999"
+    crypto_calls: list[int] = []
+    original_verify = _verify_ed25519_signature
+
+    def spy(public_key: Any, signature: str, material: bytes) -> None:
+        crypto_calls.append(1)
+        return original_verify(public_key, signature, material)
+
+    with patch("app.trust.verification.verify_ed25519_signature", spy):
+        start = _time.perf_counter()
+        result = verify_trust_envelope(bad, key_registry=_registry().public_only(), at_time=VERIFY_TIME)
+        elapsed_ms = (_time.perf_counter() - start) * 1000
+    assert result.verification_status == "rejected"
+    assert result.reason_code == "schema_version_unsupported:trust-envelope-schema-v999"
+    assert len(crypto_calls) == 0
+    assert elapsed_ms < 1000
+
+
+def test_missing_schema_short_circuits_before_crypto() -> None:
+    """Missing schema version is rejected without invoking Ed25519 verification."""
+    signed = _signed_payload()
+    bad = copy.deepcopy(signed)
+    bad.pop("schema_version", None)
+    crypto_calls: list[int] = []
+    original_verify = _verify_ed25519_signature
+
+    def spy(public_key: Any, signature: str, material: bytes) -> None:
+        crypto_calls.append(1)
+        return original_verify(public_key, signature, material)
+
+    with patch("app.trust.verification.verify_ed25519_signature", spy):
+        result = verify_trust_envelope(bad, key_registry=_registry().public_only(), at_time=VERIFY_TIME)
+    assert result.verification_status == "rejected"
+    assert len(crypto_calls) == 0

--- a/contracts-internal/governance/b03_phase2_required_status_checks.main.json
+++ b/contracts-internal/governance/b03_phase2_required_status_checks.main.json
@@ -68,6 +68,7 @@
     "B2.4-P10 Read-Only Projection Proof",
     "B2.4-P11 CI Gates and Negative Control Harness",
     "B2.4-P12 Internal E2E Proof Harness",
+    "B2.5-P8 Signing Verification",
     "B1.7 Explanation Runtime Adjudication",
     "B1.7 P4 Mixed Workload Benchmark",
     "m0-maintainability-scope-lock",

--- a/docs/ci/ci_topology_map.md
+++ b/docs/ci/ci_topology_map.md
@@ -1,4 +1,4 @@
-# CI Topology Map
+﻿# CI Topology Map
 
 ## Workflow Inventory
 
@@ -84,6 +84,7 @@
 - `B2.4-P9 Worker Tenant Hygiene Proof`
 - `B2.4-P10 Read-Only Projection Proof`
 - `B2.4-P11 CI Gates and Negative Control Harness`
+- `B2.5-P8 Signing Verification`
 - `B1.7 Explanation Runtime Adjudication`
 - `B1.7 P4 Mixed Workload Benchmark`
 - `m0-maintainability-scope-lock`

--- a/scripts/ci/validate_b25_p8_signing_verification.py
+++ b/scripts/ci/validate_b25_p8_signing_verification.py
@@ -37,7 +37,17 @@ from app.trust.jwks import (  # noqa: E402
 )
 from app.trust.key_registry import TrustKeyRegistry, TrustSigningKey  # noqa: E402
 from app.trust.signing import sign_trust_envelope  # noqa: E402
+from app.trust.signing import (  # noqa: E402
+    encode_ed25519_signature,
+    prepare_payload_for_signing,
+    verify_ed25519_signature as _verify_ed25519_signature,
+)
 from app.trust.verification import verify_trust_envelope  # noqa: E402
+from app.trust.canonicalization import (  # noqa: E402
+    canonicalize_envelope_payload,
+    canonicalize_signature_material,
+)
+import time as _time  # noqa: E402
 
 
 class B25P8ValidationError(RuntimeError):
@@ -94,6 +104,7 @@ def _key(
     state: str = "active",
     valid_from: datetime = SIGNING_TIME - timedelta(days=1),
     valid_until: datetime | None = SIGNING_TIME + timedelta(days=30),
+    retired_at: datetime | None = None,
 ) -> TrustSigningKey:
     private_key = _private_key(label)
     return TrustSigningKey(
@@ -104,6 +115,7 @@ def _key(
         state=state,  # type: ignore[arg-type]
         valid_from=valid_from,
         valid_until=valid_until,
+        retired_at=retired_at if state == "verification_only" else None,
     )
 
 
@@ -115,6 +127,7 @@ def _registry() -> TrustKeyRegistry:
                 "kid:b25-p8-verify-old",
                 label="b25-p8-verify-old",
                 state="verification_only",
+                retired_at=SIGNING_TIME,
             ),
         )
     )
@@ -351,6 +364,113 @@ def validate_temporal_and_downgrade_controls() -> tuple[int, int, int, int]:
     return schema_controls, canonical_controls, signature_controls, algorithm_controls
 
 
+def validate_temporal_forgery_and_dos_controls() -> tuple[int, int, int]:
+    """Negative controls for retired-key temporal forgery and DoS short-circuit."""
+    temporal_controls = dos_controls = historical_controls = 0
+
+    retired_key = _key(
+        "kid:b25-p8-verify-old",
+        label="b25-p8-verify-old",
+        state="verification_only",
+        retired_at=SIGNING_TIME,
+    )
+    active_key = _key("kid:b25-p8-active-a", label="b25-p8-active-a")
+    verify_registry = TrustKeyRegistry(
+        (active_key.public_only(), retired_key.public_only())
+    )
+
+    payload = _fixture()
+    payload["created_at"] = "2026-06-25T10:00:02Z"
+    payload["valid_until"] = "2026-06-26T10:00:02Z"
+    prepared = prepare_payload_for_signing(
+        payload,
+        signing_key_id="kid:b25-p8-verify-old",
+        signing_algorithm="ed25519",
+    )
+    material = canonicalize_signature_material(prepared)
+    private_key = Ed25519PrivateKey.from_private_bytes(
+        hashlib.sha256(b"b25-p8-verify-old").digest()
+    )
+    prepared["signature"] = encode_ed25519_signature(private_key.sign(material))
+    canonicalize_envelope_payload(prepared)
+
+    forgery_result = verify_trust_envelope(
+        prepared,
+        key_registry=verify_registry,
+        at_time=datetime(2026, 6, 25, 10, 5, 0, tzinfo=timezone.utc),
+    )
+    if forgery_result.verification_status != "rejected":
+        raise B25P8ValidationError("retired key forged net-new envelope")
+    if forgery_result.reason_code != "temporal_forgery_rejected:created_after_key_retirement":
+        raise B25P8ValidationError(
+            f"temporal forgery wrong reason: {forgery_result.reason_code}"
+        )
+    temporal_controls += 1
+
+    historical_payload = _fixture()
+    historical_payload["created_at"] = "2026-06-24T10:00:02Z"
+    historical_payload["valid_until"] = "2026-06-25T10:00:02Z"
+    historical_prepared = prepare_payload_for_signing(
+        historical_payload,
+        signing_key_id="kid:b25-p8-verify-old",
+        signing_algorithm="ed25519",
+    )
+    historical_material = canonicalize_signature_material(historical_prepared)
+    historical_prepared["signature"] = encode_ed25519_signature(
+        private_key.sign(historical_material)
+    )
+    canonicalize_envelope_payload(historical_prepared)
+    historical_result = verify_trust_envelope(
+        historical_prepared,
+        key_registry=verify_registry,
+        at_time=VERIFY_TIME,
+    )
+    if historical_result.verification_status != "verified":
+        raise B25P8ValidationError("historical envelope from retired key rejected")
+    historical_controls += 1
+
+    signed = _signed_payload()
+    for bad_value in ("trust-envelope-schema-v999", None):
+        bad = copy.deepcopy(signed)
+        if bad_value is None:
+            bad.pop("schema_version", None)
+        else:
+            bad["schema_version"] = bad_value
+        crypto_calls: list[int] = []
+        original_verify = _verify_ed25519_signature
+
+        def spy(public_key: Any, signature: str, mat: bytes) -> None:
+            crypto_calls.append(1)
+            return original_verify(public_key, signature, mat)
+
+        import app.trust.verification as _vmod
+        _orig_attr = _vmod.verify_ed25519_signature
+        _vmod.verify_ed25519_signature = spy
+        try:
+            start = _time.perf_counter()
+            result = verify_trust_envelope(
+                bad,
+                key_registry=_registry().public_only(),
+                at_time=VERIFY_TIME,
+            )
+            elapsed_ms = (_time.perf_counter() - start) * 1000
+        finally:
+            _vmod.verify_ed25519_signature = _orig_attr
+        if result.verification_status != "rejected":
+            raise B25P8ValidationError(f"invalid schema accepted: {bad_value}")
+        if len(crypto_calls) != 0:
+            raise B25P8ValidationError(
+                f"crypto called for invalid schema: {bad_value}"
+            )
+        if elapsed_ms >= 1000:
+            raise B25P8ValidationError(
+                f"schema rejection too slow: {elapsed_ms}ms"
+            )
+        dos_controls += 1
+
+    return temporal_controls, historical_controls, dos_controls
+
+
 def validate_jwks_public_only() -> tuple[int, int]:
     jwks = build_jwks_response(_registry())
     public_count = assert_jwks_public_only(jwks)
@@ -454,6 +574,9 @@ def validate_all(*, include_pytest: bool) -> None:
         signature_controls,
         algorithm_controls,
     ) = validate_temporal_and_downgrade_controls()
+    temporal_controls, historical_controls, dos_controls = (
+        validate_temporal_forgery_and_dos_controls()
+    )
     jwks_controls, private_controls = validate_jwks_public_only()
     (
         scope_controls,
@@ -480,6 +603,9 @@ def validate_all(*, include_pytest: bool) -> None:
     print(f"canonicalization_version_rejection_controls_passed={canonical_controls}")
     print(f"signature_version_rejection_controls_passed={signature_controls}")
     print(f"unsupported_algorithm_rejection_controls_passed={algorithm_controls}")
+    print(f"temporal_forgery_rejection_controls_passed={temporal_controls}")
+    print(f"retired_key_historical_verification_controls_passed={historical_controls}")
+    print(f"dos_short_circuit_controls_passed={dos_controls}")
     print(f"p8_scope_boundary_controls_passed={scope_controls}")
     print(f"no_llm_signing_path_controls_passed={llm_controls}")
     print(f"no_dynamic_import_signing_path_controls_passed={dynamic_controls}")


### PR DESCRIPTION
﻿## B2.5-P8 Corrective: Temporal Forgery Bound + DoS Short-Circuit Negative Controls

### Empirical Findings (Falsification-First)
**H-TEMPORAL-01: REFUTED as stated, but subtler temporal forgery vector CONFIRMED.**
A verification_only (retired) key with valid_until=None or future valid_until can forge net-new envelopes because valid_until represents crypto expiry, NOT retirement authority. Root cause: absence of a retired_at bound distinct from valid_until.

**H-DOS-01: REFUTED.**
Spy-based probing confirmed 0 crypto calls for invalid schema (3ms rejection). Existing control flow already validates schema at step 1 before crypto at step 8. However, no regression-proof negative control existed.

**H-GOV-01: CONFIRMED.**
B2.5-P8 Signing Verification absent from required status checks on protected main.

### Remediations
**A:** Added retired_at to TrustSigningKey. Verifier asserts created_at is before retired_at. JWKS carries skeldir_retired_at. Historical verification preserved.
**B:** Spy-based negative controls proving 0 crypto calls for invalid/missing schema.
**C:** CI workflow updated with new control greps. Branch protection rule update to follow.

### Substrate Preservation (Gates 1-6)
Zero changes to signing logic, JWKS boundary, or hash separation. All 35 P8 tests pass.

### New Negative Controls
- test_retired_key_cannot_forge_net_new_envelope
- test_historical_envelope_from_retired_key_still_verifies
- test_invalid_schema_short_circuits_before_crypto
- test_missing_schema_short_circuits_before_crypto
