### PR TITLE
P13-P0: close five reproduced P12 proof-system integrity defects

### DIFF
--- a/.github/workflows/b2_5-p10-trust-api-surface.yml
+++ b/.github/workflows/b2_5-p10-trust-api-surface.yml
@@ -1,20 +1,12 @@
 name: B2.5-P10 Trust API Surface
 
 on:
+  # Deliberately NOT path-filtered. This context is a REQUIRED status check.
+  # A required check that is path-filtered never reports on a PR outside its
+  # paths, and GitHub blocks that PR forever waiting for a status that cannot
+  # arrive. The push trigger keeps its paths, which is what the P12 meta-layer
+  # reads for path-trigger integrity.
   pull_request:
-    paths:
-      - "backend/app/api/trust_api.py"
-      - "backend/app/main.py"
-      - "backend/app/config/contract_scope.yaml"
-      - "backend/app/trust/**"
-      - "backend/tests/trust/**"
-      - "contracts/trust-api/**"
-      - "scripts/ci/validate_b25_p10_trust_api_surface.py"
-      - ".github/workflows/b2_5-p10-trust-api-surface.yml"
-      - "Makefile"
-      - "docs/ci/**"
-      - "docs/forensics/**"
-      - "contracts-internal/governance/b03_phase2_required_status_checks.main.json"
   push:
     branches:
       - main

--- a/.github/workflows/b2_5-p11-export-compatibility.yml
+++ b/.github/workflows/b2_5-p11-export-compatibility.yml
@@ -1,29 +1,12 @@
 name: B2.5-P11 Export Compatibility
 
 on:
+  # Deliberately NOT path-filtered. This context is a REQUIRED status check.
+  # A required check that is path-filtered never reports on a PR outside its
+  # paths, and GitHub blocks that PR forever waiting for a status that cannot
+  # arrive. The push trigger keeps its paths, which is what the P12 meta-layer
+  # reads for path-trigger integrity.
   pull_request:
-    paths:
-      - "alembic/versions/007_skeldir_foundation/*b25_p11*"
-      - "api-contracts/openapi/v1/export.yaml"
-      - "api-contracts/dist/openapi/v1/export.bundled.yaml"
-      - "backend/app/api/export.py"
-      - "backend/app/api/trust_export.py"
-      - "backend/app/main.py"
-      - "backend/app/config/contract_scope.yaml"
-      - "backend/app/trust/**"
-      - "backend/requirements*.txt"
-      - "backend/tests/trust/**"
-      - "backend/tests/integration/test_b14_p5_export_log_artifact_no_leak_runtime.py"
-      - "contracts/export/**"
-      - "contracts/trust-api/**"
-      - "scripts/ci/validate_b25_p11_export_compatibility.py"
-      - "scripts/ci/validate_b25_p9_machine_identity.py"
-      - "scripts/ci/validate_b25_p1_trust_drift.py"
-      - ".github/workflows/b2_5-p11-export-compatibility.yml"
-      - "Makefile"
-      - "docs/ci/**"
-      - "docs/forensics/**"
-      - "contracts-internal/governance/b03_phase2_required_status_checks.main.json"
   push:
     branches:
       - main

--- a/.github/workflows/b2_5-p12-ci-gates.yml
+++ b/.github/workflows/b2_5-p12-ci-gates.yml
@@ -92,7 +92,27 @@ jobs:
           grep -E "^dynamic_import_controls_passed=[1-9][0-9]*$" /tmp/b25_p12_isolation.out
           grep -E "^compute_dispatch_controls_passed=[1-9][0-9]*$" /tmp/b25_p12_isolation.out
           grep -E "^runtime_trace_paths_exercised=5$" /tmp/b25_p12_isolation.out
-          grep -E "^isolation_negative_controls_fired=3$" /tmp/b25_p12_isolation.out
+          grep -E "^isolation_negative_controls_fired=4$" /tmp/b25_p12_isolation.out
+
+      # The fresh-interpreter trace is also invoked directly, not only as a
+      # subprocess of the validator above. Registering it as a named step in the
+      # enforcer registry while leaving it unreachable from any workflow would be
+      # the exact existence-vs-invocation overclaim P13-P0 exists to remove.
+      - name: P12 runtime module trace (fresh interpreter, import-time observable)
+        run: |
+          set -o pipefail
+          python scripts/ci/_b25_p12_runtime_trace.py | tee /tmp/b25_p12_runtime_trace.out
+          python - <<'PY'
+          import json
+          report = json.loads(open("/tmp/b25_p12_runtime_trace.out").read().strip().splitlines()[-1])
+          assert not report["error"], f"runtime trace error: {report['error']}"
+          assert not report["forbidden_modules_loaded"], (
+              f"forbidden modules resident after trust paths: {report['forbidden_modules_loaded']}"
+          )
+          assert len(report["executed_paths"]) == 5, report["executed_paths"]
+          print("runtime_trace_forbidden_modules_loaded=0")
+          print(f"runtime_trace_executed_paths={len(report['executed_paths'])}")
+          PY
 
       # Plane D: prove the proofs above actually run and cannot be evaded.
       - name: P12 CI meta-validation (Plane D non-vacuity)

--- a/.github/workflows/b2_5-p8-signing-verification.yml
+++ b/.github/workflows/b2_5-p8-signing-verification.yml
@@ -22,27 +22,12 @@ on:
       - ".github/workflows/b2_5-p8-signing-verification.yml"
       - "docs/ci/**"
       - "docs/forensics/**"
+  # Deliberately NOT path-filtered. This context is a REQUIRED status check.
+  # A required check that is path-filtered never reports on a PR outside its
+  # paths, and GitHub blocks that PR forever waiting for a status that cannot
+  # arrive. The push trigger keeps its paths, which is what the P12 meta-layer
+  # reads for path-trigger integrity.
   pull_request:
-    branches: [main, develop]
-    paths:
-      - "contracts/trust-api/**"
-      - "backend/app/trust/**"
-      - "backend/app/api/trust_keys.py"
-      - "backend/app/main.py"
-      - "backend/tests/trust/**"
-      - "scripts/ci/validate_b25_p1_contracts.py"
-      - "scripts/ci/validate_b25_p1_trust_drift.py"
-      - "scripts/ci/validate_b25_p2_canonicalization.py"
-      - "scripts/ci/validate_b25_p3_text_disposition.py"
-      - "scripts/ci/validate_b25_p4_money_authority.py"
-      - "scripts/ci/validate_b25_p5_builder.py"
-      - "scripts/ci/validate_b25_p6_reason_truth_matrix.py"
-      - "scripts/ci/validate_b25_p7_provenance_audit.py"
-      - "scripts/ci/validate_b25_p8_signing_verification.py"
-      - "Makefile"
-      - ".github/workflows/b2_5-p8-signing-verification.yml"
-      - "docs/ci/**"
-      - "docs/forensics/**"
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/b2_5-p9-machine-identity.yml
+++ b/.github/workflows/b2_5-p9-machine-identity.yml
@@ -16,21 +16,12 @@ on:
       - "contracts-internal/governance/b03_phase2_required_status_checks.main.json"
       - "contracts/trust-api/**"
       - "backend/app/trust/**"
+  # Deliberately NOT path-filtered. This context is a REQUIRED status check.
+  # A required check that is path-filtered never reports on a PR outside its
+  # paths, and GitHub blocks that PR forever waiting for a status that cannot
+  # arrive. The push trigger keeps its paths, which is what the P12 meta-layer
+  # reads for path-trigger integrity.
   pull_request:
-    branches: [main, develop]
-    paths:
-      - "backend/app/trust/machine_identity.py"
-      - "backend/app/trust/machine_auth.py"
-      - "backend/tests/trust/test_b25_p9_machine_identity.py"
-      - "alembic/versions/007_skeldir_foundation/202607191200_b25_p9_machine_identity.py"
-      - "scripts/ci/validate_b25_p9_machine_identity.py"
-      - ".github/workflows/b2_5-p9-machine-identity.yml"
-      - "Makefile"
-      - "docs/ci/**"
-      - "docs/forensics/**"
-      - "contracts-internal/governance/b03_phase2_required_status_checks.main.json"
-      - "contracts/trust-api/**"
-      - "backend/app/trust/**"
   workflow_dispatch:
 
 permissions:

--- a/docs/ci/b25_p12_invariant_registry.yaml
+++ b/docs/ci/b25_p12_invariant_registry.yaml
@@ -1,301 +1,325 @@
-# B2.5-P12 invariant registry.
-#
-# PURPOSE
-# -------
-# P12 is the epistemic enforcement layer over B2.5. Its job is not to add trust
-# functionality but to make it impossible to violate a B2.5 invariant silently.
-#
-# This file is the authoritative mapping from each required CI domain to the
-# concrete proof that enforces it. It is machine-read by
-# `scripts/ci/validate_b25_p12_ci_gates.py`, which fails if an entry names a
-# validator, workflow or negative control that does not exist, or if a required
-# domain has no proof path at all.
-#
-# DESIGN RULE (directive P12-H24)
-# -------------------------------
-# Compose, do not duplicate. Where P1-P11 already own a strong proof node, this
-# registry POINTS AT IT rather than re-running it inside P12. P12 adds only the
-# proofs that no phase owns: cross-phase composition and CI meta-validation.
-#
-# `proof_owner` therefore distinguishes:
-#   inherited  - an existing phase workflow already enforces this; P12 binds it
-#   p12        - P12 introduces the proof because no phase owned the composition
-#
-# A domain marked `inherited` is NOT weaker: the named workflow is a required
-# context in its own right. P12's contribution for those domains is Plane D,
-# which proves the inherited proof actually executed and was not skipped.
-
 registry_version: b25-p12-invariant-registry-v1
-
 planes:
   A: Static authority - properties knowable without runtime
   B: Deterministic runtime - canonicalization, hashing, signing, semantics
   C: Stateful adversarial runtime - RLS, scopes, replay, no-dispatch
   D: CI meta-validation - proves planes A-C actually ran
-
 invariants:
-  - id: 1
-    invariant: Trust API contract validation
-    plane: A
-    proof_owner: p12
-    production_path: contracts/trust-api/trust-api.openapi.yaml
-    validator: scripts/ci/validate_b25_p12_contract_projection.py
-    workflow: .github/workflows/b2_5-p11-export-compatibility.yml
-    negative_control: NC-P12-P0-01
-    note: >-
-      Live issued artifact validated against the schema resolved from the
-      published 200 response. This is the composition no phase owned, and its
-      absence is exactly how the v2-runtime/v1-contract defect survived P11.
-
-  - id: 2
-    invariant: Example validation (lifecycle-aware)
-    plane: A
-    proof_owner: p12
-    production_path: contracts/trust-api/examples
-    validator: scripts/ci/validate_b25_p12_contract_projection.py
-    workflow: .github/workflows/b2_5-p11-export-compatibility.yml
-    negative_control: NC-P12-P0-02
-    note: >-
-      Active example must validate against the active schema; a historical
-      example must fail it. Without lifecycle classification a historical
-      fixture silently masquerades as active contract proof (P12-H02).
-
-  - id: 3
-    invariant: Generated model drift
-    plane: A
-    proof_owner: inherited
-    production_path: frontend/src/types/api
-    validator: scripts/contracts/generate_frontend_types.sh
-    workflow: .github/workflows/ci.yml
-    negative_control: git diff --exit-code -- frontend/src/types/api
-    note: CI regenerates types and fails on any diff against the committed output.
-
-  - id: 4
-    invariant: Schema-version downgrade rejection
-    plane: B
-    proof_owner: inherited
-    production_path: backend/app/trust/schema_verification.py
-    validator: scripts/ci/validate_b25_p8_signing_verification.py
-    workflow: .github/workflows/b2_5-p8-signing-verification.yml
-    negative_control: p8 downgrade fixtures
-    note: >-
-      P8 owns incoming verifier downgrade defense. P12 adds the separate
-      outgoing contract-version fidelity invariant as domain 1 (P12-H04).
-
-  - id: 5
-    invariant: Canonicalization determinism
-    plane: B
-    proof_owner: inherited
-    production_path: backend/app/trust/canonicalization.py
-    validator: scripts/ci/validate_b25_p2_canonicalization.py
-    workflow: .github/workflows/b2_5-p2-canonicalization.yml
-    negative_control: p2 ordering/permutation mutations
-
-  - id: 6
-    invariant: Hash separation (semantic / artifact / signature)
-    plane: B
-    proof_owner: inherited
-    production_path: backend/app/trust/hash_identity.py
-    validator: scripts/ci/validate_b25_p2_canonicalization.py
-    workflow: .github/workflows/b2_5-p2-canonicalization.yml
-    negative_control: p2 hash-domain collapse mutation
-
-  - id: 7
-    invariant: Deterministic text disposition
-    plane: B
-    proof_owner: inherited
-    production_path: backend/app/trust/text_disposition.py
-    validator: scripts/ci/validate_b25_p3_text_disposition.py
-    workflow: .github/workflows/b2_5-p3-text-disposition.yml
-    negative_control: p3 provider-text-into-authority mutation
-
-  - id: 8
-    invariant: Money authority no-float
-    plane: B
-    proof_owner: inherited
-    production_path: backend/app/trust/money_source_adapter.py
-    validator: scripts/ci/validate_b25_p4_money_authority.py
-    workflow: .github/workflows/b2_5-p4-money-authority.yml
-    negative_control: p4 float-source mutation
-
-  - id: 9
-    invariant: Signature tamper detection
-    plane: B
-    proof_owner: inherited
-    production_path: backend/app/trust/signing.py
-    validator: scripts/ci/validate_b25_p8_signing_verification.py
-    workflow: .github/workflows/b2_5-p8-signing-verification.yml
-    negative_control: p8 load-bearing tamper suite
-
-  - id: 10
-    invariant: JWKS / public verification, private-material exclusion
-    plane: B
-    proof_owner: inherited
-    production_path: backend/app/trust/jwks.py
-    validator: scripts/ci/validate_b25_p8_signing_verification.py
-    workflow: .github/workflows/b2_5-p8-signing-verification.yml
-    negative_control: p8 private-material exposure mutation
-
-  - id: 11
-    invariant: Tenant isolation (two-tenant / RLS)
-    plane: C
-    proof_owner: inherited
-    production_path: backend/app/trust/tenant_security.py
-    validator: scripts/ci/validate_b25_p10_trust_api_surface.py
-    workflow: .github/workflows/b2_5-p10-trust-api-surface.yml
-    negative_control: p10 wrong-tenant PostgreSQL proof
-
-  - id: 12
-    invariant: Agent scope denial without evidence leak
-    plane: C
-    proof_owner: inherited
-    production_path: backend/app/trust/machine_auth.py
-    validator: scripts/ci/validate_b25_p9_machine_identity.py
-    workflow: .github/workflows/b2_5-p9-machine-identity.yml
-    negative_control: p9 scope-denial evidence-leak assertions
-
-  - id: 13
-    invariant: Replay rejection (DB-atomic)
-    plane: C
-    proof_owner: inherited
-    production_path: backend/app/trust/machine_auth.py
-    validator: scripts/ci/validate_b25_p9_machine_identity.py
-    workflow: .github/workflows/b2_5-p9-machine-identity.yml
-    negative_control: p9 concurrent replay storm
-    note: >-
-      Atomic INSERT ... ON CONFLICT against real PostgreSQL. Not mocked, because
-      the guarantee is a database constraint (directive section 25).
-
-  - id: 14
-    invariant: No raw tenant ID at external boundary
-    plane: A
-    proof_owner: inherited
-    production_path: backend/app/api/trust_api.py
-    validator: scripts/ci/validate_b25_p11_export_compatibility.py
-    workflow: .github/workflows/b2_5-p11-export-compatibility.yml
-    negative_control: NC-P11-02
-    note: >-
-      Recursive runtime payload scan, not a token grep. Internal raw tenant_id
-      remains legitimate for DB authority; the ban is at the trust boundary.
-
-  - id: 15
-    invariant: AST transitive no-LLM import graph
-    plane: A
-    proof_owner: p12
-    production_path: backend/app/trust
-    validator: scripts/ci/validate_b25_p12_trust_isolation.py
-    workflow: .github/workflows/b2_5-p11-export-compatibility.yml
-    negative_control: NC-P12-ISO-01
-
-  - id: 16
-    invariant: Dynamic import ban in trust path
-    plane: A
-    proof_owner: p12
-    production_path: backend/app/trust
-    validator: scripts/ci/validate_b25_p12_trust_isolation.py
-    workflow: .github/workflows/b2_5-p11-export-compatibility.yml
-    negative_control: NC-P12-ISO-02
-
-  - id: 17
-    invariant: Runtime sys.modules trace across trust paths
-    plane: B
-    proof_owner: p12
-    production_path: backend/app/trust
-    validator: scripts/ci/validate_b25_p12_trust_isolation.py
-    workflow: .github/workflows/b2_5-p11-export-compatibility.yml
-    negative_control: NC-P12-ISO-03
-    note: happy / degraded / refused / verify / export module-load trace.
-
-  - id: 18
-    invariant: No compute dispatch from trust reads
-    plane: C
-    proof_owner: p12
-    production_path: backend/app/api/trust_api.py
-    validator: scripts/ci/validate_b25_p12_trust_isolation.py
-    workflow: .github/workflows/b2_5-p11-export-compatibility.yml
-    negative_control: NC-P12-ISO-04
-    note: >-
-      Bans indirect dispatch surfaces (send_task, enqueue helpers, outbox,
-      task-name strings), not only direct imports of compute implementations.
-
-  - id: 19
-    invariant: Policy authority never auto-executable
-    plane: B
-    proof_owner: inherited
-    production_path: backend/app/trust/policy_defaults.py
-    validator: scripts/ci/validate_b25_p6_reason_truth_matrix.py
-    workflow: .github/workflows/b2_5-p6-reason-truth-matrix.yml
-    negative_control: p6 policy escalation fixtures
-
-  - id: 20
-    invariant: Reason-code cross-field contradiction rejection
-    plane: B
-    proof_owner: inherited
-    production_path: backend/app/trust/reason_truth_matrix.py
-    validator: scripts/ci/validate_b25_p6_reason_truth_matrix.py
-    workflow: .github/workflows/b2_5-p6-reason-truth-matrix.yml
-    negative_control: p6 contradiction matrix
-
-  - id: 21
-    invariant: Refusal / degraded state validation
-    plane: B
-    proof_owner: inherited
-    production_path: backend/app/trust/refusal.py
-    validator: scripts/ci/validate_b25_p6_reason_truth_matrix.py
-    workflow: .github/workflows/b2_5-p6-reason-truth-matrix.yml
-    negative_control: p6 registered-state coverage
-
-  - id: 22
-    invariant: Export projection safety
-    plane: A
-    proof_owner: p12
-    production_path: backend/app/api/export.py
-    validator: scripts/ci/validate_b25_p12_contract_projection.py
-    workflow: .github/workflows/b2_5-p11-export-compatibility.yml
-    negative_control: NC-P12-P0-01
-    note: >-
-      Human G4 honesty and machine TrustEnvelope derivation are owned by P11;
-      P12 adds the missing third leg, active response/schema parity.
-
-# Files whose modification must not be able to evade P12 proof (P12-H25/G8).
-# Load-bearing paths that MUST reach at least one required B2.5 proof.
-# P12-G8 is satisfied when a change reaches at least one relevant required
-# context, not necessarily every one.
+- id: 1
+  invariant: Trust API contract validation
+  plane: A
+  proof_owner: p12
+  production_path: contracts/trust-api/trust-api.openapi.yaml
+  validator: scripts/ci/validate_b25_p12_contract_projection.py
+  workflow: .github/workflows/b2_5-p11-export-compatibility.yml
+  negative_control:
+    id: NC-P12-P0-01
+    resolution: source_identifier
+    resolves_in: scripts/ci/validate_b25_p12_contract_projection.py
+  note: Live issued artifact validated against the schema resolved from the published 200 response. This
+    is the composition no phase owned, and its absence is exactly how the v2-runtime/v1-contract defect
+    survived P11.
+- id: 2
+  invariant: Example validation (lifecycle-aware)
+  plane: A
+  proof_owner: p12
+  production_path: contracts/trust-api/examples
+  validator: scripts/ci/validate_b25_p12_contract_projection.py
+  workflow: .github/workflows/b2_5-p11-export-compatibility.yml
+  negative_control:
+    id: NC-P12-P0-02
+    resolution: source_identifier
+    resolves_in: scripts/ci/validate_b25_p12_contract_projection.py
+  note: Active example must validate against the active schema; a historical example must fail it. Without
+    lifecycle classification a historical fixture silently masquerades as active contract proof (P12-H02).
+- id: 3
+  invariant: Generated model drift
+  plane: A
+  proof_owner: inherited
+  production_path: frontend/src/types/api
+  validator: scripts/contracts/generate_frontend_types.sh
+  workflow: .github/workflows/ci.yml
+  negative_control:
+    id: NC-P12-INH-03
+    resolution: drift_check
+    resolves_in: scripts/contracts/generate_frontend_types.sh
+    falsifier_command: git diff --exit-code -- frontend/src/types/api
+    granularity: command_level
+  note: CI regenerates types and fails on any diff against the committed output.
+- id: 4
+  invariant: Schema-version downgrade rejection
+  plane: B
+  proof_owner: inherited
+  production_path: backend/app/trust/schema_verification.py
+  validator: scripts/ci/validate_b25_p8_signing_verification.py
+  workflow: .github/workflows/b2_5-p8-signing-verification.yml
+  negative_control:
+    id: NC-P12-INH-04
+    resolution: validator_control_mode
+    resolves_in: scripts/ci/validate_b25_p8_signing_verification.py
+    mode: --negative-control
+    granularity: mode_level
+    describes: p8 downgrade fixtures
+  note: P8 owns incoming verifier downgrade defense. P12 adds the separate outgoing contract-version fidelity
+    invariant as domain 1 (P12-H04).
+- id: 5
+  invariant: Canonicalization determinism
+  plane: B
+  proof_owner: inherited
+  production_path: backend/app/trust/canonicalization.py
+  validator: scripts/ci/validate_b25_p2_canonicalization.py
+  workflow: .github/workflows/b2_5-p2-canonicalization.yml
+  negative_control:
+    id: NC-P12-INH-05
+    resolution: validator_control_mode
+    resolves_in: scripts/ci/validate_b25_p2_canonicalization.py
+    mode: --negative-control
+    granularity: mode_level
+    describes: p2 ordering/permutation mutations
+- id: 6
+  invariant: Hash separation (semantic / artifact / signature)
+  plane: B
+  proof_owner: inherited
+  production_path: backend/app/trust/hash_identity.py
+  validator: scripts/ci/validate_b25_p2_canonicalization.py
+  workflow: .github/workflows/b2_5-p2-canonicalization.yml
+  negative_control:
+    id: NC-P12-INH-06
+    resolution: validator_control_mode
+    resolves_in: scripts/ci/validate_b25_p2_canonicalization.py
+    mode: --negative-control
+    granularity: mode_level
+    describes: p2 hash-domain collapse mutation
+- id: 7
+  invariant: Deterministic text disposition
+  plane: B
+  proof_owner: inherited
+  production_path: backend/app/trust/text_disposition.py
+  validator: scripts/ci/validate_b25_p3_text_disposition.py
+  workflow: .github/workflows/b2_5-p3-text-disposition.yml
+  negative_control:
+    id: NC-P12-INH-07
+    resolution: validator_control_mode
+    resolves_in: scripts/ci/validate_b25_p3_text_disposition.py
+    mode: --negative-control
+    granularity: mode_level
+    describes: p3 provider-text-into-authority mutation
+- id: 8
+  invariant: Money authority no-float
+  plane: B
+  proof_owner: inherited
+  production_path: backend/app/trust/money_source_adapter.py
+  validator: scripts/ci/validate_b25_p4_money_authority.py
+  workflow: .github/workflows/b2_5-p4-money-authority.yml
+  negative_control:
+    id: NC-P12-INH-08
+    resolution: validator_control_mode
+    resolves_in: scripts/ci/validate_b25_p4_money_authority.py
+    mode: --negative-control
+    granularity: mode_level
+    describes: p4 float-source mutation
+- id: 9
+  invariant: Signature tamper detection
+  plane: B
+  proof_owner: inherited
+  production_path: backend/app/trust/signing.py
+  validator: scripts/ci/validate_b25_p8_signing_verification.py
+  workflow: .github/workflows/b2_5-p8-signing-verification.yml
+  negative_control:
+    id: NC-P12-INH-09
+    resolution: validator_control_mode
+    resolves_in: scripts/ci/validate_b25_p8_signing_verification.py
+    mode: --negative-control
+    granularity: mode_level
+    describes: p8 load-bearing tamper suite
+- id: 10
+  invariant: JWKS / public verification, private-material exclusion
+  plane: B
+  proof_owner: inherited
+  production_path: backend/app/trust/jwks.py
+  validator: scripts/ci/validate_b25_p8_signing_verification.py
+  workflow: .github/workflows/b2_5-p8-signing-verification.yml
+  negative_control:
+    id: NC-P12-INH-10
+    resolution: validator_control_mode
+    resolves_in: scripts/ci/validate_b25_p8_signing_verification.py
+    mode: --negative-control
+    granularity: mode_level
+    describes: p8 private-material exposure mutation
+- id: 11
+  invariant: Tenant isolation (two-tenant / RLS)
+  plane: C
+  proof_owner: inherited
+  production_path: backend/app/trust/tenant_security.py
+  validator: scripts/ci/validate_b25_p10_trust_api_surface.py
+  workflow: .github/workflows/b2_5-p10-trust-api-surface.yml
+  negative_control:
+    id: NC-P12-INH-11
+    resolution: validator_control_mode
+    resolves_in: scripts/ci/validate_b25_p10_trust_api_surface.py
+    mode: --negative-control
+    granularity: mode_level
+    describes: p10 wrong-tenant PostgreSQL proof
+- id: 12
+  invariant: Agent scope denial without evidence leak
+  plane: C
+  proof_owner: inherited
+  production_path: backend/app/trust/machine_auth.py
+  validator: scripts/ci/validate_b25_p9_machine_identity.py
+  workflow: .github/workflows/b2_5-p9-machine-identity.yml
+  negative_control:
+    id: NC-P12-INH-12
+    resolution: validator_control_mode
+    resolves_in: scripts/ci/validate_b25_p9_machine_identity.py
+    mode: --negative-control
+    granularity: mode_level
+    describes: p9 scope-denial evidence-leak assertions
+- id: 13
+  invariant: Replay rejection (DB-atomic)
+  plane: C
+  proof_owner: inherited
+  production_path: backend/app/trust/machine_auth.py
+  validator: scripts/ci/validate_b25_p9_machine_identity.py
+  workflow: .github/workflows/b2_5-p9-machine-identity.yml
+  negative_control:
+    id: NC-P12-INH-13
+    resolution: validator_control_mode
+    resolves_in: scripts/ci/validate_b25_p9_machine_identity.py
+    mode: --negative-control
+    granularity: mode_level
+    describes: p9 concurrent replay storm
+  note: Atomic INSERT ... ON CONFLICT against real PostgreSQL. Not mocked, because the guarantee is a
+    database constraint (directive section 25).
+- id: 14
+  invariant: No raw tenant ID at external boundary
+  plane: A
+  proof_owner: inherited
+  production_path: backend/app/api/trust_api.py
+  validator: scripts/ci/validate_b25_p11_export_compatibility.py
+  workflow: .github/workflows/b2_5-p11-export-compatibility.yml
+  negative_control:
+    id: NC-P11-02
+    resolution: source_identifier
+    resolves_in: scripts/ci/validate_b25_p11_export_compatibility.py
+  note: Recursive runtime payload scan, not a token grep. Internal raw tenant_id remains legitimate for
+    DB authority; the ban is at the trust boundary.
+- id: 15
+  invariant: AST transitive no-LLM import graph
+  plane: A
+  proof_owner: p12
+  production_path: backend/app/trust
+  validator: scripts/ci/validate_b25_p12_trust_isolation.py
+  workflow: .github/workflows/b2_5-p11-export-compatibility.yml
+  negative_control:
+    id: NC-P12-ISO-01
+    resolution: source_identifier
+    resolves_in: scripts/ci/validate_b25_p12_trust_isolation.py
+- id: 16
+  invariant: Dynamic import ban in trust path
+  plane: A
+  proof_owner: p12
+  production_path: backend/app/trust
+  validator: scripts/ci/validate_b25_p12_trust_isolation.py
+  workflow: .github/workflows/b2_5-p11-export-compatibility.yml
+  negative_control:
+    id: NC-P12-ISO-02
+    resolution: source_identifier
+    resolves_in: scripts/ci/validate_b25_p12_trust_isolation.py
+- id: 17
+  invariant: Runtime sys.modules trace across trust paths
+  plane: B
+  proof_owner: p12
+  production_path: backend/app/trust
+  validator: scripts/ci/validate_b25_p12_trust_isolation.py
+  workflow: .github/workflows/b2_5-p11-export-compatibility.yml
+  negative_control:
+    id: NC-P12-ISO-03
+    resolution: source_identifier
+    resolves_in: scripts/ci/validate_b25_p12_trust_isolation.py
+  note: happy / degraded / refused / verify / export module-load trace.
+- id: 18
+  invariant: No compute dispatch from trust reads
+  plane: C
+  proof_owner: p12
+  production_path: backend/app/api/trust_api.py
+  validator: scripts/ci/validate_b25_p12_trust_isolation.py
+  workflow: .github/workflows/b2_5-p11-export-compatibility.yml
+  negative_control:
+    id: NC-P12-ISO-04
+    resolution: source_identifier
+    resolves_in: scripts/ci/validate_b25_p12_trust_isolation.py
+  note: Bans indirect dispatch surfaces (send_task, enqueue helpers, outbox, task-name strings), not only
+    direct imports of compute implementations.
+- id: 19
+  invariant: Policy authority never auto-executable
+  plane: B
+  proof_owner: inherited
+  production_path: backend/app/trust/policy_defaults.py
+  validator: scripts/ci/validate_b25_p6_reason_truth_matrix.py
+  workflow: .github/workflows/b2_5-p6-reason-truth-matrix.yml
+  negative_control:
+    id: NC-P12-INH-19
+    resolution: validator_control_mode
+    resolves_in: scripts/ci/validate_b25_p6_reason_truth_matrix.py
+    mode: --negative-control
+    granularity: mode_level
+    describes: p6 policy escalation fixtures
+- id: 20
+  invariant: Reason-code cross-field contradiction rejection
+  plane: B
+  proof_owner: inherited
+  production_path: backend/app/trust/reason_truth_matrix.py
+  validator: scripts/ci/validate_b25_p6_reason_truth_matrix.py
+  workflow: .github/workflows/b2_5-p6-reason-truth-matrix.yml
+  negative_control:
+    id: NC-P12-INH-20
+    resolution: validator_control_mode
+    resolves_in: scripts/ci/validate_b25_p6_reason_truth_matrix.py
+    mode: --negative-control
+    granularity: mode_level
+    describes: p6 contradiction matrix
+- id: 21
+  invariant: Refusal / degraded state validation
+  plane: B
+  proof_owner: inherited
+  production_path: backend/app/trust/refusal.py
+  validator: scripts/ci/validate_b25_p6_reason_truth_matrix.py
+  workflow: .github/workflows/b2_5-p6-reason-truth-matrix.yml
+  negative_control:
+    id: NC-P12-INH-21
+    resolution: validator_control_mode
+    resolves_in: scripts/ci/validate_b25_p6_reason_truth_matrix.py
+    mode: --negative-control
+    granularity: mode_level
+    describes: p6 registered-state coverage
+- id: 22
+  invariant: Export projection safety
+  plane: A
+  proof_owner: p12
+  production_path: backend/app/api/export.py
+  validator: scripts/ci/validate_b25_p12_contract_projection.py
+  workflow: .github/workflows/b2_5-p11-export-compatibility.yml
+  negative_control:
+    id: NC-P12-P0-01
+    resolution: source_identifier
+    resolves_in: scripts/ci/validate_b25_p12_contract_projection.py
+  note: Human G4 honesty and machine TrustEnvelope derivation are owned by P11; P12 adds the missing third
+    leg, active response/schema parity.
 path_trigger_required:
-  - contracts/trust-api/**
-  - backend/app/trust/**
-  - backend/app/api/trust_api.py
-  - backend/app/api/trust_export.py
-  - backend/app/api/export.py
-  - backend/tests/trust/**
-  - scripts/ci/validate_b25_p11_export_compatibility.py
-  - scripts/ci/validate_b25_p12_contract_projection.py
-  - scripts/ci/validate_b25_p12_trust_isolation.py
-  - scripts/ci/validate_b25_p12_ci_gates.py
-  - docs/ci/b25_p12_invariant_registry.yaml
-
-# Paths that currently reach NO B2.5 workflow, enumerated rather than omitted.
-#
-# Every entry is a real P12-G8 gap. The list is enforced in both directions: the
-# Plane D validator fails if an entry has since gained coverage (so the list
-# cannot rot into a stale excuse) and fails if an uncovered P12 validator is
-# missing from it (so a new gap cannot appear silently).
-# Contexts that actually emit today. The P12 proofs are bound into the
-# B2.5-P11 required context (see enforcement_binding below), so that is the
-# context which turns red on a composition regression.
+- contracts/trust-api/**
+- backend/app/trust/**
+- backend/app/api/trust_api.py
+- backend/app/api/trust_export.py
+- backend/app/api/export.py
+- backend/tests/trust/**
+- scripts/ci/validate_b25_p11_export_compatibility.py
+- scripts/ci/validate_b25_p12_contract_projection.py
+- scripts/ci/validate_b25_p12_trust_isolation.py
+- scripts/ci/validate_b25_p12_ci_gates.py
+- docs/ci/b25_p12_invariant_registry.yaml
 ci_contexts:
-  - B2.5-P11 Export Compatibility
-  - B2.5-P12 CI Gates
-
-# Honest statement of the enforcement topology.
-#
-# The P12 proofs run inside an already-REQUIRED status check, so a regression is
-# merge-blocking today. What does NOT yet exist is a dedicated `B2.5-P12 CI
-# Gates` context. Creating `.github/workflows/b2_5-p12-ci-gates.yml` requires
-# the `workflow` OAuth scope, which the available credentials do not carry.
-#
-# Enforcement strength and gate identity are different things and are reported
-# separately here rather than blurred:
+- B2.5-P11 Export Compatibility
+- B2.5-P12 CI Gates
 enforcement_binding:
   bound_context: B2.5-P11 Export Compatibility
   bound_workflow: .github/workflows/b2_5-p11-export-compatibility.yml
@@ -303,18 +327,21 @@ enforcement_binding:
   binding_function: _run_p12_composition_proofs
   merge_blocking_today: true
   dedicated_p12_context_present: true
-  # The dedicated context EXISTS and is emitted by its own workflow. Whether it
-  # is REQUIRED is a branch-protection setting, which is an administrative act
-  # and not something CI can assert for itself. The two are reported separately
-  # and must never be conflated (directive section 26).
   dedicated_p12_context: B2.5-P12 CI Gates
   dedicated_p12_context_required_in_branch_protection: true
   dedicated_p12_context_required_verified_at: 2026-08-10
-  dedicated_p12_context_required_evidence: >-
-    Verified against the live GitHub branch-protection API, not accepted on
-    report: contexts 71 -> 72, enforce_admins true, and a direct set comparison
-    against the governance contract showing 0 removals and exactly one addition
-    (B2.5-P12 CI Gates). Deleting the P12 workflow is now merge-blocking.
+  dedicated_p12_context_required_evidence: 'Verified against the live GitHub branch-protection API, not
+    accepted on report: contexts 71 -> 72, enforce_admins true, and a direct set comparison against the
+    governance contract showing 0 removals and exactly one addition (B2.5-P12 CI Gates). Deleting the
+    P12 workflow is now merge-blocking.'
   dedicated_p12_workflow: .github/workflows/b2_5-p12-ci-gates.yml
   dedicated_p12_context_blocker: null
   path_trigger_gap: null
+negative_control_resolution_doctrine: 'Every invariant''s negative_control must be mechanically resolvable
+  to something executable, not merely a non-empty string. Plane D previously checked only bool(value),
+  which accepted free-text prose and a wholly invented identifier (NC-P12-DOES-NOT-EXIST passed). Three
+  resolution classes are permitted, and each is verified differently: source_identifier requires the ID
+  to appear in the named validator''s source; validator_control_mode requires the named validator to expose
+  an executable --negative-control mode; drift_check requires a falsifier command. Where granularity is
+  mode_level the claim is deliberately NOT per-control - the validator is proven to have firing falsifiers,
+  not that one specific control maps to one specific domain. That limit is recorded rather than overstated.'

--- a/docs/ci/enforcer_registry.yaml
+++ b/docs/ci/enforcer_registry.yaml
@@ -1,4 +1,4 @@
-﻿- id: validate-b25-p12-contract-projection
+- id: validate-b25-p12-contract-projection
   path: scripts/ci/validate_b25_p12_contract_projection.py
   status: required
   owning_phase: B2.5-P12
@@ -44,6 +44,29 @@
   replacement: ''
   registry_action: keep
   evidence_pack: docs/forensics/B2.5-P12 Remediation Evidence Pack.md
+- id: b25-p12-runtime-module-trace
+  path: scripts/ci/_b25_p12_runtime_trace.py
+  status: required
+  owning_phase: B2.5-P12
+  protected_invariant: 'B2.5-P12 domain 17 runtime isolation: no forbidden LLM or Bayesian module is resident after exercising trust runtime paths. Executed in a fresh interpreter so the sys.modules baseline precedes every first-party import, which makes import-time dependencies observable. The previous in-process trace captured its baseline AFTER importing the modules under observation and could therefore only detect lazy imports.'
+  command: python scripts/ci/_b25_p12_runtime_trace.py
+  workflow_references:
+  - .github/workflows/b2_5-p12-ci-gates.yml
+  workflow_job_name: B2.5-P12 CI Gates
+  local_reproduction_command: python scripts/ci/_b25_p12_runtime_trace.py
+  expected_failure_meaning: A forbidden module was resident in sys.modules after a trust runtime path executed, whether imported lazily during the call or transitively at import time.
+  first_diagnostic_command: python scripts/ci/_b25_p12_runtime_trace.py
+  depends_on_db: false
+  depends_on_celery: false
+  depends_on_pooler: false
+  deprecation_reason: ''
+  subsumed_by: ''
+  ci_visibility: named_step
+  default_execution: true
+  execution_cohort: b2-5-p12-ci-gates
+  replacement: ''
+  registry_action: keep
+  evidence_pack: docs/forensics/B2.5-P13 Remediation Evidence Pack.md
 - id: validate-b25-p12-ci-gates
   path: scripts/ci/validate_b25_p12_ci_gates.py
   status: required
@@ -702,14 +725,12 @@
   path: scripts/ci/enforce_b17_p0_explanation_surface_lock.py
   status: required
   owning_phase: B17-P0
-  protected_invariant: Utility support script enforce_b17_p0_explanation_surface_lock; not a default adjudication gate unless
-    called by a registered workflow.
+  protected_invariant: Utility support script enforce_b17_p0_explanation_surface_lock; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b17_p0_explanation_surface_lock.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b17_p0_explanation_surface_lock.py
-  expected_failure_meaning: enforce_b17_p0_explanation_surface_lock detected drift in its protected invariant; inspect the
-    gate output before changing production semantics.
+  expected_failure_meaning: enforce_b17_p0_explanation_surface_lock detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b17_p0_explanation_surface_lock.py --help || python scripts/ci/enforce_b17_p0_explanation_surface_lock.py
   depends_on_db: true
   depends_on_celery: false
@@ -725,14 +746,12 @@
   path: scripts/ci/enforce_b21_p0_authority_convergence.py
   status: required
   owning_phase: B21-P0
-  protected_invariant: Utility support script enforce_b21_p0_authority_convergence; not a default adjudication gate unless
-    called by a registered workflow.
+  protected_invariant: Utility support script enforce_b21_p0_authority_convergence; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b21_p0_authority_convergence.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b21_p0_authority_convergence.py
-  expected_failure_meaning: enforce_b21_p0_authority_convergence detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b21_p0_authority_convergence detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b21_p0_authority_convergence.py --help || python scripts/ci/enforce_b21_p0_authority_convergence.py
   depends_on_db: true
   depends_on_celery: true
@@ -748,14 +767,12 @@
   path: scripts/ci/enforce_b21_p1_semantic_replay_lock.py
   status: required
   owning_phase: B21-P1
-  protected_invariant: Utility support script enforce_b21_p1_semantic_replay_lock; not a default adjudication gate unless
-    called by a registered workflow.
+  protected_invariant: Utility support script enforce_b21_p1_semantic_replay_lock; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b21_p1_semantic_replay_lock.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b21_p1_semantic_replay_lock.py
-  expected_failure_meaning: enforce_b21_p1_semantic_replay_lock detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b21_p1_semantic_replay_lock detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b21_p1_semantic_replay_lock.py --help || python scripts/ci/enforce_b21_p1_semantic_replay_lock.py
   depends_on_db: false
   depends_on_celery: false
@@ -771,14 +788,12 @@
   path: scripts/ci/enforce_b21_p2_strategy_kernel_lock.py
   status: required
   owning_phase: B21-P2
-  protected_invariant: Utility support script enforce_b21_p2_strategy_kernel_lock; not a default adjudication gate unless
-    called by a registered workflow.
+  protected_invariant: Utility support script enforce_b21_p2_strategy_kernel_lock; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b21_p2_strategy_kernel_lock.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b21_p2_strategy_kernel_lock.py
-  expected_failure_meaning: enforce_b21_p2_strategy_kernel_lock detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b21_p2_strategy_kernel_lock detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b21_p2_strategy_kernel_lock.py --help || python scripts/ci/enforce_b21_p2_strategy_kernel_lock.py
   depends_on_db: false
   depends_on_celery: false
@@ -794,14 +809,12 @@
   path: scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py
   status: required
   owning_phase: B21-P3
-  protected_invariant: Utility support script enforce_b21_p3_persistence_read_surface_lock; not a default adjudication gate
-    unless called by a registered workflow.
+  protected_invariant: Utility support script enforce_b21_p3_persistence_read_surface_lock; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py
-  expected_failure_meaning: enforce_b21_p3_persistence_read_surface_lock detected drift in its protected invariant; inspect
-    the gate output before changing production semantics.
+  expected_failure_meaning: enforce_b21_p3_persistence_read_surface_lock detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py --help || python scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py
   depends_on_db: true
   depends_on_celery: false
@@ -817,14 +830,12 @@
   path: scripts/ci/enforce_b21_p4_queue_isolation_semantics_lock.py
   status: required
   owning_phase: B21-P4
-  protected_invariant: Utility support script enforce_b21_p4_queue_isolation_semantics_lock; not a default adjudication gate
-    unless called by a registered workflow.
+  protected_invariant: Utility support script enforce_b21_p4_queue_isolation_semantics_lock; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b21_p4_queue_isolation_semantics_lock.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b21_p4_queue_isolation_semantics_lock.py
-  expected_failure_meaning: enforce_b21_p4_queue_isolation_semantics_lock detected drift in its protected invariant; inspect
-    the gate output before changing production semantics.
+  expected_failure_meaning: enforce_b21_p4_queue_isolation_semantics_lock detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b21_p4_queue_isolation_semantics_lock.py --help || python scripts/ci/enforce_b21_p4_queue_isolation_semantics_lock.py
   depends_on_db: false
   depends_on_celery: true
@@ -840,14 +851,12 @@
   path: scripts/ci/enforce_b21_p5_nonvacuous_adjudication.py
   status: required
   owning_phase: B21-P5
-  protected_invariant: B21-P5 invariant enforced by enforce_b21_p5_nonvacuous_adjudication; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B21-P5 invariant enforced by enforce_b21_p5_nonvacuous_adjudication; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b21_p5_nonvacuous_adjudication.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b21_p5_nonvacuous_adjudication.py
-  expected_failure_meaning: enforce_b21_p5_nonvacuous_adjudication detected drift in its protected invariant; inspect the
-    gate output before changing production semantics.
+  expected_failure_meaning: enforce_b21_p5_nonvacuous_adjudication detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b21_p5_nonvacuous_adjudication.py --help || python scripts/ci/enforce_b21_p5_nonvacuous_adjudication.py
   depends_on_db: false
   depends_on_celery: false
@@ -863,14 +872,12 @@
   path: scripts/ci/enforce_b21_p6_full_chain_closure.py
   status: required
   owning_phase: B21-P6
-  protected_invariant: B21-P6 invariant enforced by enforce_b21_p6_full_chain_closure; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B21-P6 invariant enforced by enforce_b21_p6_full_chain_closure; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b21_p6_full_chain_closure.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b21_p6_full_chain_closure.py
-  expected_failure_meaning: enforce_b21_p6_full_chain_closure detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b21_p6_full_chain_closure detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b21_p6_full_chain_closure.py --help || python scripts/ci/enforce_b21_p6_full_chain_closure.py
   depends_on_db: false
   depends_on_celery: false
@@ -886,14 +893,12 @@
   path: scripts/ci/enforce_b17_p4_strategy_closure.py
   status: required
   owning_phase: B17-P4
-  protected_invariant: Utility support script enforce_b17_p4_strategy_closure; not a default adjudication gate unless called
-    by a registered workflow.
+  protected_invariant: Utility support script enforce_b17_p4_strategy_closure; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b17_p4_strategy_closure.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b17_p4_strategy_closure.py
-  expected_failure_meaning: enforce_b17_p4_strategy_closure detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_b17_p4_strategy_closure detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b17_p4_strategy_closure.py --help || python scripts/ci/enforce_b17_p4_strategy_closure.py
   depends_on_db: false
   depends_on_celery: false
@@ -909,14 +914,12 @@
   path: scripts/ci/enforce_b17_p5_merge_blocking_adjudication.py
   status: required
   owning_phase: B17-P5
-  protected_invariant: Utility support script enforce_b17_p5_merge_blocking_adjudication; not a default adjudication gate
-    unless called by a registered workflow.
+  protected_invariant: Utility support script enforce_b17_p5_merge_blocking_adjudication; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b17_p5_merge_blocking_adjudication.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b17_p5_merge_blocking_adjudication.py
-  expected_failure_meaning: enforce_b17_p5_merge_blocking_adjudication detected drift in its protected invariant; inspect
-    the gate output before changing production semantics.
+  expected_failure_meaning: enforce_b17_p5_merge_blocking_adjudication detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b17_p5_merge_blocking_adjudication.py --help || python scripts/ci/enforce_b17_p5_merge_blocking_adjudication.py
   depends_on_db: false
   depends_on_celery: false
@@ -932,14 +935,12 @@
   path: scripts/ci/enforce_b17_p6_adjudication_plane.py
   status: required
   owning_phase: B17-P6
-  protected_invariant: B17-P6 invariant enforced by enforce_b17_p6_adjudication_plane; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B17-P6 invariant enforced by enforce_b17_p6_adjudication_plane; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b17_p6_adjudication_plane.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b17_p6_adjudication_plane.py
-  expected_failure_meaning: enforce_b17_p6_adjudication_plane detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b17_p6_adjudication_plane detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b17_p6_adjudication_plane.py --help || python scripts/ci/enforce_b17_p6_adjudication_plane.py
   depends_on_db: false
   depends_on_celery: false
@@ -955,14 +956,12 @@
   path: scripts/ci/enforce_b22_p0_webhook_surface_lock.py
   status: required
   owning_phase: B22-P0
-  protected_invariant: Utility support script enforce_b22_p0_webhook_surface_lock; not a default adjudication gate unless
-    called by a registered workflow.
+  protected_invariant: Utility support script enforce_b22_p0_webhook_surface_lock; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b22_p0_webhook_surface_lock.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b22_p0_webhook_surface_lock.py
-  expected_failure_meaning: enforce_b22_p0_webhook_surface_lock detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b22_p0_webhook_surface_lock detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b22_p0_webhook_surface_lock.py --help || python scripts/ci/enforce_b22_p0_webhook_surface_lock.py
   depends_on_db: true
   depends_on_celery: false
@@ -978,14 +977,12 @@
   path: scripts/ci/enforce_b22_p1_authenticity_semantics_lock.py
   status: required
   owning_phase: B22-P1
-  protected_invariant: Utility support script enforce_b22_p1_authenticity_semantics_lock; not a default adjudication gate
-    unless called by a registered workflow.
+  protected_invariant: Utility support script enforce_b22_p1_authenticity_semantics_lock; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b22_p1_authenticity_semantics_lock.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b22_p1_authenticity_semantics_lock.py
-  expected_failure_meaning: enforce_b22_p1_authenticity_semantics_lock detected drift in its protected invariant; inspect
-    the gate output before changing production semantics.
+  expected_failure_meaning: enforce_b22_p1_authenticity_semantics_lock detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b22_p1_authenticity_semantics_lock.py --help || python scripts/ci/enforce_b22_p1_authenticity_semantics_lock.py
   depends_on_db: false
   depends_on_celery: false
@@ -1001,14 +998,12 @@
   path: scripts/ci/enforce_b22_p2_post_auth_privacy_boundary.py
   status: required
   owning_phase: B22-P2
-  protected_invariant: Utility support script enforce_b22_p2_post_auth_privacy_boundary; not a default adjudication gate unless
-    called by a registered workflow.
+  protected_invariant: Utility support script enforce_b22_p2_post_auth_privacy_boundary; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b22_p2_post_auth_privacy_boundary.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b22_p2_post_auth_privacy_boundary.py
-  expected_failure_meaning: enforce_b22_p2_post_auth_privacy_boundary detected drift in its protected invariant; inspect the
-    gate output before changing production semantics.
+  expected_failure_meaning: enforce_b22_p2_post_auth_privacy_boundary detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b22_p2_post_auth_privacy_boundary.py --help || python scripts/ci/enforce_b22_p2_post_auth_privacy_boundary.py
   depends_on_db: false
   depends_on_celery: false
@@ -1024,14 +1019,12 @@
   path: scripts/ci/enforce_b22_p3_canonical_commerce_identity_envelope.py
   status: required
   owning_phase: B22-P3
-  protected_invariant: Utility support script enforce_b22_p3_canonical_commerce_identity_envelope; not a default adjudication
-    gate unless called by a registered workflow.
+  protected_invariant: Utility support script enforce_b22_p3_canonical_commerce_identity_envelope; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b22_p3_canonical_commerce_identity_envelope.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b22_p3_canonical_commerce_identity_envelope.py
-  expected_failure_meaning: enforce_b22_p3_canonical_commerce_identity_envelope detected drift in its protected invariant;
-    inspect the gate output before changing production semantics.
+  expected_failure_meaning: enforce_b22_p3_canonical_commerce_identity_envelope detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b22_p3_canonical_commerce_identity_envelope.py --help || python scripts/ci/enforce_b22_p3_canonical_commerce_identity_envelope.py
   depends_on_db: true
   depends_on_celery: false
@@ -1047,14 +1040,12 @@
   path: scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py
   status: required
   owning_phase: B22-P4
-  protected_invariant: Utility support script enforce_b22_p4_idempotent_ack_orchestration; not a default adjudication gate
-    unless called by a registered workflow.
+  protected_invariant: Utility support script enforce_b22_p4_idempotent_ack_orchestration; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py
-  expected_failure_meaning: enforce_b22_p4_idempotent_ack_orchestration detected drift in its protected invariant; inspect
-    the gate output before changing production semantics.
+  expected_failure_meaning: enforce_b22_p4_idempotent_ack_orchestration detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py --help || python scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py
   depends_on_db: false
   depends_on_celery: false
@@ -1070,14 +1061,12 @@
   path: scripts/ci/enforce_b22_p5_performance_negative_control_lock.py
   status: required
   owning_phase: B22-P5
-  protected_invariant: Utility support script enforce_b22_p5_performance_negative_control_lock; not a default adjudication
-    gate unless called by a registered workflow.
+  protected_invariant: Utility support script enforce_b22_p5_performance_negative_control_lock; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b22_p5_performance_negative_control_lock.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b22_p5_performance_negative_control_lock.py
-  expected_failure_meaning: enforce_b22_p5_performance_negative_control_lock detected drift in its protected invariant; inspect
-    the gate output before changing production semantics.
+  expected_failure_meaning: enforce_b22_p5_performance_negative_control_lock detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b22_p5_performance_negative_control_lock.py --help || python scripts/ci/enforce_b22_p5_performance_negative_control_lock.py
   depends_on_db: false
   depends_on_celery: false
@@ -1093,14 +1082,12 @@
   path: scripts/ci/enforce_b23_p0_typed_boundary_source_alignment.py
   status: required
   owning_phase: B23-P0
-  protected_invariant: Utility support script enforce_b23_p0_typed_boundary_source_alignment; not a default adjudication gate
-    unless called by a registered workflow.
+  protected_invariant: Utility support script enforce_b23_p0_typed_boundary_source_alignment; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b23_p0_typed_boundary_source_alignment.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b23_p0_typed_boundary_source_alignment.py
-  expected_failure_meaning: enforce_b23_p0_typed_boundary_source_alignment detected drift in its protected invariant; inspect
-    the gate output before changing production semantics.
+  expected_failure_meaning: enforce_b23_p0_typed_boundary_source_alignment detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b23_p0_typed_boundary_source_alignment.py --help || python scripts/ci/enforce_b23_p0_typed_boundary_source_alignment.py
   depends_on_db: true
   depends_on_celery: false
@@ -1116,14 +1103,12 @@
   path: scripts/ci/enforce_b23_p0_semantic_authority_freeze.py
   status: required
   owning_phase: B23-P0
-  protected_invariant: Utility support script enforce_b23_p0_semantic_authority_freeze; not a default adjudication gate unless
-    called by a registered workflow.
+  protected_invariant: Utility support script enforce_b23_p0_semantic_authority_freeze; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b23_p0_semantic_authority_freeze.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b23_p0_semantic_authority_freeze.py
-  expected_failure_meaning: enforce_b23_p0_semantic_authority_freeze detected drift in its protected invariant; inspect the
-    gate output before changing production semantics.
+  expected_failure_meaning: enforce_b23_p0_semantic_authority_freeze detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b23_p0_semantic_authority_freeze.py --help || python scripts/ci/enforce_b23_p0_semantic_authority_freeze.py
   depends_on_db: true
   depends_on_celery: false
@@ -1139,14 +1124,12 @@
   path: scripts/ci/enforce_b23_pre_p1_spec_gate.py
   status: required
   owning_phase: B23
-  protected_invariant: Utility support script enforce_b23_pre_p1_spec_gate; not a default adjudication gate unless called
-    by a registered workflow.
+  protected_invariant: Utility support script enforce_b23_pre_p1_spec_gate; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b23_pre_p1_spec_gate.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b23_pre_p1_spec_gate.py
-  expected_failure_meaning: enforce_b23_pre_p1_spec_gate detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_b23_pre_p1_spec_gate detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b23_pre_p1_spec_gate.py --help || python scripts/ci/enforce_b23_pre_p1_spec_gate.py
   depends_on_db: false
   depends_on_celery: false
@@ -1162,14 +1145,12 @@
   path: scripts/ci/enforce_b23_p1_schema_authority_lock.py
   status: required
   owning_phase: B23-P1
-  protected_invariant: Utility support script enforce_b23_p1_schema_authority_lock; not a default adjudication gate unless
-    called by a registered workflow.
+  protected_invariant: Utility support script enforce_b23_p1_schema_authority_lock; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b23_p1_schema_authority_lock.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b23_p1_schema_authority_lock.py
-  expected_failure_meaning: enforce_b23_p1_schema_authority_lock detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b23_p1_schema_authority_lock detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b23_p1_schema_authority_lock.py --help || python scripts/ci/enforce_b23_p1_schema_authority_lock.py
   depends_on_db: false
   depends_on_celery: false
@@ -1185,16 +1166,14 @@
   path: scripts/ci/verify_b23_p1_migration_reversibility.py
   status: required
   owning_phase: B23-P1
-  protected_invariant: B23-P1 invariant enforced by verify_b23_p1_migration_reversibility; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B23-P1 invariant enforced by verify_b23_p1_migration_reversibility; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/verify_b23_p1_migration_reversibility.py
   env:
     B23_P1_MIGRATION_DSN: ${MIGRATION_DATABASE_URL}
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/verify_b23_p1_migration_reversibility.py
-  expected_failure_meaning: verify_b23_p1_migration_reversibility detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: verify_b23_p1_migration_reversibility detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/verify_b23_p1_migration_reversibility.py --help || python scripts/ci/verify_b23_p1_migration_reversibility.py
   depends_on_db: true
   depends_on_celery: false
@@ -1210,14 +1189,12 @@
   path: scripts/ci/enforce_b23_p2_match_engine_kernel.py
   status: required
   owning_phase: B23-P2
-  protected_invariant: Utility support script enforce_b23_p2_match_engine_kernel; not a default adjudication gate unless called
-    by a registered workflow.
+  protected_invariant: Utility support script enforce_b23_p2_match_engine_kernel; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b23_p2_match_engine_kernel.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b23_p2_match_engine_kernel.py
-  expected_failure_meaning: enforce_b23_p2_match_engine_kernel detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b23_p2_match_engine_kernel detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b23_p2_match_engine_kernel.py --help || python scripts/ci/enforce_b23_p2_match_engine_kernel.py
   depends_on_db: false
   depends_on_celery: false
@@ -1233,14 +1210,12 @@
   path: scripts/ci/enforce_b23_p3_verdict_persistence.py
   status: required
   owning_phase: B23-P3
-  protected_invariant: Utility support script enforce_b23_p3_verdict_persistence; not a default adjudication gate unless called
-    by a registered workflow.
+  protected_invariant: Utility support script enforce_b23_p3_verdict_persistence; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b23_p3_verdict_persistence.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b23_p3_verdict_persistence.py
-  expected_failure_meaning: enforce_b23_p3_verdict_persistence detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b23_p3_verdict_persistence detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b23_p3_verdict_persistence.py --help || python scripts/ci/enforce_b23_p3_verdict_persistence.py
   depends_on_db: true
   depends_on_celery: true
@@ -1256,14 +1231,12 @@
   path: scripts/ci/enforce_b23_p4_queue_performance.py
   status: required
   owning_phase: B23-P4
-  protected_invariant: Utility support script enforce_b23_p4_queue_performance; not a default adjudication gate unless called
-    by a registered workflow.
+  protected_invariant: Utility support script enforce_b23_p4_queue_performance; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b23_p4_queue_performance.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b23_p4_queue_performance.py
-  expected_failure_meaning: enforce_b23_p4_queue_performance detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_b23_p4_queue_performance detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b23_p4_queue_performance.py --help || python scripts/ci/enforce_b23_p4_queue_performance.py
   depends_on_db: false
   depends_on_celery: true
@@ -1279,14 +1252,12 @@
   path: scripts/ci/assert_b15_p7_playwright_execution.py
   status: active
   owning_phase: B15-P7
-  protected_invariant: B15-P7 invariant enforced by assert_b15_p7_playwright_execution; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B15-P7 invariant enforced by assert_b15_p7_playwright_execution; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/assert_b15_p7_playwright_execution.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/assert_b15_p7_playwright_execution.py
-  expected_failure_meaning: assert_b15_p7_playwright_execution detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: assert_b15_p7_playwright_execution detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/assert_b15_p7_playwright_execution.py --help || python scripts/ci/assert_b15_p7_playwright_execution.py
   depends_on_db: false
   depends_on_celery: false
@@ -1302,14 +1273,12 @@
   path: scripts/ci/b055_evidence_bundle.py
   status: required
   owning_phase: B055
-  protected_invariant: B055 invariant enforced by b055_evidence_bundle; keeps its documented negative-control and proof surface
-    visible in CI.
+  protected_invariant: B055 invariant enforced by b055_evidence_bundle; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/b055_evidence_bundle.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/b055_evidence_bundle.py
-  expected_failure_meaning: b055_evidence_bundle detected drift in its protected invariant; inspect the gate output before
-    changing production semantics.
+  expected_failure_meaning: b055_evidence_bundle detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/b055_evidence_bundle.py --help || python scripts/ci/b055_evidence_bundle.py
   depends_on_db: true
   depends_on_celery: false
@@ -1325,14 +1294,12 @@
   path: scripts/ci/b15_p7_phase_closure_gate.py
   status: active
   owning_phase: B15-P7
-  protected_invariant: B15-P7 invariant enforced by b15_p7_phase_closure_gate; keeps its documented negative-control and proof
-    surface visible in CI.
+  protected_invariant: B15-P7 invariant enforced by b15_p7_phase_closure_gate; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/b15_p7_phase_closure_gate.py
   workflow_references:
   - .github/workflows/schema-deploy-production.yml
   local_reproduction_command: python scripts/ci/b15_p7_phase_closure_gate.py
-  expected_failure_meaning: b15_p7_phase_closure_gate detected drift in its protected invariant; inspect the gate output before
-    changing production semantics.
+  expected_failure_meaning: b15_p7_phase_closure_gate detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/b15_p7_phase_closure_gate.py --help || python scripts/ci/b15_p7_phase_closure_gate.py
   depends_on_db: false
   depends_on_celery: false
@@ -1348,14 +1315,12 @@
   path: scripts/ci/capture_b13_p11_branch_protection_evidence.py
   status: required
   owning_phase: B13-P11
-  protected_invariant: B13-P11 invariant enforced by capture_b13_p11_branch_protection_evidence; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P11 invariant enforced by capture_b13_p11_branch_protection_evidence; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/capture_b13_p11_branch_protection_evidence.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/capture_b13_p11_branch_protection_evidence.py
-  expected_failure_meaning: capture_b13_p11_branch_protection_evidence detected drift in its protected invariant; inspect
-    the gate output before changing production semantics.
+  expected_failure_meaning: capture_b13_p11_branch_protection_evidence detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/capture_b13_p11_branch_protection_evidence.py --help || python scripts/ci/capture_b13_p11_branch_protection_evidence.py
   depends_on_db: false
   depends_on_celery: false
@@ -1371,14 +1336,12 @@
   path: scripts/ci/capture_b14_p7_branch_protection_evidence.py
   status: required
   owning_phase: B14-P7
-  protected_invariant: B14-P7 invariant enforced by capture_b14_p7_branch_protection_evidence; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B14-P7 invariant enforced by capture_b14_p7_branch_protection_evidence; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/capture_b14_p7_branch_protection_evidence.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/capture_b14_p7_branch_protection_evidence.py
-  expected_failure_meaning: capture_b14_p7_branch_protection_evidence detected drift in its protected invariant; inspect the
-    gate output before changing production semantics.
+  expected_failure_meaning: capture_b14_p7_branch_protection_evidence detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/capture_b14_p7_branch_protection_evidence.py --help || python scripts/ci/capture_b14_p7_branch_protection_evidence.py
   depends_on_db: false
   depends_on_celery: false
@@ -1394,14 +1357,12 @@
   path: scripts/ci/eg5_cache_validation.py
   status: required
   owning_phase: CI-GOVERNANCE
-  protected_invariant: CI-GOVERNANCE invariant enforced by eg5_cache_validation; keeps its documented negative-control and
-    proof surface visible in CI.
+  protected_invariant: CI-GOVERNANCE invariant enforced by eg5_cache_validation; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/eg5_cache_validation.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/eg5_cache_validation.py
-  expected_failure_meaning: eg5_cache_validation detected drift in its protected invariant; inspect the gate output before
-    changing production semantics.
+  expected_failure_meaning: eg5_cache_validation detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/eg5_cache_validation.py --help || python scripts/ci/eg5_cache_validation.py
   depends_on_db: false
   depends_on_celery: true
@@ -1417,14 +1378,12 @@
   path: scripts/ci/enforce_b13_p0_codeowners.py
   status: required
   owning_phase: B13-P0
-  protected_invariant: B13-P0 invariant enforced by enforce_b13_p0_codeowners; keeps its documented negative-control and proof
-    surface visible in CI.
+  protected_invariant: B13-P0 invariant enforced by enforce_b13_p0_codeowners; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b13_p0_codeowners.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b13_p0_codeowners.py
-  expected_failure_meaning: enforce_b13_p0_codeowners detected drift in its protected invariant; inspect the gate output before
-    changing production semantics.
+  expected_failure_meaning: enforce_b13_p0_codeowners detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b13_p0_codeowners.py --help || python scripts/ci/enforce_b13_p0_codeowners.py
   depends_on_db: false
   depends_on_celery: false
@@ -1440,14 +1399,12 @@
   path: scripts/ci/enforce_b13_p0_evidence_pack.py
   status: required
   owning_phase: B13-P0
-  protected_invariant: B13-P0 invariant enforced by enforce_b13_p0_evidence_pack; keeps its documented negative-control and
-    proof surface visible in CI.
+  protected_invariant: B13-P0 invariant enforced by enforce_b13_p0_evidence_pack; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b13_p0_evidence_pack.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b13_p0_evidence_pack.py
-  expected_failure_meaning: enforce_b13_p0_evidence_pack detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_b13_p0_evidence_pack detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b13_p0_evidence_pack.py --help || python scripts/ci/enforce_b13_p0_evidence_pack.py
   depends_on_db: false
   depends_on_celery: false
@@ -1463,14 +1420,12 @@
   path: scripts/ci/enforce_b13_p0_scope_truth.py
   status: required
   owning_phase: B13-P0
-  protected_invariant: B13-P0 invariant enforced by enforce_b13_p0_scope_truth; keeps its documented negative-control and
-    proof surface visible in CI.
+  protected_invariant: B13-P0 invariant enforced by enforce_b13_p0_scope_truth; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b13_p0_scope_truth.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b13_p0_scope_truth.py
-  expected_failure_meaning: enforce_b13_p0_scope_truth detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_b13_p0_scope_truth detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b13_p0_scope_truth.py --help || python scripts/ci/enforce_b13_p0_scope_truth.py
   depends_on_db: false
   depends_on_celery: false
@@ -1486,14 +1441,12 @@
   path: scripts/ci/enforce_b13_p1_contract_authority.py
   status: required
   owning_phase: B13-P1
-  protected_invariant: B13-P1 invariant enforced by enforce_b13_p1_contract_authority; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P1 invariant enforced by enforce_b13_p1_contract_authority; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b13_p1_contract_authority.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b13_p1_contract_authority.py
-  expected_failure_meaning: enforce_b13_p1_contract_authority detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b13_p1_contract_authority detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b13_p1_contract_authority.py --help || python scripts/ci/enforce_b13_p1_contract_authority.py
   depends_on_db: false
   depends_on_celery: false
@@ -1509,14 +1462,12 @@
   path: scripts/ci/enforce_b13_p10_provider_tranche_proofs.py
   status: required
   owning_phase: B13-P10
-  protected_invariant: B13-P10 invariant enforced by enforce_b13_p10_provider_tranche_proofs; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P10 invariant enforced by enforce_b13_p10_provider_tranche_proofs; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b13_p10_provider_tranche_proofs.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b13_p10_provider_tranche_proofs.py
-  expected_failure_meaning: enforce_b13_p10_provider_tranche_proofs detected drift in its protected invariant; inspect the
-    gate output before changing production semantics.
+  expected_failure_meaning: enforce_b13_p10_provider_tranche_proofs detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b13_p10_provider_tranche_proofs.py --help || python scripts/ci/enforce_b13_p10_provider_tranche_proofs.py
   depends_on_db: false
   depends_on_celery: false
@@ -1532,14 +1483,12 @@
   path: scripts/ci/enforce_b13_p11_e2e_system_proofs.py
   status: required
   owning_phase: B13-P11
-  protected_invariant: B13-P11 invariant enforced by enforce_b13_p11_e2e_system_proofs; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P11 invariant enforced by enforce_b13_p11_e2e_system_proofs; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b13_p11_e2e_system_proofs.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b13_p11_e2e_system_proofs.py
-  expected_failure_meaning: enforce_b13_p11_e2e_system_proofs detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b13_p11_e2e_system_proofs detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b13_p11_e2e_system_proofs.py --help || python scripts/ci/enforce_b13_p11_e2e_system_proofs.py
   depends_on_db: false
   depends_on_celery: true
@@ -1555,14 +1504,12 @@
   path: scripts/ci/enforce_b13_p2_evidence_pack.py
   status: required
   owning_phase: B13-P2
-  protected_invariant: B13-P2 invariant enforced by enforce_b13_p2_evidence_pack; keeps its documented negative-control and
-    proof surface visible in CI.
+  protected_invariant: B13-P2 invariant enforced by enforce_b13_p2_evidence_pack; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b13_p2_evidence_pack.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b13_p2_evidence_pack.py
-  expected_failure_meaning: enforce_b13_p2_evidence_pack detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_b13_p2_evidence_pack detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b13_p2_evidence_pack.py --help || python scripts/ci/enforce_b13_p2_evidence_pack.py
   depends_on_db: false
   depends_on_celery: false
@@ -1578,14 +1525,12 @@
   path: scripts/ci/enforce_b13_p2_handshake_state.py
   status: required
   owning_phase: B13-P2
-  protected_invariant: B13-P2 invariant enforced by enforce_b13_p2_handshake_state; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P2 invariant enforced by enforce_b13_p2_handshake_state; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b13_p2_handshake_state.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b13_p2_handshake_state.py
-  expected_failure_meaning: enforce_b13_p2_handshake_state detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_b13_p2_handshake_state detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b13_p2_handshake_state.py --help || python scripts/ci/enforce_b13_p2_handshake_state.py
   depends_on_db: true
   depends_on_celery: false
@@ -1601,14 +1546,12 @@
   path: scripts/ci/enforce_b13_p3_durable_lifecycle.py
   status: required
   owning_phase: B13-P3
-  protected_invariant: B13-P3 invariant enforced by enforce_b13_p3_durable_lifecycle; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P3 invariant enforced by enforce_b13_p3_durable_lifecycle; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b13_p3_durable_lifecycle.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b13_p3_durable_lifecycle.py
-  expected_failure_meaning: enforce_b13_p3_durable_lifecycle detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_b13_p3_durable_lifecycle detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b13_p3_durable_lifecycle.py --help || python scripts/ci/enforce_b13_p3_durable_lifecycle.py
   depends_on_db: true
   depends_on_celery: false
@@ -1624,14 +1567,12 @@
   path: scripts/ci/enforce_b13_p4_boundary_hardening.py
   status: required
   owning_phase: B13-P4
-  protected_invariant: B13-P4 invariant enforced by enforce_b13_p4_boundary_hardening; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P4 invariant enforced by enforce_b13_p4_boundary_hardening; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b13_p4_boundary_hardening.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b13_p4_boundary_hardening.py
-  expected_failure_meaning: enforce_b13_p4_boundary_hardening detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b13_p4_boundary_hardening detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b13_p4_boundary_hardening.py --help || python scripts/ci/enforce_b13_p4_boundary_hardening.py
   depends_on_db: false
   depends_on_celery: false
@@ -1647,14 +1588,12 @@
   path: scripts/ci/enforce_b13_p5_adapter_layer.py
   status: required
   owning_phase: B13-P5
-  protected_invariant: B13-P5 invariant enforced by enforce_b13_p5_adapter_layer; keeps its documented negative-control and
-    proof surface visible in CI.
+  protected_invariant: B13-P5 invariant enforced by enforce_b13_p5_adapter_layer; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b13_p5_adapter_layer.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b13_p5_adapter_layer.py
-  expected_failure_meaning: enforce_b13_p5_adapter_layer detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_b13_p5_adapter_layer detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b13_p5_adapter_layer.py --help || python scripts/ci/enforce_b13_p5_adapter_layer.py
   depends_on_db: false
   depends_on_celery: false
@@ -1670,14 +1609,12 @@
   path: scripts/ci/enforce_b13_p6_runtime_lifecycle.py
   status: required
   owning_phase: B13-P6
-  protected_invariant: B13-P6 invariant enforced by enforce_b13_p6_runtime_lifecycle; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P6 invariant enforced by enforce_b13_p6_runtime_lifecycle; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b13_p6_runtime_lifecycle.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b13_p6_runtime_lifecycle.py
-  expected_failure_meaning: enforce_b13_p6_runtime_lifecycle detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_b13_p6_runtime_lifecycle detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b13_p6_runtime_lifecycle.py --help || python scripts/ci/enforce_b13_p6_runtime_lifecycle.py
   depends_on_db: false
   depends_on_celery: true
@@ -1693,14 +1630,12 @@
   path: scripts/ci/enforce_b13_p7_refresh_orchestration.py
   status: required
   owning_phase: B13-P7
-  protected_invariant: B13-P7 invariant enforced by enforce_b13_p7_refresh_orchestration; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P7 invariant enforced by enforce_b13_p7_refresh_orchestration; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b13_p7_refresh_orchestration.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b13_p7_refresh_orchestration.py
-  expected_failure_meaning: enforce_b13_p7_refresh_orchestration detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b13_p7_refresh_orchestration detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b13_p7_refresh_orchestration.py --help || python scripts/ci/enforce_b13_p7_refresh_orchestration.py
   depends_on_db: false
   depends_on_celery: true
@@ -1716,14 +1651,12 @@
   path: scripts/ci/enforce_b13_p8_failure_baseline.py
   status: required
   owning_phase: B13-P8
-  protected_invariant: B13-P8 invariant enforced by enforce_b13_p8_failure_baseline; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P8 invariant enforced by enforce_b13_p8_failure_baseline; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b13_p8_failure_baseline.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b13_p8_failure_baseline.py
-  expected_failure_meaning: enforce_b13_p8_failure_baseline detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_b13_p8_failure_baseline detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b13_p8_failure_baseline.py --help || python scripts/ci/enforce_b13_p8_failure_baseline.py
   depends_on_db: false
   depends_on_celery: false
@@ -1739,14 +1672,12 @@
   path: scripts/ci/enforce_b13_p9_core_substrate_closure.py
   status: required
   owning_phase: B13-P9
-  protected_invariant: B13-P9 invariant enforced by enforce_b13_p9_core_substrate_closure; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P9 invariant enforced by enforce_b13_p9_core_substrate_closure; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b13_p9_core_substrate_closure.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b13_p9_core_substrate_closure.py
-  expected_failure_meaning: enforce_b13_p9_core_substrate_closure detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b13_p9_core_substrate_closure detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b13_p9_core_substrate_closure.py --help || python scripts/ci/enforce_b13_p9_core_substrate_closure.py
   depends_on_db: true
   depends_on_celery: true
@@ -1762,14 +1693,12 @@
   path: scripts/ci/enforce_b14_p0_privacy_authority.py
   status: required
   owning_phase: B14-P0
-  protected_invariant: B14-P0 invariant enforced by enforce_b14_p0_privacy_authority; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B14-P0 invariant enforced by enforce_b14_p0_privacy_authority; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b14_p0_privacy_authority.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b14_p0_privacy_authority.py
-  expected_failure_meaning: enforce_b14_p0_privacy_authority detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_b14_p0_privacy_authority detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b14_p0_privacy_authority.py --help || python scripts/ci/enforce_b14_p0_privacy_authority.py
   depends_on_db: true
   depends_on_celery: true
@@ -1785,14 +1714,12 @@
   path: scripts/ci/enforce_b14_p1_ingress_privacy.py
   status: required
   owning_phase: B14-P1
-  protected_invariant: B14-P1 invariant enforced by enforce_b14_p1_ingress_privacy; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B14-P1 invariant enforced by enforce_b14_p1_ingress_privacy; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b14_p1_ingress_privacy.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b14_p1_ingress_privacy.py
-  expected_failure_meaning: enforce_b14_p1_ingress_privacy detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_b14_p1_ingress_privacy detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b14_p1_ingress_privacy.py --help || python scripts/ci/enforce_b14_p1_ingress_privacy.py
   depends_on_db: false
   depends_on_celery: false
@@ -1808,14 +1735,12 @@
   path: scripts/ci/enforce_b14_p2_session_authority.py
   status: required
   owning_phase: B14-P2
-  protected_invariant: B14-P2 invariant enforced by enforce_b14_p2_session_authority; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B14-P2 invariant enforced by enforce_b14_p2_session_authority; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b14_p2_session_authority.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b14_p2_session_authority.py
-  expected_failure_meaning: enforce_b14_p2_session_authority detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_b14_p2_session_authority detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b14_p2_session_authority.py --help || python scripts/ci/enforce_b14_p2_session_authority.py
   depends_on_db: true
   depends_on_celery: false
@@ -1831,14 +1756,12 @@
   path: scripts/ci/enforce_b14_p3_attribution_locality.py
   status: required
   owning_phase: B14-P3
-  protected_invariant: B14-P3 invariant enforced by enforce_b14_p3_attribution_locality; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B14-P3 invariant enforced by enforce_b14_p3_attribution_locality; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b14_p3_attribution_locality.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b14_p3_attribution_locality.py
-  expected_failure_meaning: enforce_b14_p3_attribution_locality detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b14_p3_attribution_locality detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b14_p3_attribution_locality.py --help || python scripts/ci/enforce_b14_p3_attribution_locality.py
   depends_on_db: true
   depends_on_celery: true
@@ -1854,14 +1777,12 @@
   path: scripts/ci/enforce_b14_p4_retention_deletion.py
   status: required
   owning_phase: B14-P4
-  protected_invariant: B14-P4 invariant enforced by enforce_b14_p4_retention_deletion; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B14-P4 invariant enforced by enforce_b14_p4_retention_deletion; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b14_p4_retention_deletion.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b14_p4_retention_deletion.py
-  expected_failure_meaning: enforce_b14_p4_retention_deletion detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b14_p4_retention_deletion detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b14_p4_retention_deletion.py --help || python scripts/ci/enforce_b14_p4_retention_deletion.py
   depends_on_db: true
   depends_on_celery: false
@@ -1877,14 +1798,12 @@
   path: scripts/ci/enforce_b14_p5_export_log_artifact_no_leak.py
   status: required
   owning_phase: B14-P5
-  protected_invariant: B14-P5 invariant enforced by enforce_b14_p5_export_log_artifact_no_leak; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B14-P5 invariant enforced by enforce_b14_p5_export_log_artifact_no_leak; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b14_p5_export_log_artifact_no_leak.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b14_p5_export_log_artifact_no_leak.py
-  expected_failure_meaning: enforce_b14_p5_export_log_artifact_no_leak detected drift in its protected invariant; inspect
-    the gate output before changing production semantics.
+  expected_failure_meaning: enforce_b14_p5_export_log_artifact_no_leak detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b14_p5_export_log_artifact_no_leak.py --help || python scripts/ci/enforce_b14_p5_export_log_artifact_no_leak.py
   depends_on_db: false
   depends_on_celery: false
@@ -1900,14 +1819,12 @@
   path: scripts/ci/enforce_b14_p6_proof_plane_binding.py
   status: required
   owning_phase: B14-P6
-  protected_invariant: B14-P6 invariant enforced by enforce_b14_p6_proof_plane_binding; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B14-P6 invariant enforced by enforce_b14_p6_proof_plane_binding; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b14_p6_proof_plane_binding.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b14_p6_proof_plane_binding.py
-  expected_failure_meaning: enforce_b14_p6_proof_plane_binding detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b14_p6_proof_plane_binding detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b14_p6_proof_plane_binding.py --help || python scripts/ci/enforce_b14_p6_proof_plane_binding.py
   depends_on_db: false
   depends_on_celery: false
@@ -1923,14 +1840,12 @@
   path: scripts/ci/enforce_b14_p7_e2e_privacy_system_proofs.py
   status: required
   owning_phase: B14-P7
-  protected_invariant: B14-P7 invariant enforced by enforce_b14_p7_e2e_privacy_system_proofs; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B14-P7 invariant enforced by enforce_b14_p7_e2e_privacy_system_proofs; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b14_p7_e2e_privacy_system_proofs.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b14_p7_e2e_privacy_system_proofs.py
-  expected_failure_meaning: enforce_b14_p7_e2e_privacy_system_proofs detected drift in its protected invariant; inspect the
-    gate output before changing production semantics.
+  expected_failure_meaning: enforce_b14_p7_e2e_privacy_system_proofs detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b14_p7_e2e_privacy_system_proofs.py --help || python scripts/ci/enforce_b14_p7_e2e_privacy_system_proofs.py
   depends_on_db: false
   depends_on_celery: true
@@ -1946,14 +1861,12 @@
   path: scripts/ci/enforce_b15_p0_authority_scope_invariants.py
   status: active
   owning_phase: B15-P0
-  protected_invariant: B15-P0 invariant enforced by enforce_b15_p0_authority_scope_invariants; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B15-P0 invariant enforced by enforce_b15_p0_authority_scope_invariants; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b15_p0_authority_scope_invariants.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b15_p0_authority_scope_invariants.py
-  expected_failure_meaning: enforce_b15_p0_authority_scope_invariants detected drift in its protected invariant; inspect the
-    gate output before changing production semantics.
+  expected_failure_meaning: enforce_b15_p0_authority_scope_invariants detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b15_p0_authority_scope_invariants.py --help || python scripts/ci/enforce_b15_p0_authority_scope_invariants.py
   depends_on_db: false
   depends_on_celery: false
@@ -1969,14 +1882,12 @@
   path: scripts/ci/enforce_b15_p1_lifecycle_authority.py
   status: active
   owning_phase: B15-P1
-  protected_invariant: B15-P1 invariant enforced by enforce_b15_p1_lifecycle_authority; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B15-P1 invariant enforced by enforce_b15_p1_lifecycle_authority; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b15_p1_lifecycle_authority.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b15_p1_lifecycle_authority.py
-  expected_failure_meaning: enforce_b15_p1_lifecycle_authority detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b15_p1_lifecycle_authority detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b15_p1_lifecycle_authority.py --help || python scripts/ci/enforce_b15_p1_lifecycle_authority.py
   depends_on_db: true
   depends_on_celery: true
@@ -1992,14 +1903,12 @@
   path: scripts/ci/enforce_b15_p3_runtime_route_binding.py
   status: active
   owning_phase: B15-P3
-  protected_invariant: B15-P3 invariant enforced by enforce_b15_p3_runtime_route_binding; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B15-P3 invariant enforced by enforce_b15_p3_runtime_route_binding; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b15_p3_runtime_route_binding.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b15_p3_runtime_route_binding.py
-  expected_failure_meaning: enforce_b15_p3_runtime_route_binding detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b15_p3_runtime_route_binding detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b15_p3_runtime_route_binding.py --help || python scripts/ci/enforce_b15_p3_runtime_route_binding.py
   depends_on_db: true
   depends_on_celery: false
@@ -2015,14 +1924,12 @@
   path: scripts/ci/enforce_b15_p4_mock_sdk_boundary.py
   status: active
   owning_phase: B15-P4
-  protected_invariant: B15-P4 invariant enforced by enforce_b15_p4_mock_sdk_boundary; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B15-P4 invariant enforced by enforce_b15_p4_mock_sdk_boundary; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b15_p4_mock_sdk_boundary.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b15_p4_mock_sdk_boundary.py
-  expected_failure_meaning: enforce_b15_p4_mock_sdk_boundary detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_b15_p4_mock_sdk_boundary detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b15_p4_mock_sdk_boundary.py --help || python scripts/ci/enforce_b15_p4_mock_sdk_boundary.py
   depends_on_db: false
   depends_on_celery: false
@@ -2038,14 +1945,12 @@
   path: scripts/ci/enforce_b15_p5_frontend_control_grammar.py
   status: active
   owning_phase: B15-P5
-  protected_invariant: B15-P5 invariant enforced by enforce_b15_p5_frontend_control_grammar; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B15-P5 invariant enforced by enforce_b15_p5_frontend_control_grammar; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b15_p5_frontend_control_grammar.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b15_p5_frontend_control_grammar.py
-  expected_failure_meaning: enforce_b15_p5_frontend_control_grammar detected drift in its protected invariant; inspect the
-    gate output before changing production semantics.
+  expected_failure_meaning: enforce_b15_p5_frontend_control_grammar detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b15_p5_frontend_control_grammar.py --help || python scripts/ci/enforce_b15_p5_frontend_control_grammar.py
   depends_on_db: false
   depends_on_celery: false
@@ -2061,14 +1966,12 @@
   path: scripts/ci/enforce_b15_p6_anti_cyborg_governance.py
   status: active
   owning_phase: B15-P6
-  protected_invariant: B15-P6 invariant enforced by enforce_b15_p6_anti_cyborg_governance; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B15-P6 invariant enforced by enforce_b15_p6_anti_cyborg_governance; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b15_p6_anti_cyborg_governance.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b15_p6_anti_cyborg_governance.py
-  expected_failure_meaning: enforce_b15_p6_anti_cyborg_governance detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b15_p6_anti_cyborg_governance detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b15_p6_anti_cyborg_governance.py --help || python scripts/ci/enforce_b15_p6_anti_cyborg_governance.py
   depends_on_db: false
   depends_on_celery: false
@@ -2084,14 +1987,12 @@
   path: scripts/ci/enforce_b15_p7_ci_adjudication_closure.py
   status: active
   owning_phase: B15-P7
-  protected_invariant: B15-P7 invariant enforced by enforce_b15_p7_ci_adjudication_closure; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B15-P7 invariant enforced by enforce_b15_p7_ci_adjudication_closure; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b15_p7_ci_adjudication_closure.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b15_p7_ci_adjudication_closure.py
-  expected_failure_meaning: enforce_b15_p7_ci_adjudication_closure detected drift in its protected invariant; inspect the
-    gate output before changing production semantics.
+  expected_failure_meaning: enforce_b15_p7_ci_adjudication_closure detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b15_p7_ci_adjudication_closure.py --help || python scripts/ci/enforce_b15_p7_ci_adjudication_closure.py
   depends_on_db: false
   depends_on_celery: false
@@ -2107,14 +2008,12 @@
   path: scripts/ci/enforce_b16_p1_provider_boundary_domain_sql.py
   status: required
   owning_phase: B16-P1
-  protected_invariant: B16-P1 invariant enforced by enforce_b16_p1_provider_boundary_domain_sql; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B16-P1 invariant enforced by enforce_b16_p1_provider_boundary_domain_sql; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b16_p1_provider_boundary_domain_sql.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b16_p1_provider_boundary_domain_sql.py
-  expected_failure_meaning: enforce_b16_p1_provider_boundary_domain_sql detected drift in its protected invariant; inspect
-    the gate output before changing production semantics.
+  expected_failure_meaning: enforce_b16_p1_provider_boundary_domain_sql detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b16_p1_provider_boundary_domain_sql.py --help || python scripts/ci/enforce_b16_p1_provider_boundary_domain_sql.py
   depends_on_db: false
   depends_on_celery: false
@@ -2130,13 +2029,11 @@
   path: scripts/ci/enforce_b16_p7_operational_closure.py
   status: utility
   owning_phase: B16-P7
-  protected_invariant: Utility support script enforce_b16_p7_operational_closure; not a default adjudication gate unless called
-    by a registered workflow.
+  protected_invariant: Utility support script enforce_b16_p7_operational_closure; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_b16_p7_operational_closure.py
   workflow_references: []
   local_reproduction_command: python scripts/ci/enforce_b16_p7_operational_closure.py
-  expected_failure_meaning: enforce_b16_p7_operational_closure detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b16_p7_operational_closure detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b16_p7_operational_closure.py --help || python scripts/ci/enforce_b16_p7_operational_closure.py
   depends_on_db: false
   depends_on_celery: false
@@ -2152,14 +2049,12 @@
   path: scripts/ci/enforce_b17_p6_benchmark_adjudication.py
   status: required
   owning_phase: B17-P6
-  protected_invariant: B17-P6 invariant enforced by enforce_b17_p6_benchmark_adjudication; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B17-P6 invariant enforced by enforce_b17_p6_benchmark_adjudication; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b17_p6_benchmark_adjudication.py
   workflow_references:
   - .github/workflows/b17-p4-mixed-workload-benchmark.yml
   local_reproduction_command: python scripts/ci/enforce_b17_p6_benchmark_adjudication.py
-  expected_failure_meaning: enforce_b17_p6_benchmark_adjudication detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b17_p6_benchmark_adjudication detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b17_p6_benchmark_adjudication.py --help || python scripts/ci/enforce_b17_p6_benchmark_adjudication.py
   depends_on_db: false
   depends_on_celery: false
@@ -2175,15 +2070,13 @@
   path: scripts/ci/enforce_b21_p4_benchmark_adjudication.py
   status: required
   owning_phase: B21-P4
-  protected_invariant: B21-P4 invariant enforced by enforce_b21_p4_benchmark_adjudication; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B21-P4 invariant enforced by enforce_b21_p4_benchmark_adjudication; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b21_p4_benchmark_adjudication.py
   workflow_references:
   - .github/workflows/ci.yml
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b21_p4_benchmark_adjudication.py
-  expected_failure_meaning: enforce_b21_p4_benchmark_adjudication detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b21_p4_benchmark_adjudication detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b21_p4_benchmark_adjudication.py --help || python scripts/ci/enforce_b21_p4_benchmark_adjudication.py
   depends_on_db: true
   depends_on_celery: true
@@ -2199,14 +2092,12 @@
   path: scripts/ci/enforce_b22_p5_webhook_benchmark_adjudication.py
   status: required
   owning_phase: B22-P5
-  protected_invariant: B22-P5 invariant enforced by enforce_b22_p5_webhook_benchmark_adjudication; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B22-P5 invariant enforced by enforce_b22_p5_webhook_benchmark_adjudication; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b22_p5_webhook_benchmark_adjudication.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b22_p5_webhook_benchmark_adjudication.py
-  expected_failure_meaning: enforce_b22_p5_webhook_benchmark_adjudication detected drift in its protected invariant; inspect
-    the gate output before changing production semantics.
+  expected_failure_meaning: enforce_b22_p5_webhook_benchmark_adjudication detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b22_p5_webhook_benchmark_adjudication.py --help || python scripts/ci/enforce_b22_p5_webhook_benchmark_adjudication.py
   depends_on_db: false
   depends_on_celery: false
@@ -2222,14 +2113,12 @@
   path: scripts/ci/enforce_b22_p6_merge_blocking_closure.py
   status: required
   owning_phase: B22-P6
-  protected_invariant: B22-P6 invariant enforced by enforce_b22_p6_merge_blocking_closure; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B22-P6 invariant enforced by enforce_b22_p6_merge_blocking_closure; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b22_p6_merge_blocking_closure.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b22_p6_merge_blocking_closure.py
-  expected_failure_meaning: enforce_b22_p6_merge_blocking_closure detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b22_p6_merge_blocking_closure detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b22_p6_merge_blocking_closure.py --help || python scripts/ci/enforce_b22_p6_merge_blocking_closure.py
   depends_on_db: false
   depends_on_celery: false
@@ -2245,14 +2134,12 @@
   path: scripts/ci/enforce_b23_p5_composite_proof.py
   status: required
   owning_phase: B23-P5
-  protected_invariant: B23-P5 invariant enforced by enforce_b23_p5_composite_proof; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B23-P5 invariant enforced by enforce_b23_p5_composite_proof; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b23_p5_composite_proof.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b23_p5_composite_proof.py
-  expected_failure_meaning: enforce_b23_p5_composite_proof detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_b23_p5_composite_proof detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b23_p5_composite_proof.py --help || python scripts/ci/enforce_b23_p5_composite_proof.py
   depends_on_db: true
   depends_on_celery: false
@@ -2268,14 +2155,12 @@
   path: scripts/ci/enforce_b23_p6_end_to_end_closure.py
   status: required
   owning_phase: B23-P6
-  protected_invariant: B23-P6 invariant enforced by enforce_b23_p6_end_to_end_closure; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B23-P6 invariant enforced by enforce_b23_p6_end_to_end_closure; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_b23_p6_end_to_end_closure.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_b23_p6_end_to_end_closure.py
-  expected_failure_meaning: enforce_b23_p6_end_to_end_closure detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_b23_p6_end_to_end_closure detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_b23_p6_end_to_end_closure.py --help || python scripts/ci/enforce_b23_p6_end_to_end_closure.py
   depends_on_db: true
   depends_on_celery: false
@@ -2291,14 +2176,12 @@
   path: scripts/ci/enforce_branch_protection_integrity.py
   status: active
   owning_phase: CI-GOVERNANCE
-  protected_invariant: CI-GOVERNANCE invariant enforced by enforce_branch_protection_integrity; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: CI-GOVERNANCE invariant enforced by enforce_branch_protection_integrity; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_branch_protection_integrity.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_branch_protection_integrity.py
-  expected_failure_meaning: enforce_branch_protection_integrity detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: enforce_branch_protection_integrity detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_branch_protection_integrity.py --help || python scripts/ci/enforce_branch_protection_integrity.py
   depends_on_db: false
   depends_on_celery: false
@@ -2314,14 +2197,12 @@
   path: scripts/ci/enforce_forensics_index.py
   status: active
   owning_phase: CI-GOVERNANCE
-  protected_invariant: CI-GOVERNANCE invariant enforced by enforce_forensics_index; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: CI-GOVERNANCE invariant enforced by enforce_forensics_index; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_forensics_index.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_forensics_index.py
-  expected_failure_meaning: enforce_forensics_index detected drift in its protected invariant; inspect the gate output before
-    changing production semantics.
+  expected_failure_meaning: enforce_forensics_index detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_forensics_index.py --help || python scripts/ci/enforce_forensics_index.py
   depends_on_db: false
   depends_on_celery: false
@@ -2337,14 +2218,12 @@
   path: scripts/ci/enforce_llm_api_call_single_write_path.py
   status: required
   owning_phase: LLM-GOVERNANCE
-  protected_invariant: LLM-GOVERNANCE invariant enforced by enforce_llm_api_call_single_write_path; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: LLM-GOVERNANCE invariant enforced by enforce_llm_api_call_single_write_path; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_llm_api_call_single_write_path.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_llm_api_call_single_write_path.py
-  expected_failure_meaning: enforce_llm_api_call_single_write_path detected drift in its protected invariant; inspect the
-    gate output before changing production semantics.
+  expected_failure_meaning: enforce_llm_api_call_single_write_path detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_llm_api_call_single_write_path.py --help || python scripts/ci/enforce_llm_api_call_single_write_path.py
   depends_on_db: false
   depends_on_celery: false
@@ -2360,13 +2239,11 @@
   path: scripts/ci/enforce_llm_provider_boundary.py
   status: utility
   owning_phase: LLM-GOVERNANCE
-  protected_invariant: Utility support script enforce_llm_provider_boundary; not a default adjudication gate unless called
-    by a registered workflow.
+  protected_invariant: Utility support script enforce_llm_provider_boundary; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/enforce_llm_provider_boundary.py
   workflow_references: []
   local_reproduction_command: python scripts/ci/enforce_llm_provider_boundary.py
-  expected_failure_meaning: enforce_llm_provider_boundary detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_llm_provider_boundary detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_llm_provider_boundary.py --help || python scripts/ci/enforce_llm_provider_boundary.py
   depends_on_db: false
   depends_on_celery: false
@@ -2382,14 +2259,12 @@
   path: scripts/ci/enforce_no_worker_http_server.py
   status: required
   owning_phase: CI-GOVERNANCE
-  protected_invariant: CI-GOVERNANCE invariant enforced by enforce_no_worker_http_server; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: CI-GOVERNANCE invariant enforced by enforce_no_worker_http_server; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_no_worker_http_server.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_no_worker_http_server.py
-  expected_failure_meaning: enforce_no_worker_http_server detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_no_worker_http_server detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_no_worker_http_server.py --help || python scripts/ci/enforce_no_worker_http_server.py
   depends_on_db: false
   depends_on_celery: true
@@ -2405,14 +2280,12 @@
   path: scripts/ci/enforce_postgres_only.py
   status: active
   owning_phase: CI-GOVERNANCE
-  protected_invariant: CI-GOVERNANCE invariant enforced by enforce_postgres_only; keeps its documented negative-control and
-    proof surface visible in CI.
+  protected_invariant: CI-GOVERNANCE invariant enforced by enforce_postgres_only; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_postgres_only.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_postgres_only.py
-  expected_failure_meaning: enforce_postgres_only detected drift in its protected invariant; inspect the gate output before
-    changing production semantics.
+  expected_failure_meaning: enforce_postgres_only detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_postgres_only.py --help || python scripts/ci/enforce_postgres_only.py
   depends_on_db: true
   depends_on_celery: true
@@ -2428,14 +2301,12 @@
   path: scripts/ci/enforce_required_status_checks.py
   status: active
   owning_phase: CI-GOVERNANCE
-  protected_invariant: CI-GOVERNANCE invariant enforced by enforce_required_status_checks; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: CI-GOVERNANCE invariant enforced by enforce_required_status_checks; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_required_status_checks.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_required_status_checks.py
-  expected_failure_meaning: enforce_required_status_checks detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_required_status_checks detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_required_status_checks.py --help || python scripts/ci/enforce_required_status_checks.py
   depends_on_db: false
   depends_on_celery: false
@@ -2451,14 +2322,12 @@
   path: scripts/ci/enforce_runtime_determinism.py
   status: required
   owning_phase: RUNTIME-GOVERNANCE
-  protected_invariant: RUNTIME-GOVERNANCE invariant enforced by enforce_runtime_determinism; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: RUNTIME-GOVERNANCE invariant enforced by enforce_runtime_determinism; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_runtime_determinism.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_runtime_determinism.py
-  expected_failure_meaning: enforce_runtime_determinism detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_runtime_determinism detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_runtime_determinism.py --help || python scripts/ci/enforce_runtime_determinism.py
   depends_on_db: false
   depends_on_celery: true
@@ -2474,14 +2343,12 @@
   path: scripts/ci/enforce_runtime_hermeticity.py
   status: required
   owning_phase: RUNTIME-GOVERNANCE
-  protected_invariant: RUNTIME-GOVERNANCE invariant enforced by enforce_runtime_hermeticity; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: RUNTIME-GOVERNANCE invariant enforced by enforce_runtime_hermeticity; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/enforce_runtime_hermeticity.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/enforce_runtime_hermeticity.py
-  expected_failure_meaning: enforce_runtime_hermeticity detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: enforce_runtime_hermeticity detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/enforce_runtime_hermeticity.py --help || python scripts/ci/enforce_runtime_hermeticity.py
   depends_on_db: false
   depends_on_celery: true
@@ -2497,14 +2364,12 @@
   path: scripts/ci/health_worker_probe.py
   status: required
   owning_phase: CI-GOVERNANCE
-  protected_invariant: CI-GOVERNANCE invariant enforced by health_worker_probe; keeps its documented negative-control and
-    proof surface visible in CI.
+  protected_invariant: CI-GOVERNANCE invariant enforced by health_worker_probe; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/health_worker_probe.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/health_worker_probe.py
-  expected_failure_meaning: health_worker_probe detected drift in its protected invariant; inspect the gate output before
-    changing production semantics.
+  expected_failure_meaning: health_worker_probe detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/health_worker_probe.py --help || python scripts/ci/health_worker_probe.py
   depends_on_db: false
   depends_on_celery: true
@@ -2520,14 +2385,12 @@
   path: scripts/ci/llm_contract_db_parity.py
   status: active
   owning_phase: LLM-GOVERNANCE
-  protected_invariant: LLM-GOVERNANCE invariant enforced by llm_contract_db_parity; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: LLM-GOVERNANCE invariant enforced by llm_contract_db_parity; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/llm_contract_db_parity.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/llm_contract_db_parity.py
-  expected_failure_meaning: llm_contract_db_parity detected drift in its protected invariant; inspect the gate output before
-    changing production semantics.
+  expected_failure_meaning: llm_contract_db_parity detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/llm_contract_db_parity.py --help || python scripts/ci/llm_contract_db_parity.py
   depends_on_db: true
   depends_on_celery: false
@@ -2543,8 +2406,7 @@
   path: .github/workflows/b2_4-gate-dry-run.yml
   status: active
   owning_phase: M3/B2.4-INSERTION
-  protected_invariant: B2.4 can attach a metadata-only gate through an isolated workflow without expanding ci.yml, mutating
-    M0/M1/M2, or installing statistical runtime dependencies.
+  protected_invariant: B2.4 can attach a metadata-only gate through an isolated workflow without expanding ci.yml, mutating M0/M1/M2, or installing statistical runtime dependencies.
   command: python scripts/ci/validate_m3_ci_governance.py --b24-dry-run
   workflow_references:
   - .github/workflows/b2_4-gate-dry-run.yml
@@ -2565,13 +2427,11 @@
   path: scripts/ci/phase2_schema_closure_gate.py
   status: utility
   owning_phase: CI-GOVERNANCE
-  protected_invariant: Utility support script phase2_schema_closure_gate; not a default adjudication gate unless called by
-    a registered workflow.
+  protected_invariant: Utility support script phase2_schema_closure_gate; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/phase2_schema_closure_gate.py
   workflow_references: []
   local_reproduction_command: python scripts/ci/phase2_schema_closure_gate.py
-  expected_failure_meaning: phase2_schema_closure_gate detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: phase2_schema_closure_gate detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/phase2_schema_closure_gate.py --help || python scripts/ci/phase2_schema_closure_gate.py
   depends_on_db: true
   depends_on_celery: false
@@ -2587,14 +2447,12 @@
   path: scripts/ci/prepare_b15_p7_browser_runtime.py
   status: active
   owning_phase: B15-P7
-  protected_invariant: B15-P7 invariant enforced by prepare_b15_p7_browser_runtime; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B15-P7 invariant enforced by prepare_b15_p7_browser_runtime; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/prepare_b15_p7_browser_runtime.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/prepare_b15_p7_browser_runtime.py
-  expected_failure_meaning: prepare_b15_p7_browser_runtime detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: prepare_b15_p7_browser_runtime detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/prepare_b15_p7_browser_runtime.py --help || python scripts/ci/prepare_b15_p7_browser_runtime.py
   depends_on_db: true
   depends_on_celery: false
@@ -2616,8 +2474,7 @@
   - .github/workflows/ci.yml
   - .github/workflows/m3-ci-governance.yml
   local_reproduction_command: python scripts/ci/run_ci_governance_cohort.py
-  expected_failure_meaning: M3 registry-backed cohort runner and failure-summary generator. failed; inspect registry, topology,
-    and cohort output.
+  expected_failure_meaning: M3 registry-backed cohort runner and failure-summary generator. failed; inspect registry, topology, and cohort output.
   first_diagnostic_command: python scripts/ci/run_ci_governance_cohort.py --help || python scripts/ci/run_ci_governance_cohort.py
   depends_on_db: false
   depends_on_celery: false
@@ -2633,14 +2490,12 @@
   path: scripts/ci/scan_b14_p5_artifacts.py
   status: required
   owning_phase: B14-P5
-  protected_invariant: B14-P5 invariant enforced by scan_b14_p5_artifacts; keeps its documented negative-control and proof
-    surface visible in CI.
+  protected_invariant: B14-P5 invariant enforced by scan_b14_p5_artifacts; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/scan_b14_p5_artifacts.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/scan_b14_p5_artifacts.py
-  expected_failure_meaning: scan_b14_p5_artifacts detected drift in its protected invariant; inspect the gate output before
-    changing production semantics.
+  expected_failure_meaning: scan_b14_p5_artifacts detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/scan_b14_p5_artifacts.py --help || python scripts/ci/scan_b14_p5_artifacts.py
   depends_on_db: false
   depends_on_celery: false
@@ -2656,14 +2511,12 @@
   path: scripts/ci/scan_b14_p7_artifacts.py
   status: required
   owning_phase: B14-P7
-  protected_invariant: B14-P7 invariant enforced by scan_b14_p7_artifacts; keeps its documented negative-control and proof
-    surface visible in CI.
+  protected_invariant: B14-P7 invariant enforced by scan_b14_p7_artifacts; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/scan_b14_p7_artifacts.py
   workflow_references:
   - .github/workflows/ci.yml
   local_reproduction_command: python scripts/ci/scan_b14_p7_artifacts.py
-  expected_failure_meaning: scan_b14_p7_artifacts detected drift in its protected invariant; inspect the gate output before
-    changing production semantics.
+  expected_failure_meaning: scan_b14_p7_artifacts detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/scan_b14_p7_artifacts.py --help || python scripts/ci/scan_b14_p7_artifacts.py
   depends_on_db: false
   depends_on_celery: false
@@ -2679,13 +2532,11 @@
   path: scripts/ci/validate_b23_pre_p1_spec_contract.py
   status: utility
   owning_phase: B23
-  protected_invariant: Utility support script validate_b23_pre_p1_spec_contract; not a default adjudication gate unless called
-    by a registered workflow.
+  protected_invariant: Utility support script validate_b23_pre_p1_spec_contract; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/validate_b23_pre_p1_spec_contract.py
   workflow_references: []
   local_reproduction_command: python scripts/ci/validate_b23_pre_p1_spec_contract.py
-  expected_failure_meaning: validate_b23_pre_p1_spec_contract detected drift in its protected invariant; inspect the gate
-    output before changing production semantics.
+  expected_failure_meaning: validate_b23_pre_p1_spec_contract detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/validate_b23_pre_p1_spec_contract.py --help || python scripts/ci/validate_b23_pre_p1_spec_contract.py
   depends_on_db: true
   depends_on_celery: false
@@ -2701,13 +2552,11 @@
   path: scripts/ci/validate_llm_write_contract.py
   status: utility
   owning_phase: LLM-GOVERNANCE
-  protected_invariant: Utility support script validate_llm_write_contract; not a default adjudication gate unless called by
-    a registered workflow.
+  protected_invariant: Utility support script validate_llm_write_contract; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/validate_llm_write_contract.py
   workflow_references: []
   local_reproduction_command: python scripts/ci/validate_llm_write_contract.py
-  expected_failure_meaning: validate_llm_write_contract detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: validate_llm_write_contract detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/validate_llm_write_contract.py --help || python scripts/ci/validate_llm_write_contract.py
   depends_on_db: false
   depends_on_celery: false
@@ -2723,14 +2572,12 @@
   path: scripts/ci/validate_m0_scope_lock.py
   status: required
   owning_phase: M0
-  protected_invariant: M0 invariant enforced by validate_m0_scope_lock; keeps its documented negative-control and proof surface
-    visible in CI.
+  protected_invariant: M0 invariant enforced by validate_m0_scope_lock; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/validate_m0_scope_lock.py
   workflow_references:
   - .github/workflows/m0-maintainability-scope-lock.yml
   local_reproduction_command: python scripts/ci/validate_m0_scope_lock.py
-  expected_failure_meaning: validate_m0_scope_lock detected drift in its protected invariant; inspect the gate output before
-    changing production semantics.
+  expected_failure_meaning: validate_m0_scope_lock detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/validate_m0_scope_lock.py --help || python scripts/ci/validate_m0_scope_lock.py
   depends_on_db: false
   depends_on_celery: true
@@ -2746,14 +2593,12 @@
   path: scripts/ci/validate_m1_local_dev_authority.py
   status: active
   owning_phase: M1
-  protected_invariant: M1 invariant enforced by validate_m1_local_dev_authority; keeps its documented negative-control and
-    proof surface visible in CI.
+  protected_invariant: M1 invariant enforced by validate_m1_local_dev_authority; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/validate_m1_local_dev_authority.py
   workflow_references:
   - .github/workflows/m1-local-dev-authority.yml
   local_reproduction_command: python scripts/ci/validate_m1_local_dev_authority.py
-  expected_failure_meaning: validate_m1_local_dev_authority detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: validate_m1_local_dev_authority detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/validate_m1_local_dev_authority.py --help || python scripts/ci/validate_m1_local_dev_authority.py
   depends_on_db: true
   depends_on_celery: true
@@ -2769,14 +2614,12 @@
   path: scripts/ci/validate_m2_test_feedback_loop.py
   status: active
   owning_phase: M2
-  protected_invariant: M2 invariant enforced by validate_m2_test_feedback_loop; keeps its documented negative-control and
-    proof surface visible in CI.
+  protected_invariant: M2 invariant enforced by validate_m2_test_feedback_loop; keeps its documented negative-control and proof surface visible in CI.
   command: python scripts/ci/validate_m2_test_feedback_loop.py
   workflow_references:
   - .github/workflows/m2-test-feedback-loop.yml
   local_reproduction_command: python scripts/ci/validate_m2_test_feedback_loop.py
-  expected_failure_meaning: validate_m2_test_feedback_loop detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: validate_m2_test_feedback_loop detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/validate_m2_test_feedback_loop.py --help || python scripts/ci/validate_m2_test_feedback_loop.py
   depends_on_db: true
   depends_on_celery: true
@@ -2813,13 +2656,11 @@
   path: scripts/ci/verify_b23_p5_branch_protection.py
   status: utility
   owning_phase: B23-P5
-  protected_invariant: Utility support script verify_b23_p5_branch_protection; not a default adjudication gate unless called
-    by a registered workflow.
+  protected_invariant: Utility support script verify_b23_p5_branch_protection; not a default adjudication gate unless called by a registered workflow.
   command: python scripts/ci/verify_b23_p5_branch_protection.py
   workflow_references: []
   local_reproduction_command: python scripts/ci/verify_b23_p5_branch_protection.py
-  expected_failure_meaning: verify_b23_p5_branch_protection detected drift in its protected invariant; inspect the gate output
-    before changing production semantics.
+  expected_failure_meaning: verify_b23_p5_branch_protection detected drift in its protected invariant; inspect the gate output before changing production semantics.
   first_diagnostic_command: python scripts/ci/verify_b23_p5_branch_protection.py --help || python scripts/ci/verify_b23_p5_branch_protection.py
   depends_on_db: false
   depends_on_celery: false
@@ -2831,7 +2672,6 @@
   deprecation_reason: Utility-only until a workflow references it through the registry.
   subsumed_by: ''
   registry_action: utility
-
 - id: validate-b25-p9-machine-identity
   path: scripts/ci/validate_b25_p9_machine_identity.py
   status: required

--- a/docs/ci/gate_subsumption_matrix.yaml
+++ b/docs/ci/gate_subsumption_matrix.yaml
@@ -28,6 +28,21 @@
   negative_control_preserved_by: python scripts/ci/validate_b25_p12_trust_isolation.py --negative-control
   local_reproduction_command: python scripts/ci/validate_b25_p12_trust_isolation.py --negative-control
   risk_if_removed: An LLM or compute path could re-enter the deterministic trust surface through a helper import, a dynamic import, or a generic enqueue helper without any gate noticing.
+- gate_id: b25-p12-runtime-module-trace
+  workflow: .github/workflows/b2_5-p12-ci-gates.yml
+  job: B2.5-P12 CI Gates
+  script: scripts/ci/_b25_p12_runtime_trace.py
+  owning_phase: B2.5-P12
+  protected_invariant: B2.5-P12 domain 17 runtime isolation executed in a fresh interpreter so the sys.modules baseline precedes every first-party import. This makes import-time forbidden dependencies observable; the prior in-process trace captured its baseline after importing the modules under observation and could only detect lazy imports.
+  current_status: required
+  default_execution: true
+  candidate_action: keep_required
+  decision: keep_required
+  subsuming_gate: ''
+  subsumption_evidence: 'Not subsumed. It is invoked twice by design: directly as a named workflow step, and as a subprocess of validate_b25_p12_trust_isolation.py, whose NC-P12-ISO-03 control mutates a trust module on disk and requires this trace to report the forbidden load.'
+  negative_control_preserved_by: NC-P12-ISO-03 in scripts/ci/validate_b25_p12_trust_isolation.py
+  local_reproduction_command: ''
+  risk_if_removed: ''
 - gate_id: validate-b25-p12-ci-gates
   workflow: .github/workflows/b2_5-p12-ci-gates.yml
   job: B2.5-P12 CI Gates
@@ -203,11 +218,7 @@
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: >-
-    P2 introduces source snapshot authority semantics that P1 and M5/M6/M7 do
-    not validate: eligibility-before-streaming, single repeatable-read snapshot,
-    total ordering, sparse sentinel hashing, and streaming canonical hash
-    discipline.
+  subsumption_evidence: 'P2 introduces source snapshot authority semantics that P1 and M5/M6/M7 do not validate: eligibility-before-streaming, single repeatable-read snapshot, total ordering, sparse sentinel hashing, and streaming canonical hash discipline.'
   negative_control_preserved_by: python scripts/ci/validate_b24_p2_source_snapshot.py --negative-control
   local_reproduction_command: make validate-b24-p2-source-snapshot
   risk_if_removed: B2.4 could hash identity-bearing, sparse, unordered, split-snapshot, or fully materialized source manifests without a merge-blocking signal.
@@ -222,11 +233,7 @@
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: >-
-    P3 introduces orchestration-safety semantics that P1/P2 do not validate:
-    hot-path dirty-only emission, debounced candidate leasing, active execution
-    uniqueness independent of source hash, claim plus outbox atomicity, dispatch
-    recovery, and fit-id-only broker payloads.
+  subsumption_evidence: 'P3 introduces orchestration-safety semantics that P1/P2 do not validate: hot-path dirty-only emission, debounced candidate leasing, active execution uniqueness independent of source hash, claim plus outbox atomicity, dispatch recovery, and fit-id-only broker payloads.'
   negative_control_preserved_by: python scripts/ci/validate_b24_p3_fit_planning.py --negative-control
   local_reproduction_command: make validate-b24-p3-fit-planning
   risk_if_removed: B2.4 could regress to hot-path snapshot generation, compute stampedes, unsafe DB-then-broker dual writes, or source-data queue payloads without a merge-blocking signal.
@@ -241,12 +248,7 @@
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: >-
-    P4 introduces resource-safety semantics that P1/P2/P3 do not validate:
-    cheap preflight leasing before source snapshot/profile work, arithmetic-only
-    input memory envelopes, formula-only symbolic graph envelopes, bounded
-    profiler query discipline, pre-dispatch rejection, and durable
-    resource/graph fallback without sampler/artifact behavior.
+  subsumption_evidence: 'P4 introduces resource-safety semantics that P1/P2/P3 do not validate: cheap preflight leasing before source snapshot/profile work, arithmetic-only input memory envelopes, formula-only symbolic graph envelopes, bounded profiler query discipline, pre-dispatch rejection, and durable resource/graph fallback without sampler/artifact behavior.'
   negative_control_preserved_by: python scripts/ci/validate_b24_p4_resource_bounds.py --negative-control
   local_reproduction_command: make validate-b24-p4-resource-bounds
   risk_if_removed: B2.4 could regress to duplicate planner DB work, unbounded cardinality profiling, allocation-backed memory proofs, PyMC/PyTensor dry-runs, oversized dispatch, or non-durable resource fallback without a merge-blocking signal.
@@ -261,12 +263,7 @@
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: >-
-    P5 introduces native-runtime physics that P1-P4 intentionally exclude:
-    PyMC/PyTensor/ArViZ dependency authority, compiler/backend viability,
-    numerical thread budgets, PyTensor compiledir isolation, process-group
-    kill behavior, durable timeout persistence, stale-running repair, and
-    runtime-image parity.
+  subsumption_evidence: 'P5 introduces native-runtime physics that P1-P4 intentionally exclude: PyMC/PyTensor/ArViZ dependency authority, compiler/backend viability, numerical thread budgets, PyTensor compiledir isolation, process-group kill behavior, durable timeout persistence, stale-running repair, and runtime-image parity.'
   negative_control_preserved_by: python scripts/ci/validate_b24_p5_runtime_harness.py --negative-control
   local_reproduction_command: make validate-b24-p5-runtime-harness
   risk_if_removed: B2.4 could pass schema/source/planning/resource gates while the Bayesian worker runtime cannot import, compile, sample, bound threads, kill native compute, repair stale fits, or preserve internal-only boundaries.
@@ -281,11 +278,7 @@
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: >-
-    P6 is not subsumed by P1-P5: it is the first gate that proves the parent
-    worker consumes a committed fit row and source snapshot, replays the frozen
-    source authority under Postgres RLS, and physically launches the DB-airgapped
-    PyMC child with source-derived observations instead of synthetic hash bytes.
+  subsumption_evidence: 'P6 is not subsumed by P1-P5: it is the first gate that proves the parent worker consumes a committed fit row and source snapshot, replays the frozen source authority under Postgres RLS, and physically launches the DB-airgapped PyMC child with source-derived observations instead of synthetic hash bytes.'
   negative_control_preserved_by: python scripts/ci/validate_b24_p6_real_fit_worker.py --negative-control
   local_reproduction_command: make validate-b24-p6-real-fit-worker
   risk_if_removed: B2.4 could retain native runtime safety while silently feeding PyMC synthetic snapshot-hash observations, bypassing P2/P4 authority, or losing protected-main evidence that real fit execution works under runtime DB identity.
@@ -300,11 +293,7 @@
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: >-
-    P7 is not subsumed by P5 or P6: P5 proves native runtime containment and
-    kill semantics, while P6 proves source-authorized sampling. P7 is the first
-    gate that adjudicates whether sampled output is statistically interval-
-    admissible and proves failed diagnostics cannot expose confidence.
+  subsumption_evidence: 'P7 is not subsumed by P5 or P6: P5 proves native runtime containment and kill semantics, while P6 proves source-authorized sampling. P7 is the first gate that adjudicates whether sampled output is statistically interval- admissible and proves failed diagnostics cannot expose confidence.'
   negative_control_preserved_by: python scripts/ci/validate_b24_p7_diagnostics.py --negative-control
   local_reproduction_command: make validate-b24-p7-diagnostics
   risk_if_removed: B2.4 could successfully sample while returning credible intervals for bad R-hat, low ESS, divergences, nonfinite diagnostics, ungoverned variables, or oversized interval payloads without a merge-blocking signal.
@@ -319,11 +308,7 @@
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: >-
-    P8 is not subsumed by P1 or P7: P1 created artifact authority rows and P7
-    blocked ungoverned trace persistence, but P8 is the first gate that proves
-    governed artifact writes, stored-byte hash semantics, tenant quota
-    accounting, retention pruning, and storage-physics prohibitions.
+  subsumption_evidence: 'P8 is not subsumed by P1 or P7: P1 created artifact authority rows and P7 blocked ungoverned trace persistence, but P8 is the first gate that proves governed artifact writes, stored-byte hash semantics, tenant quota accounting, retention pruning, and storage-physics prohibitions.'
   negative_control_preserved_by: python scripts/ci/validate_b24_p8_artifact_lifecycle.py --negative-control
   local_reproduction_command: make validate-b24-p8-artifact-lifecycle
   risk_if_removed: B2.4 could retain diagnostics while persisting unbounded traces, cloud/local artifacts, hash-ambiguous payloads, quota-racy rows, or destructive pruning without a merge-blocking signal.
@@ -393,14 +378,12 @@
   job: not_executed
   script: scripts/ci/enforce_b17_p0_explanation_surface_lock.py
   owning_phase: B17-P0
-  protected_invariant: Utility support script enforce_b17_p0_explanation_surface_lock; not a default adjudication gate unless
-    called by a registered workflow.
+  protected_invariant: Utility support script enforce_b17_p0_explanation_surface_lock; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b17_p0_explanation_surface_lock.py
   local_reproduction_command: python scripts/ci/enforce_b17_p0_explanation_surface_lock.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -410,14 +393,12 @@
   job: not_executed
   script: scripts/ci/enforce_b21_p0_authority_convergence.py
   owning_phase: B21-P0
-  protected_invariant: Utility support script enforce_b21_p0_authority_convergence; not a default adjudication gate unless
-    called by a registered workflow.
+  protected_invariant: Utility support script enforce_b21_p0_authority_convergence; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b21_p0_authority_convergence.py
   local_reproduction_command: python scripts/ci/enforce_b21_p0_authority_convergence.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -427,14 +408,12 @@
   job: not_executed
   script: scripts/ci/enforce_b21_p1_semantic_replay_lock.py
   owning_phase: B21-P1
-  protected_invariant: Utility support script enforce_b21_p1_semantic_replay_lock; not a default adjudication gate unless
-    called by a registered workflow.
+  protected_invariant: Utility support script enforce_b21_p1_semantic_replay_lock; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b21_p1_semantic_replay_lock.py
   local_reproduction_command: python scripts/ci/enforce_b21_p1_semantic_replay_lock.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -444,14 +423,12 @@
   job: not_executed
   script: scripts/ci/enforce_b21_p2_strategy_kernel_lock.py
   owning_phase: B21-P2
-  protected_invariant: Utility support script enforce_b21_p2_strategy_kernel_lock; not a default adjudication gate unless
-    called by a registered workflow.
+  protected_invariant: Utility support script enforce_b21_p2_strategy_kernel_lock; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b21_p2_strategy_kernel_lock.py
   local_reproduction_command: python scripts/ci/enforce_b21_p2_strategy_kernel_lock.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -461,14 +438,12 @@
   job: not_executed
   script: scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py
   owning_phase: B21-P3
-  protected_invariant: Utility support script enforce_b21_p3_persistence_read_surface_lock; not a default adjudication gate
-    unless called by a registered workflow.
+  protected_invariant: Utility support script enforce_b21_p3_persistence_read_surface_lock; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py
   local_reproduction_command: python scripts/ci/enforce_b21_p3_persistence_read_surface_lock.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -478,14 +453,12 @@
   job: not_executed
   script: scripts/ci/enforce_b21_p4_queue_isolation_semantics_lock.py
   owning_phase: B21-P4
-  protected_invariant: Utility support script enforce_b21_p4_queue_isolation_semantics_lock; not a default adjudication gate
-    unless called by a registered workflow.
+  protected_invariant: Utility support script enforce_b21_p4_queue_isolation_semantics_lock; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b21_p4_queue_isolation_semantics_lock.py
   local_reproduction_command: python scripts/ci/enforce_b21_p4_queue_isolation_semantics_lock.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -495,14 +468,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b21_p5_nonvacuous_adjudication.py
   owning_phase: B21-P5
-  protected_invariant: B21-P5 invariant enforced by enforce_b21_p5_nonvacuous_adjudication; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B21-P5 invariant enforced by enforce_b21_p5_nonvacuous_adjudication; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b21_p5_nonvacuous_adjudication.py
   local_reproduction_command: python scripts/ci/enforce_b21_p5_nonvacuous_adjudication.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -512,14 +483,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b21_p6_full_chain_closure.py
   owning_phase: B21-P6
-  protected_invariant: B21-P6 invariant enforced by enforce_b21_p6_full_chain_closure; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B21-P6 invariant enforced by enforce_b21_p6_full_chain_closure; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b21_p6_full_chain_closure.py
   local_reproduction_command: python scripts/ci/enforce_b21_p6_full_chain_closure.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -529,14 +498,12 @@
   job: not_executed
   script: scripts/ci/enforce_b17_p4_strategy_closure.py
   owning_phase: B17-P4
-  protected_invariant: Utility support script enforce_b17_p4_strategy_closure; not a default adjudication gate unless called
-    by a registered workflow.
+  protected_invariant: Utility support script enforce_b17_p4_strategy_closure; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b17_p4_strategy_closure.py
   local_reproduction_command: python scripts/ci/enforce_b17_p4_strategy_closure.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -546,14 +513,12 @@
   job: not_executed
   script: scripts/ci/enforce_b17_p5_merge_blocking_adjudication.py
   owning_phase: B17-P5
-  protected_invariant: Utility support script enforce_b17_p5_merge_blocking_adjudication; not a default adjudication gate
-    unless called by a registered workflow.
+  protected_invariant: Utility support script enforce_b17_p5_merge_blocking_adjudication; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b17_p5_merge_blocking_adjudication.py
   local_reproduction_command: python scripts/ci/enforce_b17_p5_merge_blocking_adjudication.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -563,14 +528,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b17_p6_adjudication_plane.py
   owning_phase: B17-P6
-  protected_invariant: B17-P6 invariant enforced by enforce_b17_p6_adjudication_plane; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B17-P6 invariant enforced by enforce_b17_p6_adjudication_plane; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b17_p6_adjudication_plane.py
   local_reproduction_command: python scripts/ci/enforce_b17_p6_adjudication_plane.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -580,14 +543,12 @@
   job: not_executed
   script: scripts/ci/enforce_b22_p0_webhook_surface_lock.py
   owning_phase: B22-P0
-  protected_invariant: Utility support script enforce_b22_p0_webhook_surface_lock; not a default adjudication gate unless
-    called by a registered workflow.
+  protected_invariant: Utility support script enforce_b22_p0_webhook_surface_lock; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b22_p0_webhook_surface_lock.py
   local_reproduction_command: python scripts/ci/enforce_b22_p0_webhook_surface_lock.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -597,14 +558,12 @@
   job: not_executed
   script: scripts/ci/enforce_b22_p1_authenticity_semantics_lock.py
   owning_phase: B22-P1
-  protected_invariant: Utility support script enforce_b22_p1_authenticity_semantics_lock; not a default adjudication gate
-    unless called by a registered workflow.
+  protected_invariant: Utility support script enforce_b22_p1_authenticity_semantics_lock; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b22_p1_authenticity_semantics_lock.py
   local_reproduction_command: python scripts/ci/enforce_b22_p1_authenticity_semantics_lock.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -614,14 +573,12 @@
   job: not_executed
   script: scripts/ci/enforce_b22_p2_post_auth_privacy_boundary.py
   owning_phase: B22-P2
-  protected_invariant: Utility support script enforce_b22_p2_post_auth_privacy_boundary; not a default adjudication gate unless
-    called by a registered workflow.
+  protected_invariant: Utility support script enforce_b22_p2_post_auth_privacy_boundary; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b22_p2_post_auth_privacy_boundary.py
   local_reproduction_command: python scripts/ci/enforce_b22_p2_post_auth_privacy_boundary.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -631,14 +588,12 @@
   job: not_executed
   script: scripts/ci/enforce_b22_p3_canonical_commerce_identity_envelope.py
   owning_phase: B22-P3
-  protected_invariant: Utility support script enforce_b22_p3_canonical_commerce_identity_envelope; not a default adjudication
-    gate unless called by a registered workflow.
+  protected_invariant: Utility support script enforce_b22_p3_canonical_commerce_identity_envelope; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b22_p3_canonical_commerce_identity_envelope.py
   local_reproduction_command: python scripts/ci/enforce_b22_p3_canonical_commerce_identity_envelope.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -648,14 +603,12 @@
   job: not_executed
   script: scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py
   owning_phase: B22-P4
-  protected_invariant: Utility support script enforce_b22_p4_idempotent_ack_orchestration; not a default adjudication gate
-    unless called by a registered workflow.
+  protected_invariant: Utility support script enforce_b22_p4_idempotent_ack_orchestration; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py
   local_reproduction_command: python scripts/ci/enforce_b22_p4_idempotent_ack_orchestration.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -665,14 +618,12 @@
   job: not_executed
   script: scripts/ci/enforce_b22_p5_performance_negative_control_lock.py
   owning_phase: B22-P5
-  protected_invariant: Utility support script enforce_b22_p5_performance_negative_control_lock; not a default adjudication
-    gate unless called by a registered workflow.
+  protected_invariant: Utility support script enforce_b22_p5_performance_negative_control_lock; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b22_p5_performance_negative_control_lock.py
   local_reproduction_command: python scripts/ci/enforce_b22_p5_performance_negative_control_lock.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -682,14 +633,12 @@
   job: not_executed
   script: scripts/ci/enforce_b23_p0_typed_boundary_source_alignment.py
   owning_phase: B23-P0
-  protected_invariant: Utility support script enforce_b23_p0_typed_boundary_source_alignment; not a default adjudication gate
-    unless called by a registered workflow.
+  protected_invariant: Utility support script enforce_b23_p0_typed_boundary_source_alignment; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b23_p0_typed_boundary_source_alignment.py
   local_reproduction_command: python scripts/ci/enforce_b23_p0_typed_boundary_source_alignment.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -699,14 +648,12 @@
   job: not_executed
   script: scripts/ci/enforce_b23_p0_semantic_authority_freeze.py
   owning_phase: B23-P0
-  protected_invariant: Utility support script enforce_b23_p0_semantic_authority_freeze; not a default adjudication gate unless
-    called by a registered workflow.
+  protected_invariant: Utility support script enforce_b23_p0_semantic_authority_freeze; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b23_p0_semantic_authority_freeze.py
   local_reproduction_command: python scripts/ci/enforce_b23_p0_semantic_authority_freeze.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -716,14 +663,12 @@
   job: not_executed
   script: scripts/ci/enforce_b23_pre_p1_spec_gate.py
   owning_phase: B23
-  protected_invariant: Utility support script enforce_b23_pre_p1_spec_gate; not a default adjudication gate unless called
-    by a registered workflow.
+  protected_invariant: Utility support script enforce_b23_pre_p1_spec_gate; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b23_pre_p1_spec_gate.py
   local_reproduction_command: python scripts/ci/enforce_b23_pre_p1_spec_gate.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -733,14 +678,12 @@
   job: not_executed
   script: scripts/ci/enforce_b23_p1_schema_authority_lock.py
   owning_phase: B23-P1
-  protected_invariant: Utility support script enforce_b23_p1_schema_authority_lock; not a default adjudication gate unless
-    called by a registered workflow.
+  protected_invariant: Utility support script enforce_b23_p1_schema_authority_lock; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b23_p1_schema_authority_lock.py
   local_reproduction_command: python scripts/ci/enforce_b23_p1_schema_authority_lock.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -750,14 +693,12 @@
   job: see workflow_references
   script: scripts/ci/verify_b23_p1_migration_reversibility.py
   owning_phase: B23-P1
-  protected_invariant: B23-P1 invariant enforced by verify_b23_p1_migration_reversibility; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B23-P1 invariant enforced by verify_b23_p1_migration_reversibility; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/verify_b23_p1_migration_reversibility.py
   local_reproduction_command: python scripts/ci/verify_b23_p1_migration_reversibility.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -767,14 +708,12 @@
   job: not_executed
   script: scripts/ci/enforce_b23_p2_match_engine_kernel.py
   owning_phase: B23-P2
-  protected_invariant: Utility support script enforce_b23_p2_match_engine_kernel; not a default adjudication gate unless called
-    by a registered workflow.
+  protected_invariant: Utility support script enforce_b23_p2_match_engine_kernel; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b23_p2_match_engine_kernel.py
   local_reproduction_command: python scripts/ci/enforce_b23_p2_match_engine_kernel.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -784,14 +723,12 @@
   job: not_executed
   script: scripts/ci/enforce_b23_p3_verdict_persistence.py
   owning_phase: B23-P3
-  protected_invariant: Utility support script enforce_b23_p3_verdict_persistence; not a default adjudication gate unless called
-    by a registered workflow.
+  protected_invariant: Utility support script enforce_b23_p3_verdict_persistence; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b23_p3_verdict_persistence.py
   local_reproduction_command: python scripts/ci/enforce_b23_p3_verdict_persistence.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -801,14 +738,12 @@
   job: not_executed
   script: scripts/ci/enforce_b23_p4_queue_performance.py
   owning_phase: B23-P4
-  protected_invariant: Utility support script enforce_b23_p4_queue_performance; not a default adjudication gate unless called
-    by a registered workflow.
+  protected_invariant: Utility support script enforce_b23_p4_queue_performance; not a default adjudication gate unless called by a registered workflow.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure
-    mode.
+  subsumption_evidence: Required contract-governance cohort gate; no stronger gate reproduces its script-specific failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b23_p4_queue_performance.py
   local_reproduction_command: python scripts/ci/enforce_b23_p4_queue_performance.py
   risk_if_removed: Loss of required Contract Semantic Drift Gate invariant coverage.
@@ -818,14 +753,12 @@
   job: see workflow_references
   script: scripts/ci/assert_b15_p7_playwright_execution.py
   owning_phase: B15-P7
-  protected_invariant: B15-P7 invariant enforced by assert_b15_p7_playwright_execution; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B15-P7 invariant enforced by assert_b15_p7_playwright_execution; keeps its documented negative-control and proof surface visible in CI.
   current_status: active
   default_execution: true
   candidate_action: keep_active_unique_invariant
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/assert_b15_p7_playwright_execution.py
   local_reproduction_command: python scripts/ci/assert_b15_p7_playwright_execution.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -835,14 +768,12 @@
   job: see workflow_references
   script: scripts/ci/b055_evidence_bundle.py
   owning_phase: B055
-  protected_invariant: B055 invariant enforced by b055_evidence_bundle; keeps its documented negative-control and proof surface
-    visible in CI.
+  protected_invariant: B055 invariant enforced by b055_evidence_bundle; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/b055_evidence_bundle.py
   local_reproduction_command: python scripts/ci/b055_evidence_bundle.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -852,14 +783,12 @@
   job: see workflow_references
   script: scripts/ci/b15_p7_phase_closure_gate.py
   owning_phase: B15-P7
-  protected_invariant: B15-P7 invariant enforced by b15_p7_phase_closure_gate; keeps its documented negative-control and proof
-    surface visible in CI.
+  protected_invariant: B15-P7 invariant enforced by b15_p7_phase_closure_gate; keeps its documented negative-control and proof surface visible in CI.
   current_status: active
   default_execution: true
   candidate_action: keep_active_unique_invariant
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/b15_p7_phase_closure_gate.py
   local_reproduction_command: python scripts/ci/b15_p7_phase_closure_gate.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -869,14 +798,12 @@
   job: see workflow_references
   script: scripts/ci/capture_b13_p11_branch_protection_evidence.py
   owning_phase: B13-P11
-  protected_invariant: B13-P11 invariant enforced by capture_b13_p11_branch_protection_evidence; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P11 invariant enforced by capture_b13_p11_branch_protection_evidence; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/capture_b13_p11_branch_protection_evidence.py
   local_reproduction_command: python scripts/ci/capture_b13_p11_branch_protection_evidence.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -886,14 +813,12 @@
   job: see workflow_references
   script: scripts/ci/capture_b14_p7_branch_protection_evidence.py
   owning_phase: B14-P7
-  protected_invariant: B14-P7 invariant enforced by capture_b14_p7_branch_protection_evidence; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B14-P7 invariant enforced by capture_b14_p7_branch_protection_evidence; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/capture_b14_p7_branch_protection_evidence.py
   local_reproduction_command: python scripts/ci/capture_b14_p7_branch_protection_evidence.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -903,14 +828,12 @@
   job: see workflow_references
   script: scripts/ci/eg5_cache_validation.py
   owning_phase: CI-GOVERNANCE
-  protected_invariant: CI-GOVERNANCE invariant enforced by eg5_cache_validation; keeps its documented negative-control and
-    proof surface visible in CI.
+  protected_invariant: CI-GOVERNANCE invariant enforced by eg5_cache_validation; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/eg5_cache_validation.py
   local_reproduction_command: python scripts/ci/eg5_cache_validation.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -920,14 +843,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b13_p0_codeowners.py
   owning_phase: B13-P0
-  protected_invariant: B13-P0 invariant enforced by enforce_b13_p0_codeowners; keeps its documented negative-control and proof
-    surface visible in CI.
+  protected_invariant: B13-P0 invariant enforced by enforce_b13_p0_codeowners; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b13_p0_codeowners.py
   local_reproduction_command: python scripts/ci/enforce_b13_p0_codeowners.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -937,14 +858,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b13_p0_evidence_pack.py
   owning_phase: B13-P0
-  protected_invariant: B13-P0 invariant enforced by enforce_b13_p0_evidence_pack; keeps its documented negative-control and
-    proof surface visible in CI.
+  protected_invariant: B13-P0 invariant enforced by enforce_b13_p0_evidence_pack; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b13_p0_evidence_pack.py
   local_reproduction_command: python scripts/ci/enforce_b13_p0_evidence_pack.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -954,14 +873,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b13_p0_scope_truth.py
   owning_phase: B13-P0
-  protected_invariant: B13-P0 invariant enforced by enforce_b13_p0_scope_truth; keeps its documented negative-control and
-    proof surface visible in CI.
+  protected_invariant: B13-P0 invariant enforced by enforce_b13_p0_scope_truth; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b13_p0_scope_truth.py
   local_reproduction_command: python scripts/ci/enforce_b13_p0_scope_truth.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -971,14 +888,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b13_p1_contract_authority.py
   owning_phase: B13-P1
-  protected_invariant: B13-P1 invariant enforced by enforce_b13_p1_contract_authority; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P1 invariant enforced by enforce_b13_p1_contract_authority; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b13_p1_contract_authority.py
   local_reproduction_command: python scripts/ci/enforce_b13_p1_contract_authority.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -988,14 +903,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b13_p10_provider_tranche_proofs.py
   owning_phase: B13-P10
-  protected_invariant: B13-P10 invariant enforced by enforce_b13_p10_provider_tranche_proofs; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P10 invariant enforced by enforce_b13_p10_provider_tranche_proofs; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b13_p10_provider_tranche_proofs.py
   local_reproduction_command: python scripts/ci/enforce_b13_p10_provider_tranche_proofs.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1005,14 +918,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b13_p11_e2e_system_proofs.py
   owning_phase: B13-P11
-  protected_invariant: B13-P11 invariant enforced by enforce_b13_p11_e2e_system_proofs; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P11 invariant enforced by enforce_b13_p11_e2e_system_proofs; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b13_p11_e2e_system_proofs.py
   local_reproduction_command: python scripts/ci/enforce_b13_p11_e2e_system_proofs.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1022,14 +933,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b13_p2_evidence_pack.py
   owning_phase: B13-P2
-  protected_invariant: B13-P2 invariant enforced by enforce_b13_p2_evidence_pack; keeps its documented negative-control and
-    proof surface visible in CI.
+  protected_invariant: B13-P2 invariant enforced by enforce_b13_p2_evidence_pack; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b13_p2_evidence_pack.py
   local_reproduction_command: python scripts/ci/enforce_b13_p2_evidence_pack.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1039,14 +948,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b13_p2_handshake_state.py
   owning_phase: B13-P2
-  protected_invariant: B13-P2 invariant enforced by enforce_b13_p2_handshake_state; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P2 invariant enforced by enforce_b13_p2_handshake_state; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b13_p2_handshake_state.py
   local_reproduction_command: python scripts/ci/enforce_b13_p2_handshake_state.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1056,14 +963,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b13_p3_durable_lifecycle.py
   owning_phase: B13-P3
-  protected_invariant: B13-P3 invariant enforced by enforce_b13_p3_durable_lifecycle; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P3 invariant enforced by enforce_b13_p3_durable_lifecycle; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b13_p3_durable_lifecycle.py
   local_reproduction_command: python scripts/ci/enforce_b13_p3_durable_lifecycle.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1073,14 +978,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b13_p4_boundary_hardening.py
   owning_phase: B13-P4
-  protected_invariant: B13-P4 invariant enforced by enforce_b13_p4_boundary_hardening; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P4 invariant enforced by enforce_b13_p4_boundary_hardening; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b13_p4_boundary_hardening.py
   local_reproduction_command: python scripts/ci/enforce_b13_p4_boundary_hardening.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1090,14 +993,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b13_p5_adapter_layer.py
   owning_phase: B13-P5
-  protected_invariant: B13-P5 invariant enforced by enforce_b13_p5_adapter_layer; keeps its documented negative-control and
-    proof surface visible in CI.
+  protected_invariant: B13-P5 invariant enforced by enforce_b13_p5_adapter_layer; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b13_p5_adapter_layer.py
   local_reproduction_command: python scripts/ci/enforce_b13_p5_adapter_layer.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1107,14 +1008,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b13_p6_runtime_lifecycle.py
   owning_phase: B13-P6
-  protected_invariant: B13-P6 invariant enforced by enforce_b13_p6_runtime_lifecycle; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P6 invariant enforced by enforce_b13_p6_runtime_lifecycle; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b13_p6_runtime_lifecycle.py
   local_reproduction_command: python scripts/ci/enforce_b13_p6_runtime_lifecycle.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1124,14 +1023,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b13_p7_refresh_orchestration.py
   owning_phase: B13-P7
-  protected_invariant: B13-P7 invariant enforced by enforce_b13_p7_refresh_orchestration; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P7 invariant enforced by enforce_b13_p7_refresh_orchestration; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b13_p7_refresh_orchestration.py
   local_reproduction_command: python scripts/ci/enforce_b13_p7_refresh_orchestration.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1141,14 +1038,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b13_p8_failure_baseline.py
   owning_phase: B13-P8
-  protected_invariant: B13-P8 invariant enforced by enforce_b13_p8_failure_baseline; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P8 invariant enforced by enforce_b13_p8_failure_baseline; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b13_p8_failure_baseline.py
   local_reproduction_command: python scripts/ci/enforce_b13_p8_failure_baseline.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1158,14 +1053,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b13_p9_core_substrate_closure.py
   owning_phase: B13-P9
-  protected_invariant: B13-P9 invariant enforced by enforce_b13_p9_core_substrate_closure; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B13-P9 invariant enforced by enforce_b13_p9_core_substrate_closure; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b13_p9_core_substrate_closure.py
   local_reproduction_command: python scripts/ci/enforce_b13_p9_core_substrate_closure.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1175,14 +1068,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b14_p0_privacy_authority.py
   owning_phase: B14-P0
-  protected_invariant: B14-P0 invariant enforced by enforce_b14_p0_privacy_authority; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B14-P0 invariant enforced by enforce_b14_p0_privacy_authority; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b14_p0_privacy_authority.py
   local_reproduction_command: python scripts/ci/enforce_b14_p0_privacy_authority.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1192,14 +1083,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b14_p1_ingress_privacy.py
   owning_phase: B14-P1
-  protected_invariant: B14-P1 invariant enforced by enforce_b14_p1_ingress_privacy; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B14-P1 invariant enforced by enforce_b14_p1_ingress_privacy; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b14_p1_ingress_privacy.py
   local_reproduction_command: python scripts/ci/enforce_b14_p1_ingress_privacy.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1209,14 +1098,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b14_p2_session_authority.py
   owning_phase: B14-P2
-  protected_invariant: B14-P2 invariant enforced by enforce_b14_p2_session_authority; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B14-P2 invariant enforced by enforce_b14_p2_session_authority; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b14_p2_session_authority.py
   local_reproduction_command: python scripts/ci/enforce_b14_p2_session_authority.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1226,14 +1113,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b14_p3_attribution_locality.py
   owning_phase: B14-P3
-  protected_invariant: B14-P3 invariant enforced by enforce_b14_p3_attribution_locality; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B14-P3 invariant enforced by enforce_b14_p3_attribution_locality; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b14_p3_attribution_locality.py
   local_reproduction_command: python scripts/ci/enforce_b14_p3_attribution_locality.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1243,14 +1128,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b14_p4_retention_deletion.py
   owning_phase: B14-P4
-  protected_invariant: B14-P4 invariant enforced by enforce_b14_p4_retention_deletion; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B14-P4 invariant enforced by enforce_b14_p4_retention_deletion; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b14_p4_retention_deletion.py
   local_reproduction_command: python scripts/ci/enforce_b14_p4_retention_deletion.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1260,14 +1143,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b14_p5_export_log_artifact_no_leak.py
   owning_phase: B14-P5
-  protected_invariant: B14-P5 invariant enforced by enforce_b14_p5_export_log_artifact_no_leak; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B14-P5 invariant enforced by enforce_b14_p5_export_log_artifact_no_leak; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b14_p5_export_log_artifact_no_leak.py
   local_reproduction_command: python scripts/ci/enforce_b14_p5_export_log_artifact_no_leak.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1277,14 +1158,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b14_p6_proof_plane_binding.py
   owning_phase: B14-P6
-  protected_invariant: B14-P6 invariant enforced by enforce_b14_p6_proof_plane_binding; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B14-P6 invariant enforced by enforce_b14_p6_proof_plane_binding; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b14_p6_proof_plane_binding.py
   local_reproduction_command: python scripts/ci/enforce_b14_p6_proof_plane_binding.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1294,14 +1173,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b14_p7_e2e_privacy_system_proofs.py
   owning_phase: B14-P7
-  protected_invariant: B14-P7 invariant enforced by enforce_b14_p7_e2e_privacy_system_proofs; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B14-P7 invariant enforced by enforce_b14_p7_e2e_privacy_system_proofs; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b14_p7_e2e_privacy_system_proofs.py
   local_reproduction_command: python scripts/ci/enforce_b14_p7_e2e_privacy_system_proofs.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1311,14 +1188,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b15_p0_authority_scope_invariants.py
   owning_phase: B15-P0
-  protected_invariant: B15-P0 invariant enforced by enforce_b15_p0_authority_scope_invariants; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B15-P0 invariant enforced by enforce_b15_p0_authority_scope_invariants; keeps its documented negative-control and proof surface visible in CI.
   current_status: active
   default_execution: true
   candidate_action: keep_active_unique_invariant
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b15_p0_authority_scope_invariants.py
   local_reproduction_command: python scripts/ci/enforce_b15_p0_authority_scope_invariants.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1328,14 +1203,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b15_p1_lifecycle_authority.py
   owning_phase: B15-P1
-  protected_invariant: B15-P1 invariant enforced by enforce_b15_p1_lifecycle_authority; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B15-P1 invariant enforced by enforce_b15_p1_lifecycle_authority; keeps its documented negative-control and proof surface visible in CI.
   current_status: active
   default_execution: true
   candidate_action: keep_active_unique_invariant
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b15_p1_lifecycle_authority.py
   local_reproduction_command: python scripts/ci/enforce_b15_p1_lifecycle_authority.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1345,14 +1218,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b15_p3_runtime_route_binding.py
   owning_phase: B15-P3
-  protected_invariant: B15-P3 invariant enforced by enforce_b15_p3_runtime_route_binding; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B15-P3 invariant enforced by enforce_b15_p3_runtime_route_binding; keeps its documented negative-control and proof surface visible in CI.
   current_status: active
   default_execution: true
   candidate_action: keep_active_unique_invariant
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b15_p3_runtime_route_binding.py
   local_reproduction_command: python scripts/ci/enforce_b15_p3_runtime_route_binding.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1362,14 +1233,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b15_p4_mock_sdk_boundary.py
   owning_phase: B15-P4
-  protected_invariant: B15-P4 invariant enforced by enforce_b15_p4_mock_sdk_boundary; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B15-P4 invariant enforced by enforce_b15_p4_mock_sdk_boundary; keeps its documented negative-control and proof surface visible in CI.
   current_status: active
   default_execution: true
   candidate_action: keep_active_unique_invariant
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b15_p4_mock_sdk_boundary.py
   local_reproduction_command: python scripts/ci/enforce_b15_p4_mock_sdk_boundary.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1379,14 +1248,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b15_p5_frontend_control_grammar.py
   owning_phase: B15-P5
-  protected_invariant: B15-P5 invariant enforced by enforce_b15_p5_frontend_control_grammar; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B15-P5 invariant enforced by enforce_b15_p5_frontend_control_grammar; keeps its documented negative-control and proof surface visible in CI.
   current_status: active
   default_execution: true
   candidate_action: keep_active_unique_invariant
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b15_p5_frontend_control_grammar.py
   local_reproduction_command: python scripts/ci/enforce_b15_p5_frontend_control_grammar.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1396,14 +1263,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b15_p6_anti_cyborg_governance.py
   owning_phase: B15-P6
-  protected_invariant: B15-P6 invariant enforced by enforce_b15_p6_anti_cyborg_governance; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B15-P6 invariant enforced by enforce_b15_p6_anti_cyborg_governance; keeps its documented negative-control and proof surface visible in CI.
   current_status: active
   default_execution: true
   candidate_action: keep_active_unique_invariant
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b15_p6_anti_cyborg_governance.py
   local_reproduction_command: python scripts/ci/enforce_b15_p6_anti_cyborg_governance.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1413,14 +1278,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b15_p7_ci_adjudication_closure.py
   owning_phase: B15-P7
-  protected_invariant: B15-P7 invariant enforced by enforce_b15_p7_ci_adjudication_closure; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B15-P7 invariant enforced by enforce_b15_p7_ci_adjudication_closure; keeps its documented negative-control and proof surface visible in CI.
   current_status: active
   default_execution: true
   candidate_action: keep_active_unique_invariant
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b15_p7_ci_adjudication_closure.py
   local_reproduction_command: python scripts/ci/enforce_b15_p7_ci_adjudication_closure.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1430,14 +1293,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b16_p1_provider_boundary_domain_sql.py
   owning_phase: B16-P1
-  protected_invariant: B16-P1 invariant enforced by enforce_b16_p1_provider_boundary_domain_sql; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B16-P1 invariant enforced by enforce_b16_p1_provider_boundary_domain_sql; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b16_p1_provider_boundary_domain_sql.py
   local_reproduction_command: python scripts/ci/enforce_b16_p1_provider_boundary_domain_sql.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1447,8 +1308,7 @@
   job: not_executed
   script: scripts/ci/enforce_b16_p7_operational_closure.py
   owning_phase: B16-P7
-  protected_invariant: Utility support script enforce_b16_p7_operational_closure; not a default adjudication gate unless called
-    by a registered workflow.
+  protected_invariant: Utility support script enforce_b16_p7_operational_closure; not a default adjudication gate unless called by a registered workflow.
   current_status: utility
   default_execution: false
   candidate_action: utility_only
@@ -1463,14 +1323,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b17_p6_benchmark_adjudication.py
   owning_phase: B17-P6
-  protected_invariant: B17-P6 invariant enforced by enforce_b17_p6_benchmark_adjudication; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B17-P6 invariant enforced by enforce_b17_p6_benchmark_adjudication; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b17_p6_benchmark_adjudication.py
   local_reproduction_command: python scripts/ci/enforce_b17_p6_benchmark_adjudication.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1480,14 +1338,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b21_p4_benchmark_adjudication.py
   owning_phase: B21-P4
-  protected_invariant: B21-P4 invariant enforced by enforce_b21_p4_benchmark_adjudication; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B21-P4 invariant enforced by enforce_b21_p4_benchmark_adjudication; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b21_p4_benchmark_adjudication.py
   local_reproduction_command: python scripts/ci/enforce_b21_p4_benchmark_adjudication.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1497,14 +1353,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b22_p5_webhook_benchmark_adjudication.py
   owning_phase: B22-P5
-  protected_invariant: B22-P5 invariant enforced by enforce_b22_p5_webhook_benchmark_adjudication; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B22-P5 invariant enforced by enforce_b22_p5_webhook_benchmark_adjudication; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b22_p5_webhook_benchmark_adjudication.py
   local_reproduction_command: python scripts/ci/enforce_b22_p5_webhook_benchmark_adjudication.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1514,14 +1368,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b22_p6_merge_blocking_closure.py
   owning_phase: B22-P6
-  protected_invariant: B22-P6 invariant enforced by enforce_b22_p6_merge_blocking_closure; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B22-P6 invariant enforced by enforce_b22_p6_merge_blocking_closure; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b22_p6_merge_blocking_closure.py
   local_reproduction_command: python scripts/ci/enforce_b22_p6_merge_blocking_closure.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1531,14 +1383,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b23_p5_composite_proof.py
   owning_phase: B23-P5
-  protected_invariant: B23-P5 invariant enforced by enforce_b23_p5_composite_proof; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B23-P5 invariant enforced by enforce_b23_p5_composite_proof; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b23_p5_composite_proof.py
   local_reproduction_command: python scripts/ci/enforce_b23_p5_composite_proof.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1548,14 +1398,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_b23_p6_end_to_end_closure.py
   owning_phase: B23-P6
-  protected_invariant: B23-P6 invariant enforced by enforce_b23_p6_end_to_end_closure; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B23-P6 invariant enforced by enforce_b23_p6_end_to_end_closure; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_b23_p6_end_to_end_closure.py
   local_reproduction_command: python scripts/ci/enforce_b23_p6_end_to_end_closure.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1565,14 +1413,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_branch_protection_integrity.py
   owning_phase: CI-GOVERNANCE
-  protected_invariant: CI-GOVERNANCE invariant enforced by enforce_branch_protection_integrity; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: CI-GOVERNANCE invariant enforced by enforce_branch_protection_integrity; keeps its documented negative-control and proof surface visible in CI.
   current_status: active
   default_execution: true
   candidate_action: keep_active_unique_invariant
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_branch_protection_integrity.py
   local_reproduction_command: python scripts/ci/enforce_branch_protection_integrity.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1582,14 +1428,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_forensics_index.py
   owning_phase: CI-GOVERNANCE
-  protected_invariant: CI-GOVERNANCE invariant enforced by enforce_forensics_index; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: CI-GOVERNANCE invariant enforced by enforce_forensics_index; keeps its documented negative-control and proof surface visible in CI.
   current_status: active
   default_execution: true
   candidate_action: keep_active_unique_invariant
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_forensics_index.py
   local_reproduction_command: python scripts/ci/enforce_forensics_index.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1599,14 +1443,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_llm_api_call_single_write_path.py
   owning_phase: LLM-GOVERNANCE
-  protected_invariant: LLM-GOVERNANCE invariant enforced by enforce_llm_api_call_single_write_path; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: LLM-GOVERNANCE invariant enforced by enforce_llm_api_call_single_write_path; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_llm_api_call_single_write_path.py
   local_reproduction_command: python scripts/ci/enforce_llm_api_call_single_write_path.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1616,8 +1458,7 @@
   job: not_executed
   script: scripts/ci/enforce_llm_provider_boundary.py
   owning_phase: LLM-GOVERNANCE
-  protected_invariant: Utility support script enforce_llm_provider_boundary; not a default adjudication gate unless called
-    by a registered workflow.
+  protected_invariant: Utility support script enforce_llm_provider_boundary; not a default adjudication gate unless called by a registered workflow.
   current_status: utility
   default_execution: false
   candidate_action: utility_only
@@ -1632,14 +1473,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_no_worker_http_server.py
   owning_phase: CI-GOVERNANCE
-  protected_invariant: CI-GOVERNANCE invariant enforced by enforce_no_worker_http_server; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: CI-GOVERNANCE invariant enforced by enforce_no_worker_http_server; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_no_worker_http_server.py
   local_reproduction_command: python scripts/ci/enforce_no_worker_http_server.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1649,14 +1488,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_postgres_only.py
   owning_phase: CI-GOVERNANCE
-  protected_invariant: CI-GOVERNANCE invariant enforced by enforce_postgres_only; keeps its documented negative-control and
-    proof surface visible in CI.
+  protected_invariant: CI-GOVERNANCE invariant enforced by enforce_postgres_only; keeps its documented negative-control and proof surface visible in CI.
   current_status: active
   default_execution: true
   candidate_action: keep_active_unique_invariant
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_postgres_only.py
   local_reproduction_command: python scripts/ci/enforce_postgres_only.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1666,14 +1503,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_required_status_checks.py
   owning_phase: CI-GOVERNANCE
-  protected_invariant: CI-GOVERNANCE invariant enforced by enforce_required_status_checks; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: CI-GOVERNANCE invariant enforced by enforce_required_status_checks; keeps its documented negative-control and proof surface visible in CI.
   current_status: active
   default_execution: true
   candidate_action: keep_active_unique_invariant
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_required_status_checks.py
   local_reproduction_command: python scripts/ci/enforce_required_status_checks.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1683,14 +1518,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_runtime_determinism.py
   owning_phase: RUNTIME-GOVERNANCE
-  protected_invariant: RUNTIME-GOVERNANCE invariant enforced by enforce_runtime_determinism; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: RUNTIME-GOVERNANCE invariant enforced by enforce_runtime_determinism; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_runtime_determinism.py
   local_reproduction_command: python scripts/ci/enforce_runtime_determinism.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1700,14 +1533,12 @@
   job: see workflow_references
   script: scripts/ci/enforce_runtime_hermeticity.py
   owning_phase: RUNTIME-GOVERNANCE
-  protected_invariant: RUNTIME-GOVERNANCE invariant enforced by enforce_runtime_hermeticity; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: RUNTIME-GOVERNANCE invariant enforced by enforce_runtime_hermeticity; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/enforce_runtime_hermeticity.py
   local_reproduction_command: python scripts/ci/enforce_runtime_hermeticity.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1717,14 +1548,12 @@
   job: see workflow_references
   script: scripts/ci/health_worker_probe.py
   owning_phase: CI-GOVERNANCE
-  protected_invariant: CI-GOVERNANCE invariant enforced by health_worker_probe; keeps its documented negative-control and
-    proof surface visible in CI.
+  protected_invariant: CI-GOVERNANCE invariant enforced by health_worker_probe; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/health_worker_probe.py
   local_reproduction_command: python scripts/ci/health_worker_probe.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1734,14 +1563,12 @@
   job: see workflow_references
   script: scripts/ci/llm_contract_db_parity.py
   owning_phase: LLM-GOVERNANCE
-  protected_invariant: LLM-GOVERNANCE invariant enforced by llm_contract_db_parity; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: LLM-GOVERNANCE invariant enforced by llm_contract_db_parity; keeps its documented negative-control and proof surface visible in CI.
   current_status: active
   default_execution: true
   candidate_action: keep_active_unique_invariant
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/llm_contract_db_parity.py
   local_reproduction_command: python scripts/ci/llm_contract_db_parity.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1751,14 +1578,12 @@
   job: see workflow_references
   script: .github/workflows/b2_4-gate-dry-run.yml
   owning_phase: M3/B2.4-INSERTION
-  protected_invariant: B2.4 can attach a metadata-only gate through an isolated workflow without expanding ci.yml, mutating
-    M0/M1/M2, or installing statistical runtime dependencies.
+  protected_invariant: B2.4 can attach a metadata-only gate through an isolated workflow without expanding ci.yml, mutating M0/M1/M2, or installing statistical runtime dependencies.
   current_status: active
   default_execution: true
   candidate_action: keep_active_unique_invariant
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: make ci-b24-gate-dry-run
   local_reproduction_command: make ci-b24-gate-dry-run
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1768,8 +1593,7 @@
   job: not_executed
   script: scripts/ci/phase2_schema_closure_gate.py
   owning_phase: CI-GOVERNANCE
-  protected_invariant: Utility support script phase2_schema_closure_gate; not a default adjudication gate unless called by
-    a registered workflow.
+  protected_invariant: Utility support script phase2_schema_closure_gate; not a default adjudication gate unless called by a registered workflow.
   current_status: utility
   default_execution: false
   candidate_action: utility_only
@@ -1784,14 +1608,12 @@
   job: see workflow_references
   script: scripts/ci/prepare_b15_p7_browser_runtime.py
   owning_phase: B15-P7
-  protected_invariant: B15-P7 invariant enforced by prepare_b15_p7_browser_runtime; keeps its documented negative-control
-    and proof surface visible in CI.
+  protected_invariant: B15-P7 invariant enforced by prepare_b15_p7_browser_runtime; keeps its documented negative-control and proof surface visible in CI.
   current_status: active
   default_execution: true
   candidate_action: keep_active_unique_invariant
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/prepare_b15_p7_browser_runtime.py
   local_reproduction_command: python scripts/ci/prepare_b15_p7_browser_runtime.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1806,8 +1628,7 @@
   default_execution: true
   candidate_action: keep_active_unique_invariant
   subsuming_gate: ''
-  subsumption_evidence: M3 governance tool is consumed by CI command surface; no stronger gate subsumes its drift/failure-summary
-    role.
+  subsumption_evidence: M3 governance tool is consumed by CI command surface; no stronger gate subsumes its drift/failure-summary role.
   negative_control_preserved_by: python scripts/ci/run_ci_governance_cohort.py
   local_reproduction_command: python scripts/ci/run_ci_governance_cohort.py
   risk_if_removed: Registry drift or opaque cohort execution could pass undetected.
@@ -1817,14 +1638,12 @@
   job: see workflow_references
   script: scripts/ci/scan_b14_p5_artifacts.py
   owning_phase: B14-P5
-  protected_invariant: B14-P5 invariant enforced by scan_b14_p5_artifacts; keeps its documented negative-control and proof
-    surface visible in CI.
+  protected_invariant: B14-P5 invariant enforced by scan_b14_p5_artifacts; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/scan_b14_p5_artifacts.py
   local_reproduction_command: python scripts/ci/scan_b14_p5_artifacts.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1834,14 +1653,12 @@
   job: see workflow_references
   script: scripts/ci/scan_b14_p7_artifacts.py
   owning_phase: B14-P7
-  protected_invariant: B14-P7 invariant enforced by scan_b14_p7_artifacts; keeps its documented negative-control and proof
-    surface visible in CI.
+  protected_invariant: B14-P7 invariant enforced by scan_b14_p7_artifacts; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/scan_b14_p7_artifacts.py
   local_reproduction_command: python scripts/ci/scan_b14_p7_artifacts.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1851,8 +1668,7 @@
   job: not_executed
   script: scripts/ci/validate_b23_pre_p1_spec_contract.py
   owning_phase: B23
-  protected_invariant: Utility support script validate_b23_pre_p1_spec_contract; not a default adjudication gate unless called
-    by a registered workflow.
+  protected_invariant: Utility support script validate_b23_pre_p1_spec_contract; not a default adjudication gate unless called by a registered workflow.
   current_status: utility
   default_execution: false
   candidate_action: utility_only
@@ -1867,8 +1683,7 @@
   job: not_executed
   script: scripts/ci/validate_llm_write_contract.py
   owning_phase: LLM-GOVERNANCE
-  protected_invariant: Utility support script validate_llm_write_contract; not a default adjudication gate unless called by
-    a registered workflow.
+  protected_invariant: Utility support script validate_llm_write_contract; not a default adjudication gate unless called by a registered workflow.
   current_status: utility
   default_execution: false
   candidate_action: utility_only
@@ -1883,14 +1698,12 @@
   job: see workflow_references
   script: scripts/ci/validate_m0_scope_lock.py
   owning_phase: M0
-  protected_invariant: M0 invariant enforced by validate_m0_scope_lock; keeps its documented negative-control and proof surface
-    visible in CI.
+  protected_invariant: M0 invariant enforced by validate_m0_scope_lock; keeps its documented negative-control and proof surface visible in CI.
   current_status: required
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/validate_m0_scope_lock.py
   local_reproduction_command: python scripts/ci/validate_m0_scope_lock.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1900,14 +1713,12 @@
   job: see workflow_references
   script: scripts/ci/validate_m1_local_dev_authority.py
   owning_phase: M1
-  protected_invariant: M1 invariant enforced by validate_m1_local_dev_authority; keeps its documented negative-control and
-    proof surface visible in CI.
+  protected_invariant: M1 invariant enforced by validate_m1_local_dev_authority; keeps its documented negative-control and proof surface visible in CI.
   current_status: active
   default_execution: true
   candidate_action: keep_active_unique_invariant
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/validate_m1_local_dev_authority.py
   local_reproduction_command: python scripts/ci/validate_m1_local_dev_authority.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1917,14 +1728,12 @@
   job: see workflow_references
   script: scripts/ci/validate_m2_test_feedback_loop.py
   owning_phase: M2
-  protected_invariant: M2 invariant enforced by validate_m2_test_feedback_loop; keeps its documented negative-control and
-    proof surface visible in CI.
+  protected_invariant: M2 invariant enforced by validate_m2_test_feedback_loop; keeps its documented negative-control and proof surface visible in CI.
   current_status: active
   default_execution: true
   candidate_action: keep_active_unique_invariant
   subsuming_gate: ''
-  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure
-    mode.
+  subsumption_evidence: Required or active gate preserves a unique invariant; no stronger registered gate reproduces its failure mode.
   negative_control_preserved_by: python scripts/ci/validate_m2_test_feedback_loop.py
   local_reproduction_command: python scripts/ci/validate_m2_test_feedback_loop.py
   risk_if_removed: Loss of branch-protected or active invariant coverage.
@@ -1939,8 +1748,7 @@
   default_execution: true
   candidate_action: keep_active_unique_invariant
   subsuming_gate: ''
-  subsumption_evidence: M3 governance tool is consumed by CI command surface; no stronger gate subsumes its drift/failure-summary
-    role.
+  subsumption_evidence: M3 governance tool is consumed by CI command surface; no stronger gate subsumes its drift/failure-summary role.
   negative_control_preserved_by: python scripts/ci/validate_m3_ci_governance.py
   local_reproduction_command: python scripts/ci/validate_m3_ci_governance.py
   risk_if_removed: Registry drift or opaque cohort execution could pass undetected.
@@ -1950,8 +1758,7 @@
   job: not_executed
   script: scripts/ci/verify_b23_p5_branch_protection.py
   owning_phase: B23-P5
-  protected_invariant: Utility support script verify_b23_p5_branch_protection; not a default adjudication gate unless called
-    by a registered workflow.
+  protected_invariant: Utility support script verify_b23_p5_branch_protection; not a default adjudication gate unless called by a registered workflow.
   current_status: utility
   default_execution: false
   candidate_action: utility_only
@@ -2001,10 +1808,7 @@
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: >-
-    P11 is not subsumed by P1-P10 because it verifies the gate system itself:
-    phase coverage, workflow job names, Makefile targets, registry entries,
-    required statuses, structured evidence, and negative-control normalization.
+  subsumption_evidence: 'P11 is not subsumed by P1-P10 because it verifies the gate system itself: phase coverage, workflow job names, Makefile targets, registry entries, required statuses, structured evidence, and negative-control normalization.'
   negative_control_preserved_by: python scripts/ci/validate_b24_p11_ci_gates.py --negative-control
   local_reproduction_command: make validate-b24-p11-ci-gates
   risk_if_removed: Loss of merge-blocking proof that B2.4 CI cannot silently omit, skip, unregister, downgrade, or overclaim P1-P10 proof jobs.
@@ -2019,11 +1823,7 @@
   default_execution: true
   candidate_action: keep_required
   subsuming_gate: ''
-  subsumption_evidence: >-
-    P12 is not subsumed by P1-P11 because it validates cross-boundary
-    composition over already accepted surfaces: committed DB visibility,
-    worker/subprocess evidence, artifact/diagnostic/projection interactions,
-    sealed serialization, and internal/local/CI-only claim discipline.
+  subsumption_evidence: 'P12 is not subsumed by P1-P11 because it validates cross-boundary composition over already accepted surfaces: committed DB visibility, worker/subprocess evidence, artifact/diagnostic/projection interactions, sealed serialization, and internal/local/CI-only claim discipline.'
   negative_control_preserved_by: python scripts/ci/validate_b24_p12_internal_e2e.py --negative-control
   local_reproduction_command: make validate-b24-p12-internal-e2e
   risk_if_removed: Loss of final internal E2E composition proof; component gates could remain green while transaction visibility, async coordination, projection payload sealing, or cross-tenant lifecycle behavior regresses.

--- a/scripts/ci/_b25_p12_runtime_trace.py
+++ b/scripts/ci/_b25_p12_runtime_trace.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Fresh-interpreter runtime module trace for B2.5-P12 domain 17.
+
+Why a separate process
+----------------------
+The previous in-process trace captured its ``sys.modules`` baseline *after*
+importing the trust modules it was observing::
+
+    from app.trust.signing import sign_trust_envelope   # forbidden dep loads here
+    ...
+    before = set(sys.modules)                           # too late to see it
+    newly_loaded = set(sys.modules) - before            # always misses it
+
+That construction can only observe *lazy* imports performed during the exercised
+calls. A forbidden module pulled in as an import-time transitive dependency is
+already resident when the baseline is taken, so it is subtracted away. This was
+reproduced: a trust module importing ``app.llm`` at import time left the trace
+reporting success while ``app.llm`` was demonstrably in ``sys.modules``.
+
+A fresh interpreter is the cheapest construction that makes the baseline
+genuinely precede every first-party import, so import-time and lazy loads are
+both observable. The trace emits JSON on stdout for the parent validator.
+
+Environmental stubs
+-------------------
+The builder paths take a database session. The property under proof here is
+*which modules load*, not database behaviour, so an inert session stub is
+legitimate under the directive's rule that mocking is permissible when the
+mocked dependency is not the property under proof. Route-level and RLS-level
+truth is proven by the P13 end-to-end harness against real PostgreSQL, not here.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+BACKEND = ROOT / "backend"
+
+FORBIDDEN_MODULE_PREFIXES = (
+    "app.llm",
+    "app.workers.llm",
+    "app.tasks.bayesian",
+    "app.bayesian",
+)
+
+
+def _is_forbidden(module: str) -> bool:
+    return any(
+        module == prefix or module.startswith(prefix + ".")
+        for prefix in FORBIDDEN_MODULE_PREFIXES
+    )
+
+
+def _utc(value):
+    return (
+        value.astimezone(_tz.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+    )
+
+
+def main() -> int:
+    # The baseline is captured before ANY first-party import, which is the whole
+    # point of this process existing.
+    baseline = set(sys.modules)
+
+    sys.path.insert(0, str(BACKEND))
+
+    import hashlib
+    from datetime import datetime, timedelta, timezone
+
+    global _tz
+    _tz = timezone
+
+    from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
+
+    from app.trust.export_artifact import (
+        build_export_artifact,
+        sign_export_artifact,
+        verify_export_artifact,
+    )
+    from app.trust.key_registry import TrustKeyRegistry, TrustSigningKey
+    from app.trust.signing import sign_trust_envelope
+    from app.trust.verification import verify_trust_envelope
+
+    private = Ed25519PrivateKey.from_private_bytes(
+        hashlib.sha256(b"b25-p12-runtime-trace").digest()
+    )
+    registry = TrustKeyRegistry(
+        (
+            TrustSigningKey(
+                kid="kid:b25-p12-runtime-trace",
+                algorithm="ed25519",
+                public_key=private.public_key(),
+                private_key=private,
+                state="active",
+                valid_from=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            ),
+        )
+    )
+
+    issued = datetime.now(timezone.utc)
+    envelope = json.loads(
+        (
+            ROOT / "contracts/trust-api/examples/deterministic_only_verified.json"
+        ).read_text(encoding="utf-8")
+    )
+    envelope["created_at"] = _utc(issued)
+    envelope["valid_until"] = _utc(issued + timedelta(days=1))
+
+    executed: list[str] = []
+
+    signed = sign_trust_envelope(envelope, key_registry=registry)
+    executed.append("sign_envelope")
+
+    verify_trust_envelope(signed, key_registry=registry.public_only())
+    executed.append("verify_envelope")
+
+    artifact = sign_export_artifact(
+        build_export_artifact(
+            envelopes=[signed],
+            tenant_id_hash=str(signed["tenant_id_hash"]),
+            generated_at=issued,
+        ),
+        key_registry=registry,
+    )
+    executed.append("export_issuance")
+
+    tampered = dict(artifact)
+    tampered["generated_at"] = _utc(issued + timedelta(hours=1))
+    if verify_export_artifact(
+        tampered, key_registry=registry.public_only()
+    ).verification_status != "rejected":
+        return _emit(baseline, executed, error="tamper_not_rejected")
+    executed.append("tampered_artifact_rejection")
+
+    unsupported = dict(artifact)
+    unsupported["artifact_schema_version"] = "b25-p11-export-artifact-v9"
+    unsupported["canonicalization_version"] = "b25-p11-artifact-framing-v9"
+    if verify_export_artifact(
+        unsupported, key_registry=registry.public_only()
+    ).verification_status != "rejected":
+        return _emit(baseline, executed, error="unsupported_not_rejected")
+    executed.append("unsupported_protocol_refusal")
+
+    return _emit(baseline, executed)
+
+
+def _emit(baseline: set[str], executed: list[str], error: str | None = None) -> int:
+    loaded = sorted(m for m in set(sys.modules) - baseline if _is_forbidden(m))
+    json.dump(
+        {
+            "executed_paths": executed,
+            "forbidden_modules_loaded": loaded,
+            "error": error,
+        },
+        sys.stdout,
+    )
+    sys.stdout.write("\n")
+    return 1 if (loaded or error) else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ci/validate_b25_p12_ci_gates.py
+++ b/scripts/ci/validate_b25_p12_ci_gates.py
@@ -36,14 +36,14 @@ import yaml
 
 ROOT = Path(__file__).resolve().parents[2]
 REGISTRY = Path("docs/ci/b25_p12_invariant_registry.yaml")
-# The P12 proofs are bound into the B2.5-P11 required context rather than a
-# dedicated P12 workflow. Reason recorded honestly: creating
-# `.github/workflows/b2_5-p12-ci-gates.yml` requires the `workflow` OAuth scope,
-# which the available credentials do not carry. Binding here is not a weaker
-# outcome for enforcement -- `B2.5-P11 Export Compatibility` is already a
-# required status check on protected main, so a composition regression is
-# merge-blocking today. It IS a weaker outcome for gate identity: there is no
-# separate P12 context yet. That distinction is reported, never blurred.
+# The P12 proofs run in BOTH the dedicated `B2.5-P12 CI Gates` context and,
+# retained deliberately, the `B2.5-P11 Export Compatibility` context. Both are
+# required status checks on protected main, so a composition regression is
+# merge-blocking on two independent gates rather than one. The earlier comment
+# here described a period when the dedicated workflow could not be created for
+# lack of the `workflow` OAuth scope; that is no longer true and the stale text
+# is removed rather than left to mislead a reader into thinking gate identity is
+# still missing.
 BINDING_WORKFLOW = Path(".github/workflows/b2_5-p11-export-compatibility.yml")
 BINDING_VALIDATOR = Path("scripts/ci/validate_b25_p11_export_compatibility.py")
 DEDICATED_WORKFLOW = Path(".github/workflows/b2_5-p12-ci-gates.yml")
@@ -82,6 +82,78 @@ def _yaml(path: Path, overrides: dict[Path, str] | None = None) -> Any:
     return yaml.safe_load(_text(path, overrides))
 
 
+def _resolve_negative_control(ident: object, row: dict) -> None:
+    """Prove an invariant's negative control resolves to something executable.
+
+    This check previously read::
+
+        _require(bool(row.get("negative_control")), ...)
+
+    which is satisfied by any non-empty string. Every *other* reference in this
+    loop -- validator, workflow, production_path -- is resolved against disk;
+    the control alone was checked for truthiness. Two consequences were
+    reproduced against protected main:
+
+    * fifteen of twenty-two controls were free-text prose ("p2 ordering/
+      permutation mutations"), which can never resolve because it is not the
+      name of anything;
+    * substituting the invented identifier ``NC-P12-DOES-NOT-EXIST`` left Plane D
+      passing with ``registry_completeness_controls_passed=22``.
+
+    A control is now resolved by class, and each class is verified differently
+    rather than uniformly asserted:
+
+    ``source_identifier``
+        The identifier must literally occur in the named validator's source, so
+        the registry row is bound to code rather than to a label.
+    ``validator_control_mode``
+        The named validator must expose an executable ``--negative-control``
+        mode. Granularity is mode-level: this proves the validator has firing
+        falsifiers, NOT that one control maps to one domain. The registry records
+        that limit instead of implying per-control precision it does not have.
+    ``drift_check``
+        A regeneration/diff falsifier, which has a command rather than a mode.
+    """
+    control = row.get("negative_control")
+    _require(isinstance(control, dict), f"invariant_control_not_structured:{ident}")
+    control_id = control.get("id")
+    _require(
+        isinstance(control_id, str) and control_id.startswith("NC-"),
+        f"invariant_control_missing_id:{ident}:{control_id}",
+    )
+    resolution = control.get("resolution")
+    _require(
+        resolution in {"source_identifier", "validator_control_mode", "drift_check"},
+        f"invariant_control_unknown_resolution:{ident}:{resolution}",
+    )
+    target = control.get("resolves_in")
+    _require(
+        isinstance(target, str) and (ROOT / target).exists(),
+        f"invariant_control_target_missing:{ident}:{target}",
+    )
+    source = (ROOT / target).read_text(encoding="utf-8", errors="replace")
+
+    if resolution == "source_identifier":
+        _require(
+            control_id in source,
+            f"invariant_control_not_executable:{ident}:{control_id}:absent_from:{target}",
+        )
+    elif resolution == "validator_control_mode":
+        _require(
+            "--negative-control" in source,
+            f"invariant_control_mode_missing:{ident}:{target}",
+        )
+        _require(
+            control.get("granularity") == "mode_level",
+            f"invariant_control_granularity_overclaimed:{ident}",
+        )
+    else:
+        _require(
+            bool(control.get("falsifier_command")),
+            f"invariant_control_missing_falsifier_command:{ident}",
+        )
+
+
 def validate_registry_completeness(
     overrides: dict[Path, str] | None = None,
 ) -> int:
@@ -111,9 +183,7 @@ def validate_registry_completeness(
             row.get("proof_owner") in {"p12", "inherited"},
             f"invariant_missing_proof_owner:{ident}",
         )
-        _require(
-            bool(row.get("negative_control")), f"invariant_missing_control:{ident}"
-        )
+        _resolve_negative_control(ident, row)
 
         validator = row.get("validator")
         _require(
@@ -419,8 +489,8 @@ def run_negative_controls() -> int:
             "NC-P12-CI-03",
             _mutate(
                 REGISTRY,
-                "    validator: scripts/ci/validate_b25_p10_trust_api_surface.py",
-                "    validator: scripts/ci/validate_b25_p10_does_not_exist.py",
+                "  validator: scripts/ci/validate_b25_p10_trust_api_surface.py",
+                "  validator: scripts/ci/validate_b25_p10_does_not_exist.py",
             ),
             "invariant_validator_missing_on_disk",
         ),

--- a/scripts/ci/validate_b25_p12_trust_isolation.py
+++ b/scripts/ci/validate_b25_p12_trust_isolation.py
@@ -32,6 +32,8 @@ from __future__ import annotations
 
 import argparse
 import ast
+import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -113,9 +115,15 @@ def _first_party_imports(source: str, module: str) -> set[str]:
                 target = f"{base}.{node.module}" if node.module else base
             else:
                 target = node.module or ""
-            if not target.startswith("app."):
+            # `from app import llm` has module == "app", so a `startswith("app.")`
+            # guard drops it and the forbidden `app.llm` dependency never enters
+            # the graph. The bare first-party package must be admitted, because
+            # its aliases are submodules. Only dotted targets are themselves
+            # dependencies; "app" alone is a namespace, not an import.
+            if target != "app" and not target.startswith("app."):
                 continue
-            imported.add(target)
+            if target.startswith("app."):
+                imported.add(target)
             for alias in node.names:
                 imported.add(f"{target}.{alias.name}")
     return imported
@@ -238,117 +246,45 @@ def validate_no_compute_dispatch(overrides: dict[Path, str] | None = None) -> in
 def validate_runtime_module_trace() -> int:
     """Domain 17: no forbidden module loads while exercising trust paths.
 
-    Covers success, refusal and verification paths rather than the happy path
-    alone, because a module can stay unimported until an error branch runs.
+    Delegated to a fresh interpreter (``_b25_p12_runtime_trace.py``) because an
+    in-process trace cannot observe import-time dependencies: it must import the
+    modules under observation before it can take a ``sys.modules`` baseline, so
+    anything pulled in at import time is already resident and gets subtracted
+    away. That defect was reproduced -- a trust module importing ``app.llm`` at
+    import time left the old trace green while the module was demonstrably
+    loaded. A subprocess makes the baseline genuinely precede every first-party
+    import, so import-time and lazy loads are both observable.
     """
-    sys.path.insert(0, str(BACKEND))
-    for name in list(sys.modules):
-        for prefix in FORBIDDEN_MODULE_PREFIXES:
-            if name == prefix or name.startswith(prefix + "."):
-                del sys.modules[name]
-
-    import hashlib  # noqa: PLC0415
-    import json  # noqa: PLC0415
-    from datetime import datetime, timedelta, timezone  # noqa: PLC0415
-
-    from cryptography.hazmat.primitives.asymmetric.ed25519 import (  # noqa: PLC0415
-        Ed25519PrivateKey,
-    )
-
-    from app.trust.export_artifact import (  # noqa: PLC0415
-        build_export_artifact,
-        sign_export_artifact,
-        verify_export_artifact,
-    )
-    from app.trust.key_registry import (
-        TrustKeyRegistry,
-        TrustSigningKey,
-    )  # noqa: PLC0415
-    from app.trust.signing import sign_trust_envelope  # noqa: PLC0415
-    from app.trust.verification import verify_trust_envelope  # noqa: PLC0415
-
-    before = set(sys.modules)
-    private = Ed25519PrivateKey.from_private_bytes(
-        hashlib.sha256(b"b25-p12-runtime-trace").digest()
-    )
-    registry = TrustKeyRegistry(
-        (
-            TrustSigningKey(
-                kid="kid:b25-p12-runtime-trace",
-                algorithm="ed25519",
-                public_key=private.public_key(),
-                private_key=private,
-                state="active",
-                valid_from=datetime(2026, 1, 1, tzinfo=timezone.utc),
-            ),
-        )
-    )
-
-    def _utc(value: datetime) -> str:
-        return (
-            value.astimezone(timezone.utc)
-            .replace(microsecond=0)
-            .isoformat()
-            .replace("+00:00", "Z")
-        )
-
-    issued = datetime.now(timezone.utc)
-    envelope = json.loads(
-        (
-            ROOT / "contracts/trust-api/examples/deterministic_only_verified.json"
-        ).read_text(encoding="utf-8")
-    )
-    envelope["created_at"] = _utc(issued)
-    envelope["valid_until"] = _utc(issued + timedelta(days=1))
-
-    paths_exercised = 0
-
-    # happy: sign an envelope
-    signed = sign_trust_envelope(envelope, key_registry=registry)
-    paths_exercised += 1
-
-    # verify path
-    verify_trust_envelope(signed, key_registry=registry.public_only())
-    paths_exercised += 1
-
-    # export issuance path
-    artifact = sign_export_artifact(
-        build_export_artifact(
-            envelopes=[signed],
-            tenant_id_hash=str(signed["tenant_id_hash"]),
-            generated_at=issued,
-        ),
-        key_registry=registry,
-    )
-    paths_exercised += 1
-
-    # refusal / rejection path: tampered artifact must be rejected, and the
-    # rejection branch must not pull in a forbidden module either.
-    tampered = dict(artifact)
-    tampered["generated_at"] = _utc(issued + timedelta(hours=1))
-    result = verify_export_artifact(tampered, key_registry=registry.public_only())
+    result = _run_runtime_trace()
     _require(
-        result.verification_status == "rejected", "runtime_trace_tamper_not_rejected"
+        not result.get("error"),
+        f"runtime_trace_failed:{result.get('error')}",
     )
-    paths_exercised += 1
+    loaded = result.get("forbidden_modules_loaded") or []
+    if loaded:
+        raise B25P12IsolationError(
+            f"forbidden_module_loaded_at_runtime:{','.join(loaded)}"
+        )
+    return len(result.get("executed_paths") or [])
 
-    # unsupported-protocol refusal path
-    unsupported = dict(artifact)
-    unsupported["artifact_schema_version"] = "b25-p11-export-artifact-v9"
-    unsupported["canonicalization_version"] = "b25-p11-artifact-framing-v9"
-    refused = verify_export_artifact(unsupported, key_registry=registry.public_only())
-    _require(
-        refused.verification_status == "rejected",
-        "runtime_trace_unsupported_protocol_not_rejected",
+
+def _run_runtime_trace() -> dict:
+    """Execute the trace in a clean interpreter and return its JSON report."""
+    proc = subprocess.run(
+        [sys.executable, str(ROOT / "scripts/ci/_b25_p12_runtime_trace.py")],
+        capture_output=True,
+        text=True,
+        cwd=str(ROOT),
     )
-    paths_exercised += 1
-
-    newly_loaded = set(sys.modules) - before
-    for name in sorted(newly_loaded):
-        for prefix in FORBIDDEN_MODULE_PREFIXES:
-            if name == prefix or name.startswith(prefix + "."):
-                raise B25P12IsolationError(f"forbidden_module_loaded_at_runtime:{name}")
-    return paths_exercised
+    stdout = (proc.stdout or "").strip()
+    if not stdout:
+        raise B25P12IsolationError(
+            f"runtime_trace_no_output:rc={proc.returncode}:{(proc.stderr or '')[-300:]}"
+        )
+    try:
+        return json.loads(stdout.splitlines()[-1])
+    except json.JSONDecodeError as exc:
+        raise B25P12IsolationError(f"runtime_trace_bad_output:{exc}") from exc
 
 
 def validate_core(overrides: dict[Path, str] | None = None) -> dict[str, int]:
@@ -411,6 +347,66 @@ def run_negative_controls() -> int:
             fired += 1
             continue
         raise B25P12IsolationError(f"negative_control_silent:{name}")
+
+    fired += _run_iso_03_runtime_control()
+    return fired
+
+
+def _run_iso_03_runtime_control() -> int:
+    """NC-P12-ISO-03: a forbidden module actually loading at trust runtime.
+
+    This control could not previously exist. Every other isolation control is a
+    *text override* evaluated by the static analyzers, and a text override cannot
+    make a module load -- only real code on disk can. Domain 17 therefore named a
+    control (``NC-P12-ISO-03``) that had no mechanism to be implemented in, and
+    Plane D reported registry completeness anyway because it only checked that
+    the identifier string was non-empty.
+
+    The mutation is written to disk so the fresh-interpreter trace genuinely
+    imports it, then restored unconditionally. It is placed after the
+    ``__future__`` import so the module stays syntactically valid: a control that
+    fires on SyntaxError proves the file stopped parsing, not that the invariant
+    was detected.
+
+    This is a *distinct defense* from the AST scan. An AST rejection proves a
+    forbidden spelling was written; this proves a forbidden module was loaded.
+    The directive is explicit that the two are not interchangeable.
+    """
+    module = "app.trust.export_artifact"
+    path = _module_path(module)
+    _require(path is not None, f"negative_control_module_missing:{module}")
+    # Byte-exact round trip: a control that leaves the tree perturbed (even
+    # only in line endings) is a control that edits the repository it is
+    # supposed to observe.
+    original_bytes = path.read_bytes()
+    try:
+        lines = original_bytes.decode("utf-8").splitlines(True)
+        index = next(
+            (n for n, line in enumerate(lines) if line.startswith("from __future__")),
+            -1,
+        )
+        lines.insert(index + 1, "import app.llm  # NC-P12-ISO-03 runtime falsifier\n")
+        mutated = "".join(lines)
+        ast.parse(mutated)  # the mutation must be valid Python, not a crash
+        path.write_bytes(mutated.encode("utf-8"))
+
+        result = _run_runtime_trace()
+        loaded = result.get("forbidden_modules_loaded") or []
+        _require(
+            bool(loaded),
+            "negative_control_silent:NC-P12-ISO-03",
+        )
+        _require(
+            any(m == "app.llm" or m.startswith("app.llm.") for m in loaded),
+            f"negative_control_wrong_reason:NC-P12-ISO-03:observed={loaded}",
+        )
+        _require(
+            bool(result.get("executed_paths")),
+            "negative_control_did_not_execute_paths:NC-P12-ISO-03",
+        )
+    finally:
+        path.write_bytes(original_bytes)
+    return 1
     return fired
 
 
@@ -426,7 +422,12 @@ def main(argv: list[str]) -> int:
         runtime_paths = validate_runtime_module_trace()
         negative_controls = run_negative_controls() if args.negative_control else 0
         if args.negative_control:
-            _require(negative_controls == 3, "isolation_negative_control_count_drift")
+            # Four: ISO-01/02/04 are static-analysis falsifiers driven by text
+            # overrides; ISO-03 is the runtime falsifier, which requires real
+            # on-disk mutation and a fresh interpreter. The count is asserted
+            # exactly so a silently deleted control is a failure rather than a
+            # smaller number nobody reads.
+            _require(negative_controls == 4, "isolation_negative_control_count_drift")
     except B25P12IsolationError as exc:
         print(f"B25_P12_TRUST_ISOLATION_VALIDATION_FAIL:{exc}")
         return 1

--- a/scripts/ci/validate_m0_scope_lock.py
+++ b/scripts/ci/validate_m0_scope_lock.py
@@ -180,6 +180,7 @@ ALLOWED_M0_PATHS = [
     ".github/workflows/b2_5-p12-ci-gates.yml",
     "scripts/ci/validate_b25_p12_contract_projection.py",
     "scripts/ci/validate_b25_p12_trust_isolation.py",
+    "scripts/ci/_b25_p12_runtime_trace.py",
     "scripts/ci/validate_b25_p12_ci_gates.py",
     "docs/ci/b25_p12_invariant_registry.yaml",
     "contracts/trust-api/export-artifact.v2.yaml",

--- a/scripts/ci/validate_m1_local_dev_authority.py
+++ b/scripts/ci/validate_m1_local_dev_authority.py
@@ -173,6 +173,7 @@ ALLOWED_M1_PATH_PREFIXES = [
     ".github/workflows/b2_5-p12-ci-gates.yml",
     "scripts/ci/validate_b25_p12_contract_projection.py",
     "scripts/ci/validate_b25_p12_trust_isolation.py",
+    "scripts/ci/_b25_p12_runtime_trace.py",
     "scripts/ci/validate_b25_p12_ci_gates.py",
     "docs/ci/b25_p12_invariant_registry.yaml",
     "contracts/trust-api/export-artifact.v2.yaml",


### PR DESCRIPTION
All nine P13-P0 hypotheses were **reproduced against `d12e99c87`** before any fix was written. Five are closed here. Four remain open and are named rather than quietly folded in.

## What the reproductions showed

| | Defect | Reproduction |
|---|---|---|
| **H00-A** | registry completeness ≠ executable controls | `NC-P12-DOES-NOT-EXIST` → Plane D **exit 0**, `controls_passed=22` |
| **H00-B** | `NC-P12-ISO-03` phantom | declared by domain 17, implemented nowhere |
| **H00-C** | ordinary import forms missed | 2 of 4 spellings passed through |
| **H00-D** | baseline captured too late | trace **passed** while `app.llm` was resident |
| **H00-I** | required contexts deadlock-capable | 4 of 5 required B2.5 contexts path-filtered |

The root cause of A and F is one line. Every other reference in the registry loop — `validator`, `workflow`, `production_path` — was resolved against disk with `.exists()`. The negative control alone was checked with `bool()`. So **15 of 22 controls were free-text prose** (`"p2 ordering/permutation mutations"`, and in one case a raw shell command), which can never resolve because it is not the name of anything.

## Closures

**H00-A** — controls are now structured and resolved by class: `source_identifier` (8, id must occur in the named validator's source), `validator_control_mode` (13, validator must expose `--negative-control`), `drift_check` (1). Where granularity is mode-level it is **recorded as mode-level**, not dressed up as per-control precision. The directive's falsifier now fails with `invariant_control_not_executable:15:...:absent_from:...`.

**H00-B** — `NC-P12-ISO-03` could not previously have existed: every other isolation control is a *text override*, and a text override cannot make a module load. Implemented as a real runtime falsifier with byte-exact restore. Controls 3 → 4.

**H00-C** — `from app import llm` has `module == "app"`, so a `startswith("app.")` guard dropped it. The bare package is now admitted.

**H00-D** — the trace imported trust modules *then* took its `sys.modules` baseline, subtracting import-time dependencies away. Moved to a fresh interpreter; the same mutation now reports `app.llm` and `app.llm.budget_policy`.

**H00-I** — B2.5-P8/P9/P10/P11 were required **and** path-filtered. A PR touching none of their paths blocks forever on a status that cannot arrive. This is the same defect found in P12 yesterday — systemic, not local. PR triggers unfiltered; `push` paths retained for path-trigger integrity.

## Not claimed

**H00-E** (runtime paths are crypto/export, not Trust API routes), **H00-F** (inherited invocation vs existence), **H00-G** (path→*any* workflow vs path→*relevant* detector), **H00-H** (detector self-protection) remain open.

**B2.5-P12 is therefore NOT closeable on this PR**, and P13-E0 has not passed. Per §49 of the directive, marking P12 complete before E0 passes is a prohibited shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)