### PR TITLE
P13-P0: close the remaining four P12 proof-integrity defects

### DIFF
--- a/.github/workflows/b2_5-p12-ci-gates.yml
+++ b/.github/workflows/b2_5-p12-ci-gates.yml
@@ -91,7 +91,7 @@ jobs:
           grep -E "^no_llm_reachability_controls_passed=[1-9][0-9]*$" /tmp/b25_p12_isolation.out
           grep -E "^dynamic_import_controls_passed=[1-9][0-9]*$" /tmp/b25_p12_isolation.out
           grep -E "^compute_dispatch_controls_passed=[1-9][0-9]*$" /tmp/b25_p12_isolation.out
-          grep -E "^runtime_trace_paths_exercised=5$" /tmp/b25_p12_isolation.out
+          grep -E "^runtime_trace_paths_exercised=7$" /tmp/b25_p12_isolation.out
           grep -E "^isolation_negative_controls_fired=4$" /tmp/b25_p12_isolation.out
 
       # The fresh-interpreter trace is also invoked directly, not only as a
@@ -109,7 +109,7 @@ jobs:
           assert not report["forbidden_modules_loaded"], (
               f"forbidden modules resident after trust paths: {report['forbidden_modules_loaded']}"
           )
-          assert len(report["executed_paths"]) == 5, report["executed_paths"]
+          assert len(report["executed_paths"]) == 7, report["executed_paths"]
           print("runtime_trace_forbidden_modules_loaded=0")
           print(f"runtime_trace_executed_paths={len(report['executed_paths'])}")
           PY
@@ -126,9 +126,9 @@ jobs:
           grep -E "^failure_masking_controls_passed=[1-9][0-9]*$" /tmp/b25_p12_gates.out
           grep -E "^gate_invocation_controls_passed=[1-9][0-9]*$" /tmp/b25_p12_gates.out
           grep -E "^context_stability_controls_passed=2$" /tmp/b25_p12_gates.out
-          grep -E "^path_trigger_controls_passed=[1-9][0-9]*$" /tmp/b25_p12_gates.out
-          grep -E "^failure_masking_controls_passed=[1-9][0-9]*$" /tmp/b25_p12_gates.out
-          grep -E "^ci_gate_negative_controls_fired=5$" /tmp/b25_p12_gates.out
+          grep -E "^inherited_binding_controls_passed=22$" /tmp/b25_p12_gates.out
+          grep -E "^detector_self_protection_controls_passed=22$" /tmp/b25_p12_gates.out
+          grep -E "^ci_gate_negative_controls_fired=7$" /tmp/b25_p12_gates.out
 
       # P12-G9: P12 enforces architecture; it must not redefine it. The inherited
       # contract/drift gates must still hold with the v2 schema in place.

--- a/docs/ci/b25_p12_invariant_registry.yaml
+++ b/docs/ci/b25_p12_invariant_registry.yaml
@@ -11,7 +11,7 @@ invariants:
   proof_owner: p12
   production_path: contracts/trust-api/trust-api.openapi.yaml
   validator: scripts/ci/validate_b25_p12_contract_projection.py
-  workflow: .github/workflows/b2_5-p11-export-compatibility.yml
+  workflow: .github/workflows/b2_5-p12-ci-gates.yml
   negative_control:
     id: NC-P12-P0-01
     resolution: source_identifier
@@ -19,19 +19,25 @@ invariants:
   note: Live issued artifact validated against the schema resolved from the published 200 response. This
     is the composition no phase owned, and its absence is exactly how the v2-runtime/v1-contract defect
     survived P11.
+  secondary_enforcement: Also invoked in-process by validate_b25_p11_export_compatibility.py inside the
+    required B2.5-P11 Export Compatibility context, so this proof is merge-blocking on two independent
+    required gates.
 - id: 2
   invariant: Example validation (lifecycle-aware)
   plane: A
   proof_owner: p12
   production_path: contracts/trust-api/examples
   validator: scripts/ci/validate_b25_p12_contract_projection.py
-  workflow: .github/workflows/b2_5-p11-export-compatibility.yml
+  workflow: .github/workflows/b2_5-p12-ci-gates.yml
   negative_control:
     id: NC-P12-P0-02
     resolution: source_identifier
     resolves_in: scripts/ci/validate_b25_p12_contract_projection.py
   note: Active example must validate against the active schema; a historical example must fail it. Without
     lifecycle classification a historical fixture silently masquerades as active contract proof (P12-H02).
+  secondary_enforcement: Also invoked in-process by validate_b25_p11_export_compatibility.py inside the
+    required B2.5-P11 Export Compatibility context, so this proof is merge-blocking on two independent
+    required gates.
 - id: 3
   invariant: Generated model drift
   plane: A
@@ -209,47 +215,59 @@ invariants:
   proof_owner: p12
   production_path: backend/app/trust
   validator: scripts/ci/validate_b25_p12_trust_isolation.py
-  workflow: .github/workflows/b2_5-p11-export-compatibility.yml
+  workflow: .github/workflows/b2_5-p12-ci-gates.yml
   negative_control:
     id: NC-P12-ISO-01
     resolution: source_identifier
     resolves_in: scripts/ci/validate_b25_p12_trust_isolation.py
+  secondary_enforcement: Also invoked in-process by validate_b25_p11_export_compatibility.py inside the
+    required B2.5-P11 Export Compatibility context, so this proof is merge-blocking on two independent
+    required gates.
 - id: 16
   invariant: Dynamic import ban in trust path
   plane: A
   proof_owner: p12
   production_path: backend/app/trust
   validator: scripts/ci/validate_b25_p12_trust_isolation.py
-  workflow: .github/workflows/b2_5-p11-export-compatibility.yml
+  workflow: .github/workflows/b2_5-p12-ci-gates.yml
   negative_control:
     id: NC-P12-ISO-02
     resolution: source_identifier
     resolves_in: scripts/ci/validate_b25_p12_trust_isolation.py
+  secondary_enforcement: Also invoked in-process by validate_b25_p11_export_compatibility.py inside the
+    required B2.5-P11 Export Compatibility context, so this proof is merge-blocking on two independent
+    required gates.
 - id: 17
   invariant: Runtime sys.modules trace across trust paths
   plane: B
   proof_owner: p12
   production_path: backend/app/trust
   validator: scripts/ci/validate_b25_p12_trust_isolation.py
-  workflow: .github/workflows/b2_5-p11-export-compatibility.yml
+  workflow: .github/workflows/b2_5-p12-ci-gates.yml
   negative_control:
     id: NC-P12-ISO-03
     resolution: source_identifier
     resolves_in: scripts/ci/validate_b25_p12_trust_isolation.py
   note: happy / degraded / refused / verify / export module-load trace.
+  secondary_enforcement: Also invoked in-process by validate_b25_p11_export_compatibility.py inside the
+    required B2.5-P11 Export Compatibility context, so this proof is merge-blocking on two independent
+    required gates.
 - id: 18
   invariant: No compute dispatch from trust reads
   plane: C
   proof_owner: p12
   production_path: backend/app/api/trust_api.py
   validator: scripts/ci/validate_b25_p12_trust_isolation.py
-  workflow: .github/workflows/b2_5-p11-export-compatibility.yml
+  workflow: .github/workflows/b2_5-p12-ci-gates.yml
   negative_control:
     id: NC-P12-ISO-04
     resolution: source_identifier
     resolves_in: scripts/ci/validate_b25_p12_trust_isolation.py
   note: Bans indirect dispatch surfaces (send_task, enqueue helpers, outbox, task-name strings), not only
     direct imports of compute implementations.
+  secondary_enforcement: Also invoked in-process by validate_b25_p11_export_compatibility.py inside the
+    required B2.5-P11 Export Compatibility context, so this proof is merge-blocking on two independent
+    required gates.
 - id: 19
   invariant: Policy authority never auto-executable
   plane: B
@@ -298,13 +316,16 @@ invariants:
   proof_owner: p12
   production_path: backend/app/api/export.py
   validator: scripts/ci/validate_b25_p12_contract_projection.py
-  workflow: .github/workflows/b2_5-p11-export-compatibility.yml
+  workflow: .github/workflows/b2_5-p12-ci-gates.yml
   negative_control:
     id: NC-P12-P0-01
     resolution: source_identifier
     resolves_in: scripts/ci/validate_b25_p12_contract_projection.py
   note: Human G4 honesty and machine TrustEnvelope derivation are owned by P11; P12 adds the missing third
     leg, active response/schema parity.
+  secondary_enforcement: Also invoked in-process by validate_b25_p11_export_compatibility.py inside the
+    required B2.5-P11 Export Compatibility context, so this proof is merge-blocking on two independent
+    required gates.
 path_trigger_required:
 - contracts/trust-api/**
 - backend/app/trust/**

--- a/scripts/ci/_b25_p12_runtime_trace.py
+++ b/scripts/ci/_b25_p12_runtime_trace.py
@@ -144,6 +144,71 @@ def main() -> int:
         return _emit(baseline, executed, error="unsupported_not_rejected")
     executed.append("unsupported_protocol_refusal")
 
+    # Builder construction paths. The five cryptographic cases above exercise
+    # signing, verification and export, but none of them runs the TrustEnvelope
+    # *construction* path -- which is where confidence, money and reason-code
+    # semantics live, and therefore where a forbidden Bayesian or LLM import is
+    # most plausible. Claiming "representative trust runtime paths" while
+    # exercising only crypto would inflate five counters into five semantics.
+    #
+    # The session is inert and raises on any access, so these paths are proven
+    # not to touch the database. That is legitimate here because the property
+    # under proof is which modules load, not database behaviour; route-level and
+    # RLS truth belong to the P13 end-to-end harness against real PostgreSQL.
+    import asyncio
+    import uuid
+
+    from app.trust.builder import (
+        TrustEnvelopeBuildRequest,
+        build_unsigned_trust_envelope,
+    )
+    from app.trust.source_adapters import MatchVerdictSource
+
+    class _InertSession:
+        async def execute(self, *args, **kwargs):
+            raise AssertionError("runtime trace builder path touched the database")
+
+        async def scalar(self, *args, **kwargs):
+            raise AssertionError("runtime trace builder path touched the database")
+
+    def _source(amount):
+        now = datetime.now(timezone.utc)
+        return MatchVerdictSource(
+            id=uuid.uuid4(),
+            tenant_id=uuid.uuid4(),
+            webhook_ingress_identity_id=None,
+            provider="stripe",
+            canonical_commerce_reference="cc-runtime-trace",
+            provider_native_event_reference="evt_runtime_trace",
+            provider_native_commerce_reference="pi_runtime_trace",
+            status="matched",
+            match_quality="exact",
+            canonical_net_verified_amount_minor=amount,
+            currency_code="USD",
+            last_transition_at=now,
+            created_at=now,
+            updated_at=now,
+        )
+
+    async def _build(amount):
+        request = TrustEnvelopeBuildRequest(
+            tenant_id=uuid.uuid4(),
+            subject_type="commerce_event",
+            subject_ref="cc-runtime-trace",
+            request_context={"audience_id": "b25-p12-runtime-trace"},
+        )
+        return await build_unsigned_trust_envelope(
+            _InertSession(), request, source=_source(amount)
+        )
+
+    asyncio.run(_build(105000))
+    executed.append("builder_normal_read")
+
+    # Money authority unavailable: the degraded construction branch, which must
+    # stay deterministic rather than reaching for a probabilistic estimate.
+    asyncio.run(_build(None))
+    executed.append("builder_degraded_money_unavailable")
+
     return _emit(baseline, executed)
 
 

--- a/scripts/ci/validate_b25_p12_ci_gates.py
+++ b/scripts/ci/validate_b25_p12_ci_gates.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import argparse
 import fnmatch
+import re
 from pathlib import Path
 from typing import Any
 
@@ -214,6 +215,104 @@ def validate_registry_completeness(
     return checks
 
 
+def _invoked_scripts(workflow: str, overrides: dict[Path, str] | None = None) -> set[str]:
+    """Scripts a workflow actually invokes in its run steps.
+
+    Reading the run text is deliberate. The alternative -- trusting the registry's
+    own ``workflow`` column -- is the defect this function exists to close: the
+    column recorded where a proof was *bound* historically, not where it runs.
+    """
+    path = Path(workflow)
+    if not (ROOT / path).exists():
+        return set()
+    text = _text(path, overrides)
+    return set(re.findall(r"(?:scripts|backend/scripts)/[A-Za-z0-9_./-]+\.(?:py|sh)", text))
+
+
+def validate_inherited_proof_binding(overrides: dict[Path, str] | None = None) -> int:
+    """Every invariant's workflow must actually invoke its validator.
+
+    Registry completeness proves the validator and workflow *files exist*. That is
+    not enforcement. Reproduced at `bcee1a055`: eight of twenty-two invariants
+    named a workflow that never invoked their validator -- seven P12 domains still
+    pointed at the binding-era `b2_5-p11-export-compatibility.yml` while those
+    validators had moved to the dedicated P12 workflow. The proofs did run, one
+    hop deeper through the P11 validator, but the registry asserted an edge that
+    did not exist. "P6 passed once" is not P12 enforcement, and neither is a
+    workflow column nobody traverses.
+    """
+    registry = _yaml(REGISTRY, overrides)
+    checks = 0
+    for row in registry.get("invariants") or []:
+        ident = row.get("id")
+        validator = row.get("validator")
+        workflow = row.get("workflow")
+        _require(
+            validator in _invoked_scripts(workflow, overrides),
+            f"invariant_workflow_does_not_invoke_validator:{ident}:{workflow}:{validator}",
+        )
+        checks += 1
+    _require(
+        checks == REQUIRED_INVARIANT_COUNT,
+        f"inherited_binding_coverage_incomplete:{checks}",
+    )
+    return checks
+
+
+def validate_detector_self_protection(overrides: dict[Path, str] | None = None) -> int:
+    """A load-bearing detector must itself be covered by its workflow's triggers.
+
+    An engineer weakening a validator is a change to proof, not to production
+    code, so a path-filtered workflow that does not list the validator's own file
+    will not run it -- the weakened detector never gets a chance to notice its own
+    weakening. Reproduced: three validators were unprotected this way.
+
+    Coverage plus the ``--negative-control`` invocation proven by
+    :func:`validate_p12_gate_invocation` gives the real chain: editing a detector
+    triggers the workflow, the workflow runs the detector with its falsifiers, and
+    a neutered detector makes its own control go silent.
+    """
+    registry = _yaml(REGISTRY, overrides)
+    checks = 0
+    for row in registry.get("invariants") or []:
+        ident = row.get("id")
+        validator = row.get("validator")
+        workflow = row.get("workflow")
+        declared = _workflow_paths(workflow, overrides)
+        _require(
+            _path_covered(validator, declared),
+            f"detector_not_self_protected:{ident}:{validator}:not_triggered_by:{workflow}",
+        )
+        checks += 1
+    return checks
+
+
+def _workflow_paths(workflow: str, overrides: dict[Path, str] | None = None) -> set[str]:
+    """Trigger paths declared by ONE workflow, across pull_request and push."""
+    path = Path(workflow)
+    if not (ROOT / path).exists():
+        return set()
+    spec = yaml.safe_load(_text(path, overrides)) or {}
+    triggers = spec.get("on") or spec.get(True) or {}
+    declared: set[str] = set()
+    for event in ("pull_request", "push"):
+        if event not in triggers:
+            continue
+        event_spec = triggers.get(event) or {}
+        if not isinstance(event_spec, dict) or "paths" not in event_spec:
+            # No `paths` key means the event is not path-filtered at all, so it
+            # covers every file by construction. `branches:` alone does not
+            # filter by path -- reading a `branches`-only spec as "no coverage"
+            # would report a workflow that runs on every PR as protecting
+            # nothing. Required contexts must be unfiltered (H00-I), so this is
+            # the normal case rather than an exception.
+            declared.add("**")
+            continue
+        for entry in event_spec.get("paths") or []:
+            declared.add(entry)
+    return declared
+
+
 def _path_covered(required: str, declared: set[str]) -> bool:
     """Glob-aware coverage: `docs/ci/**` covers `docs/ci/thing.yaml`."""
     if required in declared:
@@ -238,6 +337,52 @@ def _declared_trigger_paths(overrides: dict[Path, str] | None = None) -> set[str
             for entry in spec.get("paths") or []:
                 declared.add(entry)
     return declared
+
+
+def _require_relevant_detector(
+    required: str,
+    registry: Any,
+    overrides: dict[Path, str] | None = None,
+) -> int:
+    """Prove a load-bearing path reaches the detector RESPONSIBLE for it.
+
+    The previous check flattened trigger paths from every ``b2_5-*.yml`` workflow
+    into one set, so a path counted as covered when *any* B2.5 workflow declared
+    it -- even a workflow that never runs the validator guarding that path's
+    invariant. Editing a canonicalization file could satisfy path-trigger
+    integrity by way of an unrelated broad workflow while the canonicalization
+    proof itself never ran.
+
+    Relevance is derived from the registry rather than hand-maintained in a second
+    list: a path's relevant detectors are the validators of the invariants whose
+    ``production_path`` the path matches. Coverage must come from a workflow that
+    both declares the path AND invokes those detectors.
+    """
+    relevant: set[str] = set()
+    for row in registry.get("invariants") or []:
+        production = row.get("production_path") or ""
+        if not production:
+            continue
+        if production == required or fnmatch.fnmatch(production, required):
+            validator = row.get("validator")
+            if validator:
+                relevant.add(validator)
+    if not relevant:
+        return 0
+
+    reaching: set[str] = set()
+    for workflow_path in sorted((ROOT / ".github/workflows").glob("b2_5-*.yml")):
+        rel = workflow_path.relative_to(ROOT).as_posix()
+        if not _path_covered(required, _workflow_paths(rel, overrides)):
+            continue
+        reaching |= _invoked_scripts(rel, overrides)
+
+    missing = sorted(relevant - reaching)
+    _require(
+        not missing,
+        f"load_bearing_path_reaches_no_relevant_detector:{required}:{missing}",
+    )
+    return len(relevant)
 
 
 def validate_path_trigger_integrity(
@@ -265,6 +410,7 @@ def validate_path_trigger_integrity(
             f"load_bearing_path_not_triggering_p12:{required}",
         )
         checks += 1
+        checks += _require_relevant_detector(required, registry, overrides)
 
     for gap in sorted(known_gaps):
         _require(
@@ -405,6 +551,8 @@ def validate_context_stability(overrides: dict[Path, str] | None = None) -> int:
 def validate_core(overrides: dict[Path, str] | None = None) -> dict[str, int]:
     return {
         "registry_completeness_controls": validate_registry_completeness(overrides),
+        "inherited_binding_controls": validate_inherited_proof_binding(overrides),
+        "detector_self_protection_controls": validate_detector_self_protection(overrides),
         "path_trigger_controls": validate_path_trigger_integrity(overrides),
         "failure_masking_controls": validate_no_failure_masking(overrides),
         "gate_invocation_controls": validate_p12_gate_invocation(overrides),
@@ -464,6 +612,30 @@ def _mutate_workflow_paths_remove(target: str) -> dict[Path, str]:
     return overrides
 
 
+def _mutate_p12_workflow_excluding_detector() -> dict[Path, str]:
+    """Narrow the P12 workflow's triggers so they no longer cover its own detector.
+
+    Structured YAML rather than text substitution: an unfiltered ``pull_request``
+    covers every path by construction, so a control that only stripped the push
+    path would leave the property satisfied and fire silently. Both events are
+    narrowed to a path set that deliberately omits the isolation validator.
+    """
+    spec = yaml.safe_load((ROOT / DEDICATED_WORKFLOW).read_text(encoding="utf-8"))
+    triggers = spec.get("on") or spec.get(True) or {}
+    kept = [
+        entry
+        for entry in (triggers.get("push") or {}).get("paths") or []
+        if "validate_b25_p12_trust_isolation" not in entry
+    ]
+    triggers["pull_request"] = {"paths": list(kept)}
+    triggers["push"] = {"branches": ["main"], "paths": list(kept)}
+    if True in spec:
+        spec[True] = triggers
+    else:
+        spec["on"] = triggers
+    return {DEDICATED_WORKFLOW: yaml.safe_dump(spec, sort_keys=False, width=200)}
+
+
 def run_negative_controls() -> int:
     """Semantic falsifiers for the enforcement topology itself."""
     controls: tuple[tuple[str, dict[Path, str], str], ...] = (
@@ -515,6 +687,33 @@ def run_negative_controls() -> int:
             ),
             "p12_proof_failure_not_propagated",
         ),
+        (
+            # H00-F: an invariant points at a workflow that never runs its
+            # validator. This is the shape the registry was actually in --
+            # seven P12 domains named the binding-era P11 workflow while their
+            # validators had moved to the dedicated P12 gate.
+            "NC-P12-CI-06",
+            _mutate(
+                REGISTRY,
+                "  workflow: .github/workflows/b2_5-p12-ci-gates.yml\n"
+                "  negative_control:\n"
+                "    id: NC-P12-ISO-01",
+                "  workflow: .github/workflows/b2_5-p9-machine-identity.yml\n"
+                "  negative_control:\n"
+                "    id: NC-P12-ISO-01",
+            ),
+            "invariant_workflow_does_not_invoke_validator",
+        ),
+        (
+            # H00-H: the detector stops being reachable by its own workflow's
+            # triggers, so weakening it would not run it. Both events must be
+            # narrowed: an unfiltered `pull_request` covers every file, so
+            # removing only the push path would leave the property intact and
+            # the control silent.
+            "NC-P12-CI-07",
+            _mutate_p12_workflow_excluding_detector(),
+            "detector_not_self_protected",
+        ),
     )
     fired = 0
     for name, overrides, expected in controls:
@@ -541,7 +740,11 @@ def main(argv: list[str]) -> int:
         counters = validate_core()
         negative_controls = run_negative_controls() if args.negative_control else 0
         if args.negative_control:
-            _require(negative_controls == 5, "ci_gate_negative_control_count_drift")
+            # Seven: five original, plus NC-P12-CI-06 (inherited proof binding)
+            # and NC-P12-CI-07 (detector self-protection), added when H00-F
+            # and H00-H were closed. Asserted exactly so a deleted control is
+            # a failure rather than a smaller number nobody reads.
+            _require(negative_controls == 7, "ci_gate_negative_control_count_drift")
     except B25P12CiGateError as exc:
         print(f"B25_P12_CI_GATES_VALIDATION_FAIL:{exc}")
         return 1


### PR DESCRIPTION
Completes the P13-P0 mandatory entry gate. H00-A/B/C/D/I landed in #628; this closes **E, F, G and H**.

## Reproductions, before any fix

| | Defect | Reproduced |
|---|---|---|
| **H00-F** | inherited binding proves existence, not invocation | **8 of 22** invariants named a workflow that never invoked their validator |
| **H00-G** | path → *any* workflow, not the relevant detector | `_declared_trigger_paths` flattens all `b2_5-*.yml` paths into one set |
| **H00-H** | detectors not self-protecting | **3** validators not covered by their own workflow's triggers |
| **H00-E** | runtime cases ≠ claimed trust paths | all 5 cases cryptographic; none ran TrustEnvelope construction |

## What was actually wrong with H00-F

Seven P12 domains pointed at `b2_5-p11-export-compatibility.yml` — the binding-era workflow — while those validators had since moved to the dedicated P12 gate. The proofs *did* run, one hop deeper through the P11 validator, but the registry asserted an edge nobody traversed. That is precisely "historical P6 passed once is not P12 enforcement."

## Closures

- **H00-F** — `validate_inherited_proof_binding` reads each workflow's run steps and requires the named validator to appear. **22/22**. Control `NC-P12-CI-06`.
- **H00-G** — relevance derived from the registry itself: a path's relevant detectors are the validators of invariants whose `production_path` it matches, and coverage must come from a workflow that declares the path **and** invokes those detectors. `path_trigger_controls` 14 → **25**.
- **H00-H** — `validate_detector_self_protection`, 22/22. Control `NC-P12-CI-07` narrows **both** events, because an unfiltered `pull_request` covers every path and stripping only the push path would leave the control silent.
- **H00-E** — added `builder_normal_read` and `builder_degraded_money_unavailable`; **5 → 7** paths. The session is inert and raises on access, so these are proven not to touch the DB — the property under proof is module loading, and route/RLS truth belongs to the P13 harness against real PostgreSQL.

`ci_gate_negative_controls_fired`: 5 → **7**.

## Consequence

With all nine entry-gate defects closed, **P13-E0 becomes passable** and B2.5-P12 becomes formally closeable — pending this landing on main with exact-main proof, per §14 of the directive. Neither is claimed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)