### PR TITLE
Fix R2 canonical schema trigger anchoring

### DIFF
--- a/.github/workflows/r2-data-truth-hardening.yml
+++ b/.github/workflows/r2-data-truth-hardening.yml
@@ -272,10 +272,13 @@ jobs:
               allocation_deferred_blocks.append(match.group(0).strip() + "\n")
               reordered = reordered[: match.start()] + "\n" + reordered[match.end() :]
 
-          allocation_trigger_marker = "-- Name: attribution_allocations trg_check_allocation_sum; Type: TRIGGER; Schema: public; Owner: -"
-          marker_index = reordered.find(allocation_trigger_marker)
-          if marker_index == -1:
+          allocation_trigger_pattern = re.compile(
+              r"(?m)^CREATE TRIGGER trg_check_allocation_sum\b"
+          )
+          trigger_match = allocation_trigger_pattern.search(reordered)
+          if trigger_match is None:
               raise SystemExit("unable to locate allocation trigger insertion point in canonical schema")
+          marker_index = trigger_match.start()
           reordered = (
               reordered[:marker_index].rstrip()
               + "\n\n"


### PR DESCRIPTION
## Outcome

Repairs the exact-main R2 canonical-schema bootstrap failure discovered after Directive III technical PR #645 merged.

## Root cause

The bootstrap transformation anchored allocation-function relocation on a pg_dump metadata comment. Canonical schema normalization removes pg_dump comments, so the executable trigger existed but the workflow could not locate the insertion point.

## Remediation

Anchor to the stable executable SQL object boundary (`CREATE TRIGGER trg_check_allocation_sum`) with a line-anchored regex.

## Falsifiable validation

- workflow YAML parses
- all four allocation trigger functions are found and relocated before the three trigger statements
- exact trigger cardinality remains one per trigger
- M0: 93/93
- M1: valid
- `git diff --check`: clean

The pre-fix exact-main failure is https://github.com/Synergyscape-V1/skeldir-2.0/actions/runs/31733359463.