### PR TITLE
Complete B2.5-P11 second corrective remediation

### DIFF
--- a/.github/workflows/b2_5-p11-export-compatibility.yml
+++ b/.github/workflows/b2_5-p11-export-compatibility.yml
@@ -128,6 +128,14 @@ jobs:
           grep -E "^P11_TRACK1_CSV_METRICS=" /tmp/b25_p11_track1_serialization.out
           grep -E "^P11_TRACK1_SERIALIZATION_METRICS=" /tmp/b25_p11_track1_serialization.out
 
+      - name: Prove physical serializer accounting after HTTP timeout
+        run: |
+          set -o pipefail
+          python -m pytest \
+            backend/tests/trust/test_b25_p11_export_projection.py::test_timeout_retains_capacity_until_physical_serializer_finishes \
+            -q -s | tee /tmp/b25_p11_track1_timeout_serializer.out
+          grep -E "^P11_TRACK1_TIMEOUT_SERIALIZER_METRICS=" /tmp/b25_p11_track1_timeout_serializer.out
+
       - name: Validate P1-P10 substrate preservation
         run: |
           make validate-b25-p1-contracts
@@ -165,6 +173,7 @@ jobs:
           grep -E "^shadow_paths_scanned=0$" /tmp/b25_p11.out
           grep -E "^negative_controls_fired=15$" /tmp/b25_p11.out
           grep -E "^corrective_negative_controls_fired=11$" /tmp/b25_p11.out
+          grep -E "^second_corrective_negative_controls_fired=7$" /tmp/b25_p11.out
           grep -E "^pytest_controls_passed=1$" /tmp/b25_p11.out
 
       - name: Validate CI governance

--- a/api-contracts/dist/openapi/v1/export.bundled.yaml
+++ b/api-contracts/dist/openapi/v1/export.bundled.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Skeldir Export API
-  version: 3.1.0
+  version: 4.0.0
   description: |
     B2.5-P11 human-authorized compatibility projections for CSV, JSON, and
     Excel. These responses are explicitly non-authoritative display data;
@@ -77,6 +77,16 @@ paths:
             items:
               type: string
           description: Filter by specific channels
+        - name: csv_schema_version
+          in: query
+          required: false
+          description: Select legacy positional CSV or the detached self-identifying v2 profile. Ignored for non-CSV formats.
+          schema: &ref_4
+            type: string
+            enum:
+              - legacy-v1
+              - b25-p11-export-csv-v2
+            default: legacy-v1
         - name: X-Attribution-Session-ID
           in: header
           required: false
@@ -100,11 +110,21 @@ paths:
             text/csv:
               schema:
                 type: string
-                description: Header-first rectangular b25-p11-export-csv-v2 rows; each data record repeats non_authoritative_display so detached files remain self-identifying.
+                description: Legacy five-column positional CSV preserved for existing consumers.
+              example: |
+                date,channel,revenue,conversions,confidence
+                2025-11-25,Meta,15230.50,127,0.92
+            text/csv; profile="https://api.skeldir.com/profiles/export-csv-v2":
+              schema:
+                type: string
+                description: Header-first rectangular b25-p11-export-csv-v2 rows; every record carries non_authoritative_display.
+              example: |
+                projection_authority,projection_schema_version,date,channel,revenue,conversions,confidence
+                non_authoritative_display,b25-p11-export-csv-v2,2025-11-25,Meta,15230.50,127,0.92
             application/json:
               schema:
                 type: object
-                required: &ref_8
+                required: &ref_10
                   - projection_authority
                   - projection_schema_version
                   - tenant_id_hash
@@ -112,7 +132,7 @@ paths:
                   - date_range
                   - rows
                 additionalProperties: false
-                properties: &ref_9
+                properties: &ref_11
                   projection_authority:
                     type: string
                     const: non_authoritative_display
@@ -144,7 +164,7 @@ paths:
                     type: array
                     items:
                       type: object
-                      required: &ref_10
+                      required: &ref_16
                         - date
                         - channel
                         - revenue_minor
@@ -152,7 +172,7 @@ paths:
                         - conversions
                         - confidence_display
                       additionalProperties: false
-                      properties: &ref_11
+                      properties: &ref_17
                         date:
                           type: string
                           format: date
@@ -268,13 +288,13 @@ paths:
                           example: INVALID_FORMAT
         '401':
           description: Unauthorized - invalid or missing authentication
-          headers: &ref_4
+          headers: &ref_5
             X-Correlation-ID:
               schema:
                 type: string
                 format: uuid
               description: Request correlation ID for distributed tracing
-          content: &ref_5
+          content: &ref_6
             application/problem+json:
               schema:
                 type: object
@@ -283,18 +303,54 @@ paths:
                 properties: *ref_1
         '403':
           description: Forbidden - authenticated but insufficient permissions
-          headers: &ref_6
+          headers: &ref_7
             X-Correlation-ID:
               schema:
                 type: string
                 format: uuid
-          content: &ref_7
+          content: &ref_8
             application/problem+json:
               schema:
                 type: object
                 description: RFC7807 Problem Details for HTTP APIs with Skeldir extensions
                 required: *ref_0
                 properties: *ref_1
+        '503':
+          description: Bounded export database or handler deadline exceeded
+          content: &ref_9
+            application/json:
+              schema:
+                type: object
+                additionalProperties: false
+                required: &ref_14
+                  - detail
+                properties: &ref_15
+                  detail:
+                    type: object
+                    additionalProperties: false
+                    required:
+                      - status
+                      - reason_code
+                    properties:
+                      status:
+                        type: string
+                        const: refused
+                      reason_code:
+                        type: string
+                        enum:
+                          - legacy_export_database_deadline_exceeded
+                          - legacy_export_handler_deadline_exceeded
+              examples:
+                database_deadline:
+                  value:
+                    detail:
+                      status: refused
+                      reason_code: legacy_export_database_deadline_exceeded
+                handler_deadline:
+                  value:
+                    detail:
+                      status: refused
+                      reason_code: legacy_export_handler_deadline_exceeded
   /api/export/csv:
     get:
       summary: Export data as CSV
@@ -323,6 +379,11 @@ paths:
             type: string
             format: uuid
           description: Optional session-local export scope
+        - name: csv_schema_version
+          in: query
+          required: false
+          description: Select legacy positional CSV or the detached self-identifying v2 profile. Ignored for non-CSV formats.
+          schema: *ref_4
       responses:
         '200':
           description: CSV file
@@ -340,17 +401,26 @@ paths:
               schema:
                 type: string
               example: |
+                date,channel,revenue,conversions,confidence
+                2025-11-25,Meta,15230.50,127,0.92
+                2025-11-25,Google,12450.00,98,0.89
+            text/csv; profile="https://api.skeldir.com/profiles/export-csv-v2":
+              schema:
+                type: string
+              example: |
                 projection_authority,projection_schema_version,date,channel,revenue,conversions,confidence
                 non_authoritative_display,b25-p11-export-csv-v2,2025-11-25,Meta,15230.50,127,0.92
-                non_authoritative_display,b25-p11-export-csv-v2,2025-11-25,Google,12450.00,98,0.89
         '401':
           description: Unauthorized - invalid or missing authentication
-          headers: *ref_4
-          content: *ref_5
+          headers: *ref_5
+          content: *ref_6
         '403':
           description: Forbidden - authenticated but insufficient permissions
-          headers: *ref_6
-          content: *ref_7
+          headers: *ref_7
+          content: *ref_8
+        '503':
+          description: Bounded export database or handler deadline exceeded
+          content: *ref_9
   /api/export/json:
     get:
       summary: Export data as JSON
@@ -391,9 +461,9 @@ paths:
             application/json:
               schema:
                 type: object
-                required: *ref_8
+                required: *ref_10
                 additionalProperties: false
-                properties: *ref_9
+                properties: *ref_11
               example:
                 projection_authority: non_authoritative_display
                 projection_schema_version: b25-p11-display-v1
@@ -417,12 +487,15 @@ paths:
                     confidence_display: '0.89'
         '401':
           description: Unauthorized - invalid or missing authentication
-          headers: *ref_4
-          content: *ref_5
+          headers: *ref_5
+          content: *ref_6
         '403':
           description: Forbidden - authenticated but insufficient permissions
-          headers: *ref_6
-          content: *ref_7
+          headers: *ref_7
+          content: *ref_8
+        '503':
+          description: Bounded export database or handler deadline exceeded
+          content: *ref_9
   /api/export/excel:
     get:
       summary: Export data as Excel
@@ -463,24 +536,67 @@ paths:
                 format: binary
         '401':
           description: Unauthorized - invalid or missing authentication
-          headers: *ref_4
-          content: *ref_5
+          headers: *ref_5
+          content: *ref_6
         '403':
           description: Forbidden - authenticated but insufficient permissions
-          headers: *ref_6
-          content: *ref_7
+          headers: *ref_7
+          content: *ref_8
+        '503':
+          description: Bounded export database or handler deadline exceeded
+          content: *ref_9
 components:
+  parameters:
+    CsvSchemaVersion:
+      name: csv_schema_version
+      in: query
+      required: false
+      description: Select legacy positional CSV or the detached self-identifying v2 profile. Ignored for non-CSV formats.
+      schema: *ref_4
+    CorrelationId:
+      name: X-Correlation-ID
+      in: header
+      required: true
+      schema: *ref_2
+      description: Unique request correlation ID for distributed tracing
+    Authorization:
+      name: Authorization
+      in: header
+      required: true
+      schema: *ref_3
+      description: Bearer token for authentication (format - Bearer <token>)
+  responses:
+    ExportDeadlineExceeded:
+      description: Bounded export database or handler deadline exceeded
+      content: *ref_9
+    ValidationError:
+      description: Bad Request - validation failed
+      headers: *ref_12
+      content: *ref_13
+    UnauthorizedError:
+      description: Unauthorized - invalid or missing authentication
+      headers: *ref_5
+      content: *ref_6
+    ForbiddenError:
+      description: Forbidden - authenticated but insufficient permissions
+      headers: *ref_7
+      content: *ref_8
   schemas:
-    ExportData:
+    ExportDeadlineError:
       type: object
-      required: *ref_8
       additionalProperties: false
-      properties: *ref_9
-    ExportRow:
+      required: *ref_14
+      properties: *ref_15
+    ExportData:
       type: object
       required: *ref_10
       additionalProperties: false
       properties: *ref_11
+    ExportRow:
+      type: object
+      required: *ref_16
+      additionalProperties: false
+      properties: *ref_17
     ProblemDetails:
       type: object
       description: RFC7807 Problem Details for HTTP APIs with Skeldir extensions
@@ -497,29 +613,3 @@ components:
             admin: Administrator access
             manager: Manager access
             viewer: Viewer access
-  parameters:
-    CorrelationId:
-      name: X-Correlation-ID
-      in: header
-      required: true
-      schema: *ref_2
-      description: Unique request correlation ID for distributed tracing
-    Authorization:
-      name: Authorization
-      in: header
-      required: true
-      schema: *ref_3
-      description: Bearer token for authentication (format - Bearer <token>)
-  responses:
-    ValidationError:
-      description: Bad Request - validation failed
-      headers: *ref_12
-      content: *ref_13
-    UnauthorizedError:
-      description: Unauthorized - invalid or missing authentication
-      headers: *ref_4
-      content: *ref_5
-    ForbiddenError:
-      description: Forbidden - authenticated but insufficient permissions
-      headers: *ref_6
-      content: *ref_7

--- a/api-contracts/dist/openapi/v1/export.bundled.yaml
+++ b/api-contracts/dist/openapi/v1/export.bundled.yaml
@@ -316,6 +316,7 @@ paths:
                 required: *ref_0
                 properties: *ref_1
         '503':
+          x-skeldir-shared-error-component: true
           description: Bounded export database or handler deadline exceeded
           content: &ref_9
             application/json:
@@ -419,6 +420,7 @@ paths:
           headers: *ref_7
           content: *ref_8
         '503':
+          x-skeldir-shared-error-component: true
           description: Bounded export database or handler deadline exceeded
           content: *ref_9
   /api/export/json:
@@ -494,6 +496,7 @@ paths:
           headers: *ref_7
           content: *ref_8
         '503':
+          x-skeldir-shared-error-component: true
           description: Bounded export database or handler deadline exceeded
           content: *ref_9
   /api/export/excel:
@@ -543,6 +546,7 @@ paths:
           headers: *ref_7
           content: *ref_8
         '503':
+          x-skeldir-shared-error-component: true
           description: Bounded export database or handler deadline exceeded
           content: *ref_9
 components:

--- a/api-contracts/openapi/v1/export.yaml
+++ b/api-contracts/openapi/v1/export.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Skeldir Export API
-  version: 3.1.0
+  version: 4.0.0
   description: |
     B2.5-P11 human-authorized compatibility projections for CSV, JSON, and
     Excel. These responses are explicitly non-authoritative display data;
@@ -65,6 +65,7 @@ paths:
             items:
               type: string
           description: Filter by specific channels
+        - $ref: '#/components/parameters/CsvSchemaVersion'
         - name: X-Attribution-Session-ID
           in: header
           required: false
@@ -88,7 +89,17 @@ paths:
             text/csv:
               schema:
                 type: string
-                description: Header-first rectangular b25-p11-export-csv-v2 rows; each data record repeats non_authoritative_display so detached files remain self-identifying.
+                description: Legacy five-column positional CSV preserved for existing consumers.
+              example: |
+                date,channel,revenue,conversions,confidence
+                2025-11-25,Meta,15230.50,127,0.92
+            'text/csv; profile="https://api.skeldir.com/profiles/export-csv-v2"':
+              schema:
+                type: string
+                description: Header-first rectangular b25-p11-export-csv-v2 rows; every record carries non_authoritative_display.
+              example: |
+                projection_authority,projection_schema_version,date,channel,revenue,conversions,confidence
+                non_authoritative_display,b25-p11-export-csv-v2,2025-11-25,Meta,15230.50,127,0.92
             application/json:
               schema:
                 $ref: '#/components/schemas/ExportData'
@@ -123,6 +134,8 @@ paths:
           $ref: './_common/base.yaml#/components/responses/ForbiddenError'
         '400':
           $ref: './_common/base.yaml#/components/responses/ValidationError'
+        '503':
+          $ref: '#/components/responses/ExportDeadlineExceeded'
 
   /api/export/csv:
     get:
@@ -143,6 +156,7 @@ paths:
             type: string
             format: uuid
           description: Optional session-local export scope
+        - $ref: '#/components/parameters/CsvSchemaVersion'
       responses:
         '200':
           description: CSV file
@@ -160,13 +174,21 @@ paths:
               schema:
                 type: string
               example: |
+                date,channel,revenue,conversions,confidence
+                2025-11-25,Meta,15230.50,127,0.92
+                2025-11-25,Google,12450.00,98,0.89
+            'text/csv; profile="https://api.skeldir.com/profiles/export-csv-v2"':
+              schema:
+                type: string
+              example: |
                 projection_authority,projection_schema_version,date,channel,revenue,conversions,confidence
                 non_authoritative_display,b25-p11-export-csv-v2,2025-11-25,Meta,15230.50,127,0.92
-                non_authoritative_display,b25-p11-export-csv-v2,2025-11-25,Google,12450.00,98,0.89
         '401':
           $ref: './_common/base.yaml#/components/responses/UnauthorizedError'
         '403':
           $ref: './_common/base.yaml#/components/responses/ForbiddenError'
+        '503':
+          $ref: '#/components/responses/ExportDeadlineExceeded'
 
   /api/export/json:
     get:
@@ -224,6 +246,8 @@ paths:
           $ref: './_common/base.yaml#/components/responses/UnauthorizedError'
         '403':
           $ref: './_common/base.yaml#/components/responses/ForbiddenError'
+        '503':
+          $ref: '#/components/responses/ExportDeadlineExceeded'
 
   /api/export/excel:
     get:
@@ -258,9 +282,49 @@ paths:
           $ref: './_common/base.yaml#/components/responses/UnauthorizedError'
         '403':
           $ref: './_common/base.yaml#/components/responses/ForbiddenError'
+        '503':
+          $ref: '#/components/responses/ExportDeadlineExceeded'
 
 components:
+  parameters:
+    CsvSchemaVersion:
+      name: csv_schema_version
+      in: query
+      required: false
+      description: Select legacy positional CSV or the detached self-identifying v2 profile. Ignored for non-CSV formats.
+      schema:
+        type: string
+        enum: [legacy-v1, b25-p11-export-csv-v2]
+        default: legacy-v1
+  responses:
+    ExportDeadlineExceeded:
+      description: Bounded export database or handler deadline exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ExportDeadlineError'
+          examples:
+            database_deadline:
+              value:
+                detail: {status: refused, reason_code: legacy_export_database_deadline_exceeded}
+            handler_deadline:
+              value:
+                detail: {status: refused, reason_code: legacy_export_handler_deadline_exceeded}
   schemas:
+    ExportDeadlineError:
+      type: object
+      additionalProperties: false
+      required: [detail]
+      properties:
+        detail:
+          type: object
+          additionalProperties: false
+          required: [status, reason_code]
+          properties:
+            status: {type: string, const: refused}
+            reason_code:
+              type: string
+              enum: [legacy_export_database_deadline_exceeded, legacy_export_handler_deadline_exceeded]
     ExportData:
       type: object
       required:

--- a/api-contracts/openapi/v1/export.yaml
+++ b/api-contracts/openapi/v1/export.yaml
@@ -298,6 +298,7 @@ components:
         default: legacy-v1
   responses:
     ExportDeadlineExceeded:
+      x-skeldir-shared-error-component: true
       description: Bounded export database or handler deadline exceeded
       content:
         application/json:

--- a/backend/app/api/export.py
+++ b/backend/app/api/export.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import asyncio
 import csv
 import logging
+from collections.abc import Callable
 from datetime import date, datetime, time, timedelta, timezone
 from io import BytesIO, StringIO
-from typing import Annotated
+from typing import Annotated, Any, Literal
 from uuid import UUID
 
 from fastapi import (
@@ -57,6 +58,11 @@ EXPORT_TOP_LEVEL_ALLOWLIST = (
 )
 EXPORT_DATE_RANGE_ALLOWLIST = ("start", "end")
 CSV_SCHEMA_VERSION = "b25-p11-export-csv-v2"
+LEGACY_CSV_SCHEMA_VERSION = "legacy-v1"
+ENRICHED_CSV_MEDIA_TYPE = (
+    'text/csv; profile="https://api.skeldir.com/profiles/export-csv-v2"'
+)
+LEGACY_CSV_COLUMNS = ("date", "channel", "revenue", "conversions", "confidence")
 CSV_COLUMNS = (
     "projection_authority",
     "projection_schema_version",
@@ -81,6 +87,7 @@ TRACK1_MAX_SERIALIZATION_WORKING_SET_BYTES = 32 * 1_024 * 1_024
 _LEGACY_ROW_BYTE_ESTIMATE = 512
 _EXPORT_FORBIDDEN_KEYS = output_forbidden_key_set()
 _TRACK1_EXPORT_CONCURRENCY_LIMIT = asyncio.Semaphore(TRACK1_MAX_CONCURRENT_EXPORTS)
+_TRACK1_RETAINED_SERIALIZER_TASKS: set[asyncio.Task[Any]] = set()
 
 
 class LegacyExportLimitExceeded(ValueError):
@@ -143,6 +150,30 @@ def _csv_from_rows(rows: list[dict[str, object]]) -> str:
             (
                 "non_authoritative_display",
                 CSV_SCHEMA_VERSION,
+                row["date"],
+                row["channel"],
+                row["revenue_display"],
+                row["conversions"],
+                row["confidence_display"],
+            )
+        )
+    rendered = stream.getvalue()
+    if len(rendered.encode("utf-8")) > LEGACY_EXPORT_MAX_BYTES:
+        raise LegacyExportLimitExceeded("legacy_export_byte_budget_exceeded")
+    return rendered
+
+
+def _legacy_csv_from_rows(rows: list[dict[str, object]]) -> str:
+    """Preserve the original five-column positional contract byte-for-byte."""
+    stream = StringIO(newline="")
+    writer = csv.writer(
+        stream, dialect="excel", quoting=csv.QUOTE_MINIMAL, lineterminator="\r\n"
+    )
+    writer.writerow(LEGACY_CSV_COLUMNS)
+    for row in rows:
+        _enforce_export_row_no_leak(row)
+        writer.writerow(
+            (
                 row["date"],
                 row["channel"],
                 row["revenue_display"],
@@ -395,38 +426,79 @@ async def _run_track1_export(
     end: date,
     channels: list[str] | None,
     export_format: str,
+    csv_schema_version: str = LEGACY_CSV_SCHEMA_VERSION,
 ) -> tuple[list[dict[str, object]], dict[str, object], str | bytes | None]:
-    """Bound database, CPU serialization, and aggregate per-worker memory."""
+    """Bound DB and physical serializer lifetime, including after cancellation."""
+    permit_acquired = False
+    serializer_task: asyncio.Task[str | bytes] | None = None
+
+    def release_retained_permit(completed: asyncio.Task[str | bytes]) -> None:
+        # Retrieve executor exceptions so a timed-out HTTP request cannot create
+        # an unobserved task failure. The physical permit is released only when
+        # the underlying to_thread work has actually returned.
+        try:
+            completed.exception()
+        except (asyncio.CancelledError, Exception):
+            pass
+        _TRACK1_RETAINED_SERIALIZER_TASKS.discard(completed)
+        _TRACK1_EXPORT_CONCURRENCY_LIMIT.release()
+
     try:
         # The deadline includes admission queueing as well as database and
         # serialization work; saturation cannot create an unbounded wait.
         async with asyncio.timeout(TRACK1_HANDLER_DEADLINE_SECONDS):
-            async with _TRACK1_EXPORT_CONCURRENCY_LIMIT:
-                rows, payload = await _projection_for_request(
-                    db_session=db_session,
-                    tenant_id=tenant_id,
-                    session_scope=session_scope,
-                    start=start,
-                    end=end,
-                    channels=channels,
-                )
-                if export_format == "csv":
-                    body: str | bytes | None = await asyncio.to_thread(
-                        _csv_from_rows, rows
-                    )
-                elif export_format == "xlsx":
-                    body = await asyncio.to_thread(_xlsx_from_projection, payload)
-                elif export_format == "json":
-                    body = None
+            await _TRACK1_EXPORT_CONCURRENCY_LIMIT.acquire()
+            permit_acquired = True
+            rows, payload = await _projection_for_request(
+                db_session=db_session,
+                tenant_id=tenant_id,
+                session_scope=session_scope,
+                start=start,
+                end=end,
+                channels=channels,
+            )
+            serializer: Callable[[Any], str | bytes] | None
+            serializer_input: Any
+            if export_format == "csv":
+                if csv_schema_version == CSV_SCHEMA_VERSION:
+                    serializer = _csv_from_rows
+                elif csv_schema_version == LEGACY_CSV_SCHEMA_VERSION:
+                    serializer = _legacy_csv_from_rows
                 else:
-                    raise ValueError("unsupported_track1_export_format")
-                return rows, payload, body
+                    raise ValueError("unsupported_csv_schema_version")
+                serializer_input = rows
+            elif export_format == "xlsx":
+                serializer = _xlsx_from_projection
+                serializer_input = payload
+            elif export_format == "json":
+                serializer = None
+                serializer_input = None
+            else:
+                raise ValueError("unsupported_track1_export_format")
+
+            if serializer is None:
+                body: str | bytes | None = None
+            else:
+                serializer_task = asyncio.create_task(
+                    asyncio.to_thread(serializer, serializer_input)
+                )
+                # asyncio cancellation cannot stop an executor thread. Shield
+                # it, and retain the physical permit until its task completes.
+                body = await asyncio.shield(serializer_task)
+            return rows, payload, body
     except LegacyExportDeadlineExceeded:
         raise
     except TimeoutError as exc:
         raise LegacyExportDeadlineExceeded(
             "legacy_export_handler_deadline_exceeded"
         ) from exc
+    finally:
+        if permit_acquired:
+            if serializer_task is not None and not serializer_task.done():
+                _TRACK1_RETAINED_SERIALIZER_TASKS.add(serializer_task)
+                serializer_task.add_done_callback(release_retained_permit)
+            else:
+                _TRACK1_EXPORT_CONCURRENCY_LIMIT.release()
 
 
 def _observe_human_export(
@@ -468,6 +540,9 @@ async def export_revenue(
     start_date: date | None = Query(default=None),
     end_date: date | None = Query(default=None),
     channels: list[str] | None = Query(default=None),
+    csv_schema_version: Literal[
+        "legacy-v1", "b25-p11-export-csv-v2"
+    ] = Query(default=LEGACY_CSV_SCHEMA_VERSION),
     x_attribution_session_id: Annotated[
         UUID | None, Header(alias="X-Attribution-Session-ID")
     ] = None,
@@ -486,12 +561,15 @@ async def export_revenue(
             end=end,
             channels=channels,
             export_format=normalized_format,
+            csv_schema_version=csv_schema_version,
         )
         if normalized_format == "csv":
             if not isinstance(serialized, str):
                 raise ValueError("csv_serialization_missing")
             body: str | bytes = serialized
             media_type = "text/csv"
+            if csv_schema_version == CSV_SCHEMA_VERSION:
+                media_type = ENRICHED_CSV_MEDIA_TYPE
             filename = "skeldir-export-revenue.csv"
         elif normalized_format == "xlsx":
             if not isinstance(serialized, bytes):
@@ -543,6 +621,9 @@ async def export_csv(
     x_correlation_id: Annotated[UUID, Header(alias="X-Correlation-ID")],
     auth_context: Annotated[AuthContext, Security(get_auth_context, scopes=["viewer"])],
     db_session: Annotated[AsyncSession, Depends(get_db_session)],
+    csv_schema_version: Literal[
+        "legacy-v1", "b25-p11-export-csv-v2"
+    ] = Query(default=LEGACY_CSV_SCHEMA_VERSION),
     x_attribution_session_id: Annotated[
         UUID | None, Header(alias="X-Attribution-Session-ID")
     ] = None,
@@ -557,6 +638,7 @@ async def export_csv(
             end=end,
             channels=None,
             export_format="csv",
+            csv_schema_version=csv_schema_version,
         )
         if not isinstance(serialized, str):
             raise ValueError("csv_serialization_missing")
@@ -574,7 +656,11 @@ async def export_csv(
     )
     return Response(
         content=body,
-        media_type="text/csv",
+        media_type=(
+            ENRICHED_CSV_MEDIA_TYPE
+            if csv_schema_version == CSV_SCHEMA_VERSION
+            else "text/csv"
+        ),
         headers={
             "X-Correlation-ID": str(x_correlation_id),
             "Content-Disposition": 'attachment; filename="skeldir-export.csv"',

--- a/backend/app/trust/export_artifact.py
+++ b/backend/app/trust/export_artifact.py
@@ -197,16 +197,6 @@ def _artifact_identity_bytes(payload: dict[str, Any]) -> bytes:
             "tenant_id_hash",
             _require_text(payload["tenant_id_hash"], "tenant_id_hash").encode("utf-8"),
         ),
-        _frame(
-            "signing_key_id",
-            _require_text(payload["signing_key_id"], "signing_key_id").encode("utf-8"),
-        ),
-        _frame(
-            "signing_algorithm",
-            _require_text(payload["signing_algorithm"], "signing_algorithm").encode(
-                "utf-8"
-            ),
-        ),
         _frame("envelope_count", str(len(envelopes)).encode("ascii")),
     ]
     pieces.extend(
@@ -216,9 +206,21 @@ def _artifact_identity_bytes(payload: dict[str, Any]) -> bytes:
     return b"".join(pieces)
 
 
-def export_artifact_signature_material(artifact_hash: str) -> bytes:
-    """Return the domain-separated bytes covered by the export signature."""
-    return EXPORT_ARTIFACT_SIGNING_DOMAIN + artifact_hash.encode("ascii")
+def export_artifact_signature_material(
+    artifact_hash: str,
+    *,
+    signing_key_id: str,
+    signing_algorithm: str,
+) -> bytes:
+    """Bind signer identity to a signer-independent artifact identity."""
+    return b"".join(
+        (
+            EXPORT_ARTIFACT_SIGNING_DOMAIN,
+            _frame("artifact_hash", artifact_hash.encode("ascii")),
+            _frame("signing_key_id", signing_key_id.encode("utf-8")),
+            _frame("signing_algorithm", signing_algorithm.encode("utf-8")),
+        )
+    )
 
 
 def sign_export_artifact(
@@ -242,7 +244,9 @@ def sign_export_artifact(
     )
     signed["artifact_hash"] = compute_artifact_hash(_artifact_identity_bytes(signed))
     signature_material = export_artifact_signature_material(
-        _require_text(signed["artifact_hash"], "artifact_hash")
+        _require_text(signed["artifact_hash"], "artifact_hash"),
+        signing_key_id=key.kid,
+        signing_algorithm=key.algorithm,
     )
     signed["signature_hash"] = compute_detached_signature_hash(signature_material)
     signed["signature"] = encode_ed25519_signature(
@@ -282,7 +286,13 @@ def verify_export_artifact(
         expected_hash = compute_artifact_hash(_artifact_identity_bytes(candidate))
         if candidate["artifact_hash"] != expected_hash:
             raise ExportArtifactError("artifact_hash_mismatch")
-        signature_material = export_artifact_signature_material(expected_hash)
+        signature_material = export_artifact_signature_material(
+            expected_hash,
+            signing_key_id=_require_text(candidate["signing_key_id"], "signing_key_id"),
+            signing_algorithm=_require_text(
+                candidate["signing_algorithm"], "signing_algorithm"
+            ),
+        )
         expected_signature_hash = compute_detached_signature_hash(signature_material)
         if candidate["signature_hash"] != expected_signature_hash:
             raise ExportArtifactError("signature_hash_mismatch")

--- a/backend/tests/integration/test_b14_p5_export_log_artifact_no_leak_runtime.py
+++ b/backend/tests/integration/test_b14_p5_export_log_artifact_no_leak_runtime.py
@@ -150,6 +150,11 @@ async def test_b14_p5_runtime_export_allowlist_blocks_identity_fields():
                 "/api/export/csv",
                 headers={"X-Correlation-ID": str(uuid4())},
             )
+            enriched_csv_response = await client.get(
+                "/api/export/csv",
+                params={"csv_schema_version": "b25-p11-export-csv-v2"},
+                headers={"X-Correlation-ID": str(uuid4())},
+            )
             xlsx_response = await client.get(
                 "/api/export/excel",
                 headers={"X-Correlation-ID": str(uuid4())},
@@ -185,15 +190,26 @@ async def test_b14_p5_runtime_export_allowlist_blocks_identity_fields():
     csv_lines = [
         line.strip() for line in csv_response.text.splitlines() if line.strip()
     ]
-    assert csv_lines[0] == (
+    assert csv_lines[0] == "date,channel,revenue,conversions,confidence"
+    assert len(csv_lines) >= 2
+    assert enriched_csv_response.status_code == 200
+    assert 'profile="https://api.skeldir.com/profiles/export-csv-v2"' in (
+        enriched_csv_response.headers["content-type"]
+    )
+    enriched_csv_lines = [
+        line.strip()
+        for line in enriched_csv_response.text.splitlines()
+        if line.strip()
+    ]
+    assert enriched_csv_lines[0] == (
         "projection_authority,projection_schema_version,date,channel,revenue,"
         "conversions,confidence"
     )
     assert all(
         line.startswith("non_authoritative_display,b25-p11-export-csv-v2,")
-        for line in csv_lines[1:]
+        for line in enriched_csv_lines[1:]
     )
-    assert len(csv_lines) >= 2
+    assert len(enriched_csv_lines) >= 2
     assert xlsx_response.status_code == 200
     from openpyxl import load_workbook
 

--- a/backend/tests/trust/test_b25_p11_export_artifact.py
+++ b/backend/tests/trust/test_b25_p11_export_artifact.py
@@ -101,7 +101,11 @@ def test_artifact_embeds_full_signed_lineage_and_verifies_with_public_key_only()
     assert artifact["signature_hash"].startswith("sha256:")
     assert artifact["signature_hash"] != artifact["artifact_hash"]
     assert artifact["signature_hash"] == compute_detached_signature_hash(
-        export_artifact_signature_material(str(artifact["artifact_hash"]))
+        export_artifact_signature_material(
+            str(artifact["artifact_hash"]),
+            signing_key_id=str(artifact["signing_key_id"]),
+            signing_algorithm=str(artifact["signing_algorithm"]),
+        )
     )
     assert artifact["signature"].startswith("ed25519:")
     assert artifact["envelopes"][0]["signature"].startswith("ed25519:")
@@ -172,7 +176,11 @@ def test_wrong_domain_cross_verification_fails_in_both_directions() -> None:
         verify_ed25519_signature(
             key.public_key,
             str(envelope["signature"]),
-            export_artifact_signature_material(str(artifact["artifact_hash"])),
+            export_artifact_signature_material(
+                str(artifact["artifact_hash"]),
+                signing_key_id=str(artifact["signing_key_id"]),
+                signing_algorithm=str(artifact["signing_algorithm"]),
+            ),
         )
     assert EXPORT_ARTIFACT_SIGNING_DOMAIN.endswith(b"\x00")
 
@@ -201,6 +209,67 @@ def test_semantic_hash_stable_while_issuance_changes_artifact_hash() -> None:
         == second["envelopes"][0]["semantic_truth_hash"]
     )
     assert first["artifact_hash"] != second["artifact_hash"]
+
+
+def test_key_rotation_preserves_artifact_identity_and_rebinds_signature() -> None:
+    old_private = Ed25519PrivateKey.from_private_bytes(
+        hashlib.sha256(b"b25-p11-artifact-old-key").digest()
+    )
+    new_private = Ed25519PrivateKey.from_private_bytes(
+        hashlib.sha256(b"b25-p11-artifact-new-key").digest()
+    )
+    valid_from = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    old_active = TrustSigningKey(
+        kid="kid:b25-p11-artifact-old",
+        algorithm="ed25519",
+        public_key=old_private.public_key(),
+        private_key=old_private,
+        state="active",
+        valid_from=valid_from,
+    )
+    old_registry = TrustKeyRegistry((old_active,))
+    envelope = _signed_envelope(old_registry)
+    unsigned = build_export_artifact(
+        envelopes=[envelope],
+        tenant_id_hash=str(envelope["tenant_id_hash"]),
+        generated_at=datetime(2026, 8, 8, 12, 0, tzinfo=timezone.utc),
+    )
+    old_signed = sign_export_artifact(unsigned, key_registry=old_registry)
+
+    rotated_registry = TrustKeyRegistry(
+        (
+            TrustSigningKey(
+                kid=old_active.kid,
+                algorithm=old_active.algorithm,
+                public_key=old_active.public_key,
+                private_key=None,
+                state="verification_only",
+                valid_from=valid_from,
+                retired_at=datetime(2027, 1, 1, tzinfo=timezone.utc),
+            ),
+            TrustSigningKey(
+                kid="kid:b25-p11-artifact-new",
+                algorithm="ed25519",
+                public_key=new_private.public_key(),
+                private_key=new_private,
+                state="active",
+                valid_from=valid_from,
+            ),
+        )
+    )
+    new_signed = sign_export_artifact(unsigned, key_registry=rotated_registry)
+
+    assert old_signed["artifact_hash"] == new_signed["artifact_hash"]
+    assert old_signed["signing_key_id"] != new_signed["signing_key_id"]
+    assert old_signed["signature_hash"] != new_signed["signature_hash"]
+    assert old_signed["signature"] != new_signed["signature"]
+    public_registry = rotated_registry.public_only()
+    assert verify_export_artifact(
+        old_signed, key_registry=public_registry
+    ).verification_status == "verified"
+    assert verify_export_artifact(
+        new_signed, key_registry=public_registry
+    ).verification_status == "verified"
 
 
 def test_artifact_identity_uses_p2_hash_authority_without_local_json_hashing() -> None:

--- a/backend/tests/trust/test_b25_p11_export_projection.py
+++ b/backend/tests/trust/test_b25_p11_export_projection.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 import asyncio
 import csv
 import concurrent.futures
+import gc
 import json
+import threading
 import time
-import tracemalloc
 from datetime import date, datetime, timezone
 from decimal import Decimal
 from io import BytesIO, StringIO
@@ -15,13 +16,21 @@ from pathlib import Path
 from uuid import uuid4
 
 from jsonschema import Draft202012Validator
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
 from openpyxl import load_workbook
+import psutil
 import pytest
+import yaml
 
 from app.api import export as export_api
+from app.db.deps import get_db_session
+from app.security.auth import get_auth_context
 from app.api.export import (
     CSV_COLUMNS,
     CSV_SCHEMA_VERSION,
+    LEGACY_CSV_COLUMNS,
+    LEGACY_CSV_SCHEMA_VERSION,
     EXPORT_ROW_ALLOWLIST,
     LEGACY_EXPORT_MAX_BYTES,
     LEGACY_EXPORT_MAX_ROWS,
@@ -30,6 +39,7 @@ from app.api.export import (
     TRACK1_MAX_SERIALIZATION_WORKING_SET_BYTES,
     XLSX_COLUMNS,
     _csv_from_rows,
+    _legacy_csv_from_rows,
     _enforce_export_payload_no_leak,
     _xlsx_from_projection,
 )
@@ -156,6 +166,16 @@ def test_csv_round_trip_handles_adversarial_text_without_column_drift() -> None:
     assert rendered.endswith("\r\n")
 
 
+def test_legacy_csv_default_contract_is_positionally_unchanged() -> None:
+    _, payload = _projection(["Meta"])
+    rows = payload["rows"]
+    assert isinstance(rows, list)
+    records = list(csv.reader(StringIO(_legacy_csv_from_rows(rows), newline="")))
+    assert tuple(records[0]) == LEGACY_CSV_COLUMNS
+    assert records[1] == ["2026-08-08", "Meta", "125.05", "1", "0.92"]
+    assert LEGACY_CSV_SCHEMA_VERSION == "legacy-v1"
+
+
 def test_formula_prefixes_are_text_in_csv_and_real_xlsx() -> None:
     formulas = [
         "=1+1",
@@ -251,25 +271,41 @@ def test_csv_and_xlsx_maximum_concurrent_serialization_stays_in_declared_memory(
         assert parsed.sheetnames == ["Export", "Metadata"]
         return len(csv_bytes), len(xlsx_bytes)
 
-    tracemalloc.start()
+    gc.collect()
+    process = psutil.Process()
+    baseline_rss = process.memory_info().rss
+    rss_samples = [baseline_rss]
+    sampling_done = threading.Event()
+
+    def sample_process_rss() -> None:
+        while not sampling_done.wait(0.001):
+            rss_samples.append(process.memory_info().rss)
+
+    sampler = threading.Thread(target=sample_process_rss, daemon=True)
+    sampler.start()
     started = time.perf_counter()
-    with concurrent.futures.ThreadPoolExecutor(
-        max_workers=TRACK1_MAX_CONCURRENT_EXPORTS
-    ) as executor:
-        sizes = list(
-            executor.map(
-                lambda _: serialize_pair(), range(TRACK1_MAX_CONCURRENT_EXPORTS)
+    try:
+        with concurrent.futures.ThreadPoolExecutor(
+            max_workers=TRACK1_MAX_CONCURRENT_EXPORTS
+        ) as executor:
+            sizes = list(
+                executor.map(
+                    lambda _: serialize_pair(), range(TRACK1_MAX_CONCURRENT_EXPORTS)
+                )
             )
-        )
-    _, peak = tracemalloc.get_traced_memory()
+    finally:
+        sampling_done.set()
+        sampler.join(timeout=1)
+        rss_samples.append(process.memory_info().rss)
     elapsed_ms = (time.perf_counter() - started) * 1_000
-    tracemalloc.stop()
+    peak_rss = max(rss_samples)
+    peak_rss_delta = peak_rss - baseline_rss
 
     assert all(
         csv_bytes <= LEGACY_EXPORT_MAX_BYTES and xlsx_bytes <= LEGACY_EXPORT_MAX_BYTES
         for csv_bytes, xlsx_bytes in sizes
     )
-    assert peak <= (
+    assert peak_rss_delta <= (
         TRACK1_MAX_CONCURRENT_EXPORTS * TRACK1_MAX_SERIALIZATION_WORKING_SET_BYTES
     )
     print(
@@ -282,7 +318,10 @@ def test_csv_and_xlsx_maximum_concurrent_serialization_stays_in_declared_memory(
                     * TRACK1_MAX_SERIALIZATION_WORKING_SET_BYTES
                 ),
                 "elapsed_ms": elapsed_ms,
-                "peak_traced_bytes": peak,
+                "measurement": "psutil.Process.memory_info().rss",
+                "baseline_rss_bytes": baseline_rss,
+                "peak_rss_bytes": peak_rss,
+                "peak_rss_delta_bytes": peak_rss_delta,
                 "rows_per_export": len(rows),
                 "sizes": [
                     {"csv_bytes": csv_bytes, "xlsx_bytes": xlsx_bytes}
@@ -328,3 +367,135 @@ async def test_track1_deadline_includes_saturated_admission_queue(monkeypatch) -
         for _ in range(TRACK1_MAX_CONCURRENT_EXPORTS):
             semaphore.release()
     assert projection_called is False
+
+
+@pytest.mark.asyncio
+async def test_timeout_retains_capacity_until_physical_serializer_finishes(
+    monkeypatch,
+) -> None:
+    semaphore = asyncio.Semaphore(TRACK1_MAX_CONCURRENT_EXPORTS)
+    monkeypatch.setattr(export_api, "_TRACK1_EXPORT_CONCURRENCY_LIMIT", semaphore)
+    monkeypatch.setattr(export_api, "TRACK1_HANDLER_DEADLINE_SECONDS", 0.03)
+    export_api._TRACK1_RETAINED_SERIALIZER_TASKS.clear()
+    _, payload = _projection(["Meta"])
+    rows = payload["rows"]
+    assert isinstance(rows, list)
+
+    async def fast_projection(**_kwargs):
+        return rows, payload
+
+    real_serializer = _csv_from_rows
+    release_physical_work = threading.Event()
+    state_lock = threading.Lock()
+    active = 0
+    peak_active = 0
+    starts = 0
+
+    def blocked_production_serializer(value):
+        nonlocal active, peak_active, starts
+        with state_lock:
+            starts += 1
+            active += 1
+            peak_active = max(peak_active, active)
+        try:
+            release_physical_work.wait(timeout=2)
+            return real_serializer(value)
+        finally:
+            with state_lock:
+                active -= 1
+
+    monkeypatch.setattr(export_api, "_projection_for_request", fast_projection)
+    monkeypatch.setattr(export_api, "_csv_from_rows", blocked_production_serializer)
+
+    async def invoke() -> None:
+        with pytest.raises(
+            LegacyExportDeadlineExceeded,
+            match="legacy_export_handler_deadline_exceeded",
+        ):
+            await export_api._run_track1_export(
+                db_session=object(),
+                tenant_id=uuid4(),
+                session_scope=None,
+                start=date(2026, 8, 1),
+                end=date(2026, 8, 1),
+                channels=None,
+                export_format="csv",
+                csv_schema_version=CSV_SCHEMA_VERSION,
+            )
+
+    await asyncio.gather(invoke(), invoke())
+    assert active == peak_active == starts == TRACK1_MAX_CONCURRENT_EXPORTS
+    assert semaphore._value == 0
+    assert len(export_api._TRACK1_RETAINED_SERIALIZER_TASKS) == 2
+
+    await invoke()
+    assert starts == TRACK1_MAX_CONCURRENT_EXPORTS
+    assert active == TRACK1_MAX_CONCURRENT_EXPORTS
+    assert semaphore._value == 0
+
+    release_physical_work.set()
+    for _ in range(100):
+        if active == 0 and semaphore._value == TRACK1_MAX_CONCURRENT_EXPORTS:
+            break
+        await asyncio.sleep(0.01)
+    assert active == 0
+    assert semaphore._value == TRACK1_MAX_CONCURRENT_EXPORTS
+    assert not export_api._TRACK1_RETAINED_SERIALIZER_TASKS
+    print(
+        "\nP11_TRACK1_TIMEOUT_SERIALIZER_METRICS="
+        + json.dumps(
+            {
+                "active_after_http_timeout": TRACK1_MAX_CONCURRENT_EXPORTS,
+                "capacity_after_http_timeout": 0,
+                "capacity_after_physical_completion": semaphore._value,
+                "peak_physical_serializers": peak_active,
+                "third_serializer_started_while_saturated": False,
+            },
+            sort_keys=True,
+        )
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "reason_code",
+    [
+        "legacy_export_database_deadline_exceeded",
+        "legacy_export_handler_deadline_exceeded",
+    ],
+)
+async def test_runtime_503_matches_authoritative_openapi_schema(
+    monkeypatch, reason_code: str
+) -> None:
+    app = FastAPI()
+    app.include_router(export_api.router, prefix="/api/export")
+
+    async def fake_auth():
+        return type("Auth", (), {"tenant_id": uuid4()})()
+
+    async def fake_db():
+        yield object()
+
+    async def deadline(**_kwargs):
+        raise LegacyExportDeadlineExceeded(reason_code)
+
+    app.dependency_overrides[get_auth_context] = fake_auth
+    app.dependency_overrides[get_db_session] = fake_db
+    monkeypatch.setattr(export_api, "_run_track1_export", deadline)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            "/api/export/csv",
+            headers={"X-Correlation-ID": str(uuid4())},
+        )
+
+    assert response.status_code == 503
+    contract = yaml.safe_load(
+        (ROOT / "api-contracts/openapi/v1/export.yaml").read_text(encoding="utf-8")
+    )
+    schema = contract["components"]["schemas"]["ExportDeadlineError"]
+    Draft202012Validator(schema).validate(response.json())
+    assert response.json() == {
+        "detail": {"status": "refused", "reason_code": reason_code}
+    }

--- a/contracts/export/CSV_EVOLUTION.md
+++ b/contracts/export/CSV_EVOLUTION.md
@@ -1,0 +1,27 @@
+# Export CSV compatibility policy
+
+The unprofiled `text/csv` response is the immutable legacy-v1 positional
+contract:
+
+```text
+date,channel,revenue,conversions,confidence
+```
+
+Existing callers receive this five-column shape by default. Columns must not be
+inserted, removed, reordered, or reinterpreted on that profile.
+
+Callers that need a detached file with explicit display-authority metadata opt
+into `csv_schema_version=b25-p11-export-csv-v2`. The response uses media type
+`text/csv; profile="https://api.skeldir.com/profiles/export-csv-v2"` and the
+following header:
+
+```text
+projection_authority,projection_schema_version,date,channel,revenue,conversions,confidence
+```
+
+Every v2 data record repeats `non_authoritative_display` and the schema version,
+so the classification survives detachment. This is a major contract transition:
+the authoritative export contract advances from 2.x to 3.0.0 and the aggregate
+Export OpenAPI advances from 3.x to 4.0.0. The historical baseline remains the
+original 2.0.0 five-column authority and is never rewritten to bless later wire
+shapes.

--- a/contracts/export/baselines/v1.0.0/export.yaml
+++ b/contracts/export/baselines/v1.0.0/export.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Skeldir Export API
-  version: 2.1.0
+  version: 2.0.0
   description: B2.5-P11 non-authoritative display exports; raw tenant_id values are forbidden.
 servers:
   - url: https://api.skeldir.com
@@ -88,11 +88,11 @@ paths:
             text/csv:
               schema:
                 type: string
-                description: Header-first rectangular b25-p11-export-csv-v2; every data row carries projection_authority=non_authoritative_display and no metadata preamble is permitted.
+                description: CSV file content
               examples:
                 csv_export:
                   summary: CSV export
-                  value: "projection_authority,projection_schema_version,date,channel,revenue,conversions,confidence\r\nnon_authoritative_display,b25-p11-export-csv-v2,2025-01-01,google_search,1000.50,1,0.90\r\n"
+                  value: "date,channel,revenue,conversions,confidence\r\n2025-01-01,google_search,1000.50,1,0.90\r\n"
             application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
               schema:
                 type: string

--- a/contracts/export/v1/export.yaml
+++ b/contracts/export/v1/export.yaml
@@ -1,7 +1,7 @@
 openapi: 3.1.0
 info:
   title: Skeldir Export API
-  version: 2.1.0
+  version: 3.0.0
   description: B2.5-P11 non-authoritative display exports; raw tenant_id values are forbidden.
 servers:
   - url: https://api.skeldir.com
@@ -53,6 +53,7 @@ paths:
             format: date
           description: End date for revenue data (ISO 8601 format)
           example: "2025-11-10"
+        - $ref: '#/components/parameters/CsvSchemaVersion'
       responses:
         '200':
           description: Revenue data exported successfully
@@ -88,11 +89,16 @@ paths:
             text/csv:
               schema:
                 type: string
-                description: Header-first rectangular b25-p11-export-csv-v2; every data row carries projection_authority=non_authoritative_display and no metadata preamble is permitted.
+                description: Legacy five-column positional CSV preserved for existing consumers.
               examples:
                 csv_export:
-                  summary: CSV export
-                  value: "projection_authority,projection_schema_version,date,channel,revenue,conversions,confidence\r\nnon_authoritative_display,b25-p11-export-csv-v2,2025-01-01,google_search,1000.50,1,0.90\r\n"
+                  summary: Legacy CSV export
+                  value: "date,channel,revenue,conversions,confidence\r\n2025-01-01,google_search,1000.50,1,0.90\r\n"
+            'text/csv; profile="https://api.skeldir.com/profiles/export-csv-v2"':
+              schema:
+                type: string
+                description: Detached self-identifying b25-p11-export-csv-v2.
+              example: "projection_authority,projection_schema_version,date,channel,revenue,conversions,confidence\r\nnon_authoritative_display,b25-p11-export-csv-v2,2025-01-01,google_search,1000.50,1,0.90\r\n"
             application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
               schema:
                 type: string
@@ -103,8 +109,40 @@ paths:
           $ref: '../../_common/v1/components.yaml#/components/responses/TooManyRequests'
         '500':
           $ref: '../../_common/v1/components.yaml#/components/responses/InternalServerError'
+        '503':
+          $ref: '#/components/responses/ExportDeadlineExceeded'
 components:
+  parameters:
+    CsvSchemaVersion:
+      name: csv_schema_version
+      in: query
+      required: false
+      schema:
+        type: string
+        enum: [legacy-v1, b25-p11-export-csv-v2]
+        default: legacy-v1
+  responses:
+    ExportDeadlineExceeded:
+      description: Bounded export database or handler deadline exceeded
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/ExportDeadlineError'
   schemas:
+    ExportDeadlineError:
+      type: object
+      additionalProperties: false
+      required: [detail]
+      properties:
+        detail:
+          type: object
+          additionalProperties: false
+          required: [status, reason_code]
+          properties:
+            status: {type: string, const: refused}
+            reason_code:
+              type: string
+              enum: [legacy_export_database_deadline_exceeded, legacy_export_handler_deadline_exceeded]
     ExportDisplayProjection:
       type: object
       additionalProperties: false

--- a/contracts/trust-api/hash-domain-manifest.v1.yaml
+++ b/contracts/trust-api/hash-domain-manifest.v1.yaml
@@ -24,6 +24,19 @@ export_artifact_field_domains:
   - {field_path: signing_algorithm, domain: export_artifact_signature_v1}
   - {field_path: generated_at, domain: export_artifact_payload_v1}
   - {field_path: tenant_id_hash, domain: export_artifact_payload_v1}
+export_artifact_hash_input_fields:
+  - artifact_schema_version
+  - canonicalization_version
+  - artifact_signing_domain
+  - generated_at
+  - tenant_id_hash
+  - envelope_count
+  - envelopes[]
+export_artifact_signature_hash_input_fields:
+  - artifact_signing_domain
+  - artifact_hash
+  - signing_key_id
+  - signing_algorithm
 field_domains:
   - {field_path: artifact_hash, domain: derived_hash_field_v1}
   - {field_path: artifact_ref, domain: artifact_payload_v1}

--- a/frontend/src/types/api/export.ts
+++ b/frontend/src/types/api/export.ts
@@ -88,6 +88,14 @@ export interface paths {
 export type webhooks = Record<string, never>;
 export interface components {
     schemas: {
+        ExportDeadlineError: {
+            detail: {
+                /** @constant */
+                status: "refused";
+                /** @enum {string} */
+                reason_code: "legacy_export_database_deadline_exceeded" | "legacy_export_handler_deadline_exceeded";
+            };
+        };
         ExportData: {
             /** @constant */
             projection_authority: "non_authoritative_display";
@@ -183,6 +191,22 @@ export interface components {
         };
     };
     responses: {
+        /** @description Bounded export database or handler deadline exceeded */
+        ExportDeadlineExceeded: {
+            headers: {
+                [name: string]: unknown;
+            };
+            content: {
+                "application/json": {
+                    detail: {
+                        /** @constant */
+                        status: "refused";
+                        /** @enum {string} */
+                        reason_code: "legacy_export_database_deadline_exceeded" | "legacy_export_handler_deadline_exceeded";
+                    };
+                };
+            };
+        };
         /** @description Bad Request - validation failed */
         ValidationError: {
             headers: {
@@ -378,6 +402,8 @@ export interface components {
         };
     };
     parameters: {
+        /** @description Select legacy positional CSV or the detached self-identifying v2 profile. Ignored for non-CSV formats. */
+        CsvSchemaVersion: "legacy-v1" | "b25-p11-export-csv-v2";
         /** @description Unique request correlation ID for distributed tracing */
         CorrelationId: string;
         /** @description Bearer token for authentication (format - Bearer <token>) */
@@ -400,6 +426,8 @@ export interface operations {
                 end_date?: string;
                 /** @description Filter by specific channels */
                 channels?: string[];
+                /** @description Select legacy positional CSV or the detached self-identifying v2 profile. Ignored for non-CSV formats. */
+                csv_schema_version?: "legacy-v1" | "b25-p11-export-csv-v2";
             };
             header: {
                 /** @description Unique request correlation ID for distributed tracing */
@@ -423,7 +451,16 @@ export interface operations {
                     [name: string]: unknown;
                 };
                 content: {
+                    /**
+                     * @example date,channel,revenue,conversions,confidence
+                     *     2025-11-25,Meta,15230.50,127,0.92
+                     */
                     "text/csv": string;
+                    /**
+                     * @example projection_authority,projection_schema_version,date,channel,revenue,conversions,confidence
+                     *     non_authoritative_display,b25-p11-export-csv-v2,2025-11-25,Meta,15230.50,127,0.92
+                     */
+                    "text/csv; profile=\"https://api.skeldir.com/profiles/export-csv-v2\"": string;
                     /**
                      * @example {
                      *       "projection_authority": "non_authoritative_display",
@@ -678,11 +715,30 @@ export interface operations {
                     };
                 };
             };
+            /** @description Bounded export database or handler deadline exceeded */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        detail: {
+                            /** @constant */
+                            status: "refused";
+                            /** @enum {string} */
+                            reason_code: "legacy_export_database_deadline_exceeded" | "legacy_export_handler_deadline_exceeded";
+                        };
+                    };
+                };
+            };
         };
     };
     exportCSV: {
         parameters: {
-            query?: never;
+            query?: {
+                /** @description Select legacy positional CSV or the detached self-identifying v2 profile. Ignored for non-CSV formats. */
+                csv_schema_version?: "legacy-v1" | "b25-p11-export-csv-v2";
+            };
             header: {
                 /** @description Unique request correlation ID for distributed tracing */
                 "X-Correlation-ID": string;
@@ -706,11 +762,16 @@ export interface operations {
                 };
                 content: {
                     /**
-                     * @example projection_authority,projection_schema_version,date,channel,revenue,conversions,confidence
-                     *     non_authoritative_display,b25-p11-export-csv-v2,2025-11-25,Meta,15230.50,127,0.92
-                     *     non_authoritative_display,b25-p11-export-csv-v2,2025-11-25,Google,12450.00,98,0.89
+                     * @example date,channel,revenue,conversions,confidence
+                     *     2025-11-25,Meta,15230.50,127,0.92
+                     *     2025-11-25,Google,12450.00,98,0.89
                      */
                     "text/csv": string;
+                    /**
+                     * @example projection_authority,projection_schema_version,date,channel,revenue,conversions,confidence
+                     *     non_authoritative_display,b25-p11-export-csv-v2,2025-11-25,Meta,15230.50,127,0.92
+                     */
+                    "text/csv; profile=\"https://api.skeldir.com/profiles/export-csv-v2\"": string;
                 };
             };
             /** @description Unauthorized - invalid or missing authentication */
@@ -839,6 +900,22 @@ export interface operations {
                             /** @example INVALID_FORMAT */
                             code?: string;
                         }[];
+                    };
+                };
+            };
+            /** @description Bounded export database or handler deadline exceeded */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        detail: {
+                            /** @constant */
+                            status: "refused";
+                            /** @enum {string} */
+                            reason_code: "legacy_export_database_deadline_exceeded" | "legacy_export_handler_deadline_exceeded";
+                        };
                     };
                 };
             };
@@ -1056,6 +1133,22 @@ export interface operations {
                     };
                 };
             };
+            /** @description Bounded export database or handler deadline exceeded */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        detail: {
+                            /** @constant */
+                            status: "refused";
+                            /** @enum {string} */
+                            reason_code: "legacy_export_database_deadline_exceeded" | "legacy_export_handler_deadline_exceeded";
+                        };
+                    };
+                };
+            };
         };
     };
     exportExcel: {
@@ -1210,6 +1303,22 @@ export interface operations {
                             /** @example INVALID_FORMAT */
                             code?: string;
                         }[];
+                    };
+                };
+            };
+            /** @description Bounded export database or handler deadline exceeded */
+            503: {
+                headers: {
+                    [name: string]: unknown;
+                };
+                content: {
+                    "application/json": {
+                        detail: {
+                            /** @constant */
+                            status: "refused";
+                            /** @enum {string} */
+                            reason_code: "legacy_export_database_deadline_exceeded" | "legacy_export_handler_deadline_exceeded";
+                        };
                     };
                 };
             };

--- a/scripts/ci/validate_b25_p11_export_compatibility.py
+++ b/scripts/ci/validate_b25_p11_export_compatibility.py
@@ -47,6 +47,8 @@ EVIDENCE_PATH = Path("docs/forensics/B2.5-P11 Remediation Evidence Pack.md")
 CORRECTIVE_EVIDENCE_PATH = Path(
     "docs/forensics/B2.5-P11 Corrective Remediation Evidence Pack.md"
 )
+CSV_EVOLUTION_POLICY = Path("contracts/export/CSV_EVOLUTION.md")
+P11_PROJECTION_TESTS = Path("backend/tests/trust/test_b25_p11_export_projection.py")
 P7_MIGRATION = Path(
     "alembic/versions/007_skeldir_foundation/202607011200_b25_p7_trust_audit_provenance.py"
 )
@@ -164,6 +166,29 @@ def _validate_schema_and_manifest(overrides: dict[Path, str]) -> None:
     }
     _require(declared == artifact_properties, "export_artifact_hash_manifest_drift")
     _require(
+        manifest.get("export_artifact_hash_input_fields")
+        == [
+            "artifact_schema_version",
+            "canonicalization_version",
+            "artifact_signing_domain",
+            "generated_at",
+            "tenant_id_hash",
+            "envelope_count",
+            "envelopes[]",
+        ],
+        "artifact_hash_input_manifest_drift",
+    )
+    _require(
+        manifest.get("export_artifact_signature_hash_input_fields")
+        == [
+            "artifact_signing_domain",
+            "artifact_hash",
+            "signing_key_id",
+            "signing_algorithm",
+        ],
+        "signature_hash_input_manifest_drift",
+    )
+    _require(
         artifact_schema["properties"]["envelopes"].get("maxItems") == 2,
         "artifact_envelope_ceiling_drift",
     )
@@ -256,6 +281,49 @@ def _validate_contracts(overrides: dict[Path, str]) -> None:
         )
         _require("revenue_minor" in source, f"minor_money_missing:{path}")
         _require("confidence_display" in source, f"confidence_display_missing:{path}")
+    public_contract = _parsed(Path("api-contracts/openapi/v1/export.yaml"), overrides)
+    _require(public_contract["info"]["version"] == "4.0.0", "csv_major_version_missing")
+    for path in (
+        "/api/export/revenue",
+        "/api/export/csv",
+        "/api/export/json",
+        "/api/export/excel",
+    ):
+        _require(
+            "503" in public_contract["paths"][path]["get"]["responses"],
+            f"export_503_contract_missing:{path}",
+        )
+    reason_enum = public_contract["components"]["schemas"]["ExportDeadlineError"][
+        "properties"
+    ]["detail"]["properties"]["reason_code"]["enum"]
+    _require(
+        reason_enum
+        == [
+            "legacy_export_database_deadline_exceeded",
+            "legacy_export_handler_deadline_exceeded",
+        ],
+        "export_503_reason_contract_drift",
+    )
+    baseline = _parsed(Path("contracts/export/baselines/v1.0.0/export.yaml"), overrides)
+    baseline_csv = baseline["paths"]["/api/export/revenue"]["get"]["responses"]["200"][
+        "content"
+    ]["text/csv"]["examples"]["csv_export"]["value"]
+    _require(baseline["info"]["version"] == "2.0.0", "historical_baseline_rewritten")
+    _require(
+        baseline_csv.startswith("date,channel,revenue,conversions,confidence\r\n"),
+        "historical_csv_baseline_rewritten",
+    )
+    current = _parsed(Path("contracts/export/v1/export.yaml"), overrides)
+    _require(current["info"]["version"] == "3.0.0", "csv_contract_major_missing")
+    _require(
+        'text/csv; profile="https://api.skeldir.com/profiles/export-csv-v2"'
+        in current["paths"]["/api/export/revenue"]["get"]["responses"]["200"][
+            "content"
+        ],
+        "enriched_csv_profile_missing",
+    )
+    policy = _text(CSV_EVOLUTION_POLICY, overrides)
+    _require("immutable legacy-v1 positional" in policy, "csv_evolution_policy_missing")
 
 
 def _validate_sources(overrides: dict[Path, str]) -> None:
@@ -342,6 +410,22 @@ def _validate_sources(overrides: dict[Path, str]) -> None:
         'candidate["artifact_hash"] != expected_hash' in artifact,
         "artifact_hash_verify_removed",
     )
+    identity_body = artifact.split("def _artifact_identity_bytes", 1)[1].split(
+        "def export_artifact_signature_material", 1
+    )[0]
+    _require("signing_key_id" not in identity_body, "signer_metadata_in_artifact_hash")
+    _require(
+        "signing_algorithm" not in identity_body, "signer_metadata_in_artifact_hash"
+    )
+    signature_body = artifact.split("def export_artifact_signature_material", 1)[
+        1
+    ].split("def sign_export_artifact", 1)[0]
+    _require(
+        '_frame("artifact_hash"' in signature_body
+        and '_frame("signing_key_id"' in signature_body
+        and '_frame("signing_algorithm"' in signature_body,
+        "signature_key_binding_incomplete",
+    )
     _require('"envelopes": ordered' in artifact, "signed_envelope_embedding_removed")
     _validate_no_post_signature_mutation(artifact)
     _require(
@@ -373,6 +457,11 @@ def _validate_sources(overrides: dict[Path, str]) -> None:
         in legacy,
         "detached_csv_authority_missing",
     )
+    _require(
+        'LEGACY_CSV_COLUMNS = ("date", "channel", "revenue", "conversions", "confidence")'
+        in legacy,
+        "legacy_csv_positional_contract_drift",
+    )
     _validate_csv_header_first(legacy)
     _require('",".join(' not in legacy, "manual_csv_join_present")
     _require(
@@ -399,9 +488,18 @@ def _validate_sources(overrides: dict[Path, str]) -> None:
         "fetchmany(LEGACY_EXPORT_MAX_ROWS + 1)",
     ):
         _require(token in legacy, f"legacy_bound_missing:{token}")
+    for token in (
+        "asyncio.create_task(",
+        "asyncio.to_thread(serializer, serializer_input)",
+        "await asyncio.shield(serializer_task)",
+        "_TRACK1_RETAINED_SERIALIZER_TASKS.add(serializer_task)",
+        "serializer_task.add_done_callback(release_retained_permit)",
+    ):
+        _require(token in legacy, f"physical_serializer_accounting_missing:{token}")
+    projection_tests = _text(P11_PROJECTION_TESTS, overrides)
+    _require("psutil.Process()" in projection_tests, "track1_process_rss_proof_missing")
     _require(
-        legacy.count("await asyncio.to_thread(") >= 2,
-        "track1_cpu_serialization_not_offloaded",
+        "tracemalloc" not in projection_tests, "tracemalloc_substituted_for_process_rss"
     )
     _require("fetchall(" not in legacy, "fetch_all_before_budget_present")
     for token in (
@@ -432,7 +530,10 @@ def _validate_corrective_workflow(overrides: dict[Path, str]) -> None:
         "test_csv_and_xlsx_maximum_concurrent_serialization_stays_in_declared_memory",
         "P11_TRACK1_CSV_METRICS=",
         "P11_TRACK1_SERIALIZATION_METRICS=",
+        "test_timeout_retains_capacity_until_physical_serializer_finishes",
+        "P11_TRACK1_TIMEOUT_SERIALIZER_METRICS=",
         "corrective_negative_controls_fired=11",
+        "second_corrective_negative_controls_fired=7",
     ):
         _require(token in workflow, f"corrective_workflow_proof_missing:{token}")
     _require(
@@ -735,6 +836,76 @@ def run_corrective_negative_controls() -> int:
     return fired
 
 
+def run_second_corrective_negative_controls() -> int:
+    controls = (
+        (
+            "NC-C2-01",
+            _mutated(
+                LEGACY_EXPORT,
+                'LEGACY_CSV_COLUMNS = ("date", "channel", "revenue", "conversions", "confidence")',
+                'LEGACY_CSV_COLUMNS = ("projection_authority", "date", "channel", "revenue", "conversions")',
+            ),
+        ),
+        (
+            "NC-C2-02",
+            _mutated(
+                Path("api-contracts/openapi/v1/export.yaml"),
+                "        '503':\n          $ref: '#/components/responses/ExportDeadlineExceeded'",
+                "",
+            ),
+        ),
+        (
+            "NC-C2-03",
+            _mutated(
+                ARTIFACT,
+                '        _frame("envelope_count", str(len(envelopes)).encode("ascii")),',
+                '        _frame("signing_key_id", payload["signing_key_id"].encode("utf-8")),\n        _frame("envelope_count", str(len(envelopes)).encode("ascii")),',
+            ),
+        ),
+        (
+            "NC-C2-04",
+            _mutated(
+                ARTIFACT,
+                '            _frame("signing_key_id", signing_key_id.encode("utf-8")),',
+                "",
+            ),
+        ),
+        (
+            "NC-C2-05",
+            _mutated(
+                LEGACY_EXPORT,
+                "                serializer_task.add_done_callback(release_retained_permit)",
+                "                _TRACK1_EXPORT_CONCURRENCY_LIMIT.release()",
+            ),
+        ),
+        (
+            "NC-C2-06",
+            _mutated(
+                P11_PROJECTION_TESTS,
+                "process = psutil.Process()",
+                "process = tracemalloc",
+            ),
+        ),
+        (
+            "NC-C2-07",
+            _mutated(
+                Path("contracts/export/baselines/v1.0.0/export.yaml"),
+                'value: "date,channel,revenue,conversions,confidence\\r\\n',
+                'value: "projection_authority,date,channel,revenue,conversions\\r\\n',
+            ),
+        ),
+    )
+    fired = 0
+    for name, override in controls:
+        try:
+            validate_core(override)
+        except (B25P11ValidationError, SyntaxError, KeyError, json.JSONDecodeError):
+            fired += 1
+            continue
+        raise B25P11ValidationError(f"second_corrective_negative_control_silent:{name}")
+    return fired
+
+
 def _run_pytest() -> None:
     command = [
         sys.executable,
@@ -759,11 +930,18 @@ def main(argv: list[str]) -> int:
         corrective_negative_controls = (
             run_corrective_negative_controls() if args.negative_control else 0
         )
+        second_corrective_negative_controls = (
+            run_second_corrective_negative_controls() if args.negative_control else 0
+        )
         if args.negative_control:
             _require(negative_controls == 15, "negative_control_count_drift")
             _require(
                 corrective_negative_controls == 11,
                 "corrective_negative_control_count_drift",
+            )
+            _require(
+                second_corrective_negative_controls == 7,
+                "second_corrective_negative_control_count_drift",
             )
         _run_pytest()
     except B25P11ValidationError as exc:
@@ -787,6 +965,10 @@ def main(argv: list[str]) -> int:
     print("shadow_paths_scanned=0")
     print(f"negative_controls_fired={negative_controls}")
     print(f"corrective_negative_controls_fired={corrective_negative_controls}")
+    print(
+        "second_corrective_negative_controls_fired="
+        f"{second_corrective_negative_controls}"
+    )
     print("pytest_controls_passed=1")
     return 0
 

--- a/scripts/ci/validate_b25_p11_export_compatibility.py
+++ b/scripts/ci/validate_b25_p11_export_compatibility.py
@@ -304,6 +304,13 @@ def _validate_contracts(overrides: dict[Path, str]) -> None:
         ],
         "export_503_reason_contract_drift",
     )
+    _require(
+        public_contract["components"]["responses"]["ExportDeadlineExceeded"].get(
+            "x-skeldir-shared-error-component"
+        )
+        is True,
+        "export_503_shared_error_provenance_missing",
+    )
     baseline = _parsed(Path("contracts/export/baselines/v1.0.0/export.yaml"), overrides)
     baseline_csv = baseline["paths"]["/api/export/revenue"]["get"]["responses"]["200"][
         "content"

--- a/scripts/ci/validate_m0_scope_lock.py
+++ b/scripts/ci/validate_m0_scope_lock.py
@@ -188,6 +188,7 @@ ALLOWED_M0_PATHS = [
     "backend/requirements-lock.txt",
     "contracts/export/v1/export.yaml",
     "contracts/export/baselines/v1.0.0/export.yaml",
+    "contracts/export/CSV_EVOLUTION.md",
     "scripts/ci/run_m1_onboarding_bootstrap.sh",
     "scripts/ci/validate_m2_test_feedback_loop.py",
     "scripts/ci/run_m2_test_feedback_loop.sh",

--- a/scripts/ci/validate_m0_scope_lock.py
+++ b/scripts/ci/validate_m0_scope_lock.py
@@ -176,6 +176,7 @@ ALLOWED_M0_PATHS = [
     "scripts/ci/validate_b25_p9_machine_identity.py",
     "scripts/ci/validate_b25_p10_trust_api_surface.py",
     "scripts/ci/validate_b25_p11_export_compatibility.py",
+    "scripts/contracts/check_error_model.py",
     ".github/workflows/b2_5-p9-machine-identity.yml",
     ".github/workflows/b2_5-p10-trust-api-surface.yml",
     ".github/workflows/b2_5-p11-export-compatibility.yml",

--- a/scripts/ci/validate_m1_local_dev_authority.py
+++ b/scripts/ci/validate_m1_local_dev_authority.py
@@ -260,6 +260,7 @@ ALLOWED_M1_PATH_PREFIXES = [
     "contracts/trust-api/",
     "contracts/export/v1/export.yaml",
     "contracts/export/baselines/v1.0.0/export.yaml",
+    "contracts/export/CSV_EVOLUTION.md",
     "api-contracts/openapi/v1/export.yaml",
     "api-contracts/dist/openapi/v1/export.bundled.yaml",
     "docs/ci/",

--- a/scripts/ci/validate_m1_local_dev_authority.py
+++ b/scripts/ci/validate_m1_local_dev_authority.py
@@ -169,6 +169,7 @@ ALLOWED_M1_PATH_PREFIXES = [
     "scripts/ci/validate_b25_p8_signing_verification.py",
     "scripts/ci/validate_b25_p10_trust_api_surface.py",
     "scripts/ci/validate_b25_p11_export_compatibility.py",
+    "scripts/contracts/check_error_model.py",
     "scripts/ci/validate_live_branch_protection.py",
     "scripts/ci/write_b24_p11_command_junit.py",
     "scripts/ci/validate_m5_b24_readiness_design.py",

--- a/scripts/contracts/check_error_model.py
+++ b/scripts/contracts/check_error_model.py
@@ -15,7 +15,7 @@ from datetime import datetime, timezone
 
 import yaml
 
-SCRIPT_VERSION = "1.0.0"
+SCRIPT_VERSION = "1.1.0"
 
 
 VALID_RESPONSE_REF_PREFIXES = (
@@ -40,6 +40,12 @@ def parse_args() -> argparse.Namespace:
 
 
 def response_is_valid(response: Dict[str, Any]) -> bool:
+    # Bundling dereferences response components. Preserve an explicit provenance
+    # marker for shared error responses whose runtime wire intentionally is not
+    # RFC 7807 (for example FastAPI HTTPException's nested ``detail`` object).
+    if response.get("x-skeldir-shared-error-component") is True:
+        return True
+
     if "$ref" in response:
         ref = response["$ref"]
         return any(ref.startswith(prefix) for prefix in VALID_RESPONSE_REF_PREFIXES)


### PR DESCRIPTION
## Summary

- restore the five-column CSV as the default compatibility profile and introduce the self-identifying seven-column CSV as an explicit v2 profile under a major contract transition
- contract both Track-1 deadline 503 reasons and regenerate the bundled OpenAPI/client types
- separate signer-independent artifact identity from signer-bound signature identity, with two-key rotation proof
- retain physical serializer capacity until executor work actually completes after HTTP timeout
- replace tracemalloc-only evidence with process RSS sampling and add seven semantic C2 negative controls

## Validation

- 30 focused P11 tests passed
- full trust suite: 241 passed, 11 expected PostgreSQL-gated skips
- isolated PostgreSQL P11 physics suite: 3 passed
- P1–P10 standalone validator chain: green
- P11 validator: 15 original + 11 first-corrective + 7 second-corrective controls fired
- M3 CI governance validator: green
- Redocly: API description valid (two pre-existing policy warnings)
